### PR TITLE
Use img_prefix and seg_prefix for loading

### DIFF
--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -134,7 +134,7 @@ class CustomDataset(Dataset):
                     img_info = dict(filename=img_name + img_suffix)
                     if ann_dir is not None:
                         seg_map = img_name + seg_map_suffix
-                        img_info['ann'] = dict(seg_map)
+                        img_info['ann'] = dict(seg_map=seg_map)
                     img_infos.append(img_info)
         else:
             for img in mmcv.scandir(img_dir, img_suffix, recursive=True):

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -131,19 +131,15 @@ class CustomDataset(Dataset):
             with open(split) as f:
                 for line in f:
                     img_name = line.strip()
-                    img_file = osp.join(img_dir, img_name + img_suffix)
-                    img_info = dict(filename=img_file)
+                    img_info = dict(filename=img_name + img_suffix)
                     if ann_dir is not None:
-                        seg_map = osp.join(ann_dir, img_name + seg_map_suffix)
-                        img_info['ann'] = dict(seg_map=seg_map)
+                        img_info['ann'] = dict(seg_map=img_name + seg_map_suffix)
                     img_infos.append(img_info)
         else:
             for img in mmcv.scandir(img_dir, img_suffix, recursive=True):
-                img_file = osp.join(img_dir, img)
-                img_info = dict(filename=img_file)
+                img_info = dict(filename=img)
                 if ann_dir is not None:
-                    seg_map = osp.join(ann_dir,
-                                       img.replace(img_suffix, seg_map_suffix))
+                    seg_map = img.replace(img_suffix, seg_map_suffix)
                     img_info['ann'] = dict(seg_map=seg_map)
                 img_infos.append(img_info)
 
@@ -165,6 +161,8 @@ class CustomDataset(Dataset):
     def pre_pipeline(self, results):
         """Prepare results dict for pipeline."""
         results['seg_fields'] = []
+        resuts['img_prefix'] = self.img_dir
+        results['seg_prefix'] = self.ann_dir
         if self.custom_classes:
             results['label_map'] = self.label_map
 
@@ -225,8 +223,9 @@ class CustomDataset(Dataset):
         """Get ground truth segmentation maps for evaluation."""
         gt_seg_maps = []
         for img_info in self.img_infos:
+            seg_map = osp.join(self.ann_dir, img_info['ann']['seg_map'])
             gt_seg_map = mmcv.imread(
-                img_info['ann']['seg_map'], flag='unchanged', backend='pillow')
+                seg_map, flag='unchanged', backend='pillow')
             # modify if custom classes
             if self.label_map is not None:
                 for old_id, new_id in self.label_map.items():

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -133,7 +133,8 @@ class CustomDataset(Dataset):
                     img_name = line.strip()
                     img_info = dict(filename=img_name + img_suffix)
                     if ann_dir is not None:
-                        img_info['ann'] = dict(seg_map=img_name + seg_map_suffix)
+                        seg_map = img_name + seg_map_suffix
+                        img_info['ann'] = dict(seg_map)
                     img_infos.append(img_info)
         else:
             for img in mmcv.scandir(img_dir, img_suffix, recursive=True):
@@ -161,7 +162,7 @@ class CustomDataset(Dataset):
     def pre_pipeline(self, results):
         """Prepare results dict for pipeline."""
         results['seg_fields'] = []
-        resuts['img_prefix'] = self.img_dir
+        results['img_prefix'] = self.img_dir
         results['seg_prefix'] = self.ann_dir
         if self.custom_classes:
             results['label_map'] = self.label_map


### PR DESCRIPTION
Without using these prefixes, `single_gpu_test` with `output_dir` enabled will overwrite the original images because `ori_filename`  is being set to the absolute path to the image.