### PR TITLE
fix acc and iou compute nan problem

### DIFF
--- a/mmseg/core/evaluation/mean_iou.py
+++ b/mmseg/core/evaluation/mean_iou.py
@@ -34,7 +34,7 @@ def intersect_and_union(pred_label, label, num_classes, ignore_index):
     return area_intersect, area_union, area_pred_label, area_label
 
 
-def mean_iou(results, gt_seg_maps, num_classes, ignore_index):
+def mean_iou(results, gt_seg_maps, num_classes, ignore_index, nan_to_num=None):
     """Calculate Intersection and Union (IoU)
 
     Args:
@@ -42,6 +42,7 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index):
         gt_seg_maps (list[ndarray]): list of ground truth segmentation maps
         num_classes (int): Number of categories
         ignore_index (int): Index that will be ignored in evaluation.
+        nan_to_num (int): Replace NaN with the numbers defined by the user.
 
      Returns:
          float: Overall accuracy on all images.
@@ -64,7 +65,8 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index):
         total_area_pred_label += area_pred_label
         total_area_label += area_label
     all_acc = total_area_intersect.sum() / total_area_label.sum()
-    acc = total_area_intersect / (total_area_label + 2.220446049250313e-16)
-    iou = total_area_intersect / (total_area_union + 2.220446049250313e-16)
-
+    acc = total_area_intersect / total_area_label
+    iou = total_area_intersect / total_area_union
+    if nan_to_num is not None:
+        return all_acc, np.nan_to_num(acc, nan=nan_to_num), np.nan_to_num(iou, nan=nan_to_num)
     return all_acc, acc, iou

--- a/mmseg/core/evaluation/mean_iou.py
+++ b/mmseg/core/evaluation/mean_iou.py
@@ -64,7 +64,7 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index):
         total_area_pred_label += area_pred_label
         total_area_label += area_label
     all_acc = total_area_intersect.sum() / total_area_label.sum()
-    acc = total_area_intersect / total_area_label
-    iou = total_area_intersect / total_area_union
+    acc = total_area_intersect / (total_area_label+2.220446049250313e-16)
+    iou = total_area_intersect / (total_area_union+2.220446049250313e-16)
 
     return all_acc, acc, iou

--- a/mmseg/core/evaluation/mean_iou.py
+++ b/mmseg/core/evaluation/mean_iou.py
@@ -42,7 +42,7 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index, nan_to_num=None):
         gt_seg_maps (list[ndarray]): list of ground truth segmentation maps
         num_classes (int): Number of categories
         ignore_index (int): Index that will be ignored in evaluation.
-        nan_to_num (int): Replace NaN with the numbers defined by the user.
+        nan_to_num (int, optional): If specified, NaN values will be replaced by the numbers defined by the user. Default: None. 
 
      Returns:
          float: Overall accuracy on all images.

--- a/mmseg/core/evaluation/mean_iou.py
+++ b/mmseg/core/evaluation/mean_iou.py
@@ -64,7 +64,7 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index):
         total_area_pred_label += area_pred_label
         total_area_label += area_label
     all_acc = total_area_intersect.sum() / total_area_label.sum()
-    acc = total_area_intersect / (total_area_label+2.220446049250313e-16)
-    iou = total_area_intersect / (total_area_union+2.220446049250313e-16)
+    acc = total_area_intersect / (total_area_label + 2.220446049250313e-16)
+    iou = total_area_intersect / (total_area_union + 2.220446049250313e-16)
 
     return all_acc, acc, iou

--- a/mmseg/core/evaluation/mean_iou.py
+++ b/mmseg/core/evaluation/mean_iou.py
@@ -42,8 +42,8 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index, nan_to_num=None):
         gt_seg_maps (list[ndarray]): list of ground truth segmentation maps
         num_classes (int): Number of categories
         ignore_index (int): Index that will be ignored in evaluation.
-        nan_to_num (int, optional): If specified, NaN values will be replaced 
-            by the numbers defined by the user. Default: None. 
+        nan_to_num (int, optional): If specified, NaN values will be replaced
+            by the numbers defined by the user. Default: None.
 
      Returns:
          float: Overall accuracy on all images.

--- a/mmseg/core/evaluation/mean_iou.py
+++ b/mmseg/core/evaluation/mean_iou.py
@@ -68,5 +68,6 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index, nan_to_num=None):
     acc = total_area_intersect / total_area_label
     iou = total_area_intersect / total_area_union
     if nan_to_num is not None:
-        return all_acc, np.nan_to_num(acc, nan=nan_to_num), np.nan_to_num(iou, nan=nan_to_num)
+        return all_acc, np.nan_to_num(acc, nan=nan_to_num), \
+            np.nan_to_num(iou, nan=nan_to_num)
     return all_acc, acc, iou

--- a/mmseg/core/evaluation/mean_iou.py
+++ b/mmseg/core/evaluation/mean_iou.py
@@ -42,7 +42,8 @@ def mean_iou(results, gt_seg_maps, num_classes, ignore_index, nan_to_num=None):
         gt_seg_maps (list[ndarray]): list of ground truth segmentation maps
         num_classes (int): Number of categories
         ignore_index (int): Index that will be ignored in evaluation.
-        nan_to_num (int, optional): If specified, NaN values will be replaced by the numbers defined by the user. Default: None. 
+        nan_to_num (int, optional): If specified, NaN values will be replaced 
+            by the numbers defined by the user. Default: None. 
 
      Returns:
          float: Overall accuracy on all images.

--- a/tests/test_mean_iou.py
+++ b/tests/test_mean_iou.py
@@ -57,7 +57,7 @@ def test_mean_iou():
 
     results = np.random.randint(0, 5, size=pred_size)
     label = np.random.randint(0, 4, size=pred_size)
-    all_acc, acc, iou = mean_iou(results, label,num_classes, ignore_index=255,
+    all_acc, acc, iou = mean_iou(results, label, num_classes, ignore_index=255,
                                  nan_to_num=-1)
     assert acc[-1] == -1
     assert iou[-1] == -1

--- a/tests/test_mean_iou.py
+++ b/tests/test_mean_iou.py
@@ -57,7 +57,7 @@ def test_mean_iou():
 
     results = np.random.randint(0, 5, size=pred_size)
     label = np.random.randint(0, 4, size=pred_size)
-    all_acc, acc, iou = mean_iou(results, label, num_classes, ignore_index=255,
-                                 nan_to_num=-1)
+    all_acc, acc, iou = mean_iou(
+        results, label, num_classes, ignore_index=255, nan_to_num=-1)
     assert acc[-1] == -1
     assert iou[-1] == -1

--- a/tests/test_mean_iou.py
+++ b/tests/test_mean_iou.py
@@ -54,3 +54,9 @@ def test_mean_iou():
     assert all_acc == all_acc_l
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, iou_l)
+
+    results = np.random.randint(0, 5, size=pred_size)
+    label = np.random.randint(0,4, size=pred_size)
+    all_acc, acc, iou = mean_iou(results, label,num_classes, ignore_index=255, nan_to_num=-1)
+    assert acc[-1] == -1
+    assert iou[-1] == -1

--- a/tests/test_mean_iou.py
+++ b/tests/test_mean_iou.py
@@ -56,7 +56,8 @@ def test_mean_iou():
     assert np.allclose(iou, iou_l)
 
     results = np.random.randint(0, 5, size=pred_size)
-    label = np.random.randint(0,4, size=pred_size)
-    all_acc, acc, iou = mean_iou(results, label,num_classes, ignore_index=255, nan_to_num=-1)
+    label = np.random.randint(0, 4, size=pred_size)
+    all_acc, acc, iou = mean_iou(results, label,num_classes, ignore_index=255,
+                                 nan_to_num=-1)
     assert acc[-1] == -1
     assert iou[-1] == -1


### PR DESCRIPTION
Reproduce
```python
In [4]: import torch
   ...: targets = torch.randint(0, 5, size=(12,3,256,256))
   ...: preds = torch.randint(0,4, size=(12,3,256,256))
   ...: mean_iou(preds, targets,7, ignore_index=255)
/usr/local/bin/ipython:63: RuntimeWarning: invalid value encountered in true_divide
[471730. 473621. 472044. 471450. 470451.      0.      0.]
/usr/local/bin/ipython:65: RuntimeWarning: invalid value encountered in true_divide

Out[4]:
(0.20025168524848092,
 array([0.25013461, 0.25040275, 0.25065036, 0.2493223 , 0.     ,    nan,        nan]),
 array([0.12510297, 0.12543045, 0.12530315, 0.1246835 , 0.        ,    nan,        nan]))
```

new result:

```python
In [6]: import torch
   ...: targets = torch.randint(0, 5, size=(12,3,256,256))
   ...: preds = torch.randint(0,4, size=(12,3,256,256))
   ...: mean_iou(preds, targets,7, ignore_index=255)
[472809. 472306. 470679. 471310. 472192.      0.      0.]
Out[6]:
(0.19984902275933158,
 array([0.24924229, 0.25092842, 0.25056355, 0.2486877 , 0.      , 0.        , 0.        ]),
 array([0.12472205, 0.12560796, 0.12515188, 0.12413867, 0.        ,   0.        , 0.        ]))

In [7]:
```