### PR TITLE
Bugfix: num of augmentations and image meta not match when run TTA on CPU

### DIFF
--- a/mmseg/apis/inference.py
+++ b/mmseg/apis/inference.py
@@ -89,7 +89,7 @@ def inference_segmentor(model, img):
         # scatter to specified GPU
         data = scatter(data, [device])[0]
     else:
-        data['img_metas'] = data['img_metas'][0].data
+        data['img_metas'] = [i.data[0] for i in data['img_metas']]
 
     # forward the model
     with torch.no_grad():

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,25 @@
+import os.path as osp
+
+from mmseg.apis import inference_segmentor, init_segmentor
+import mmcv
+
+
+def test_test_time_augmentation_on_cpu():
+    config_file = 'configs/pspnet/pspnet_r50-d8_512x1024_40k_cityscapes.py'
+    config = mmcv.Config.fromfile(config_file)
+
+    # Replace SyncBN with BN to inference on CPU
+    norm_cfg = dict(type='BN', requires_grad=True)
+    config.model.backbone.norm_cfg = norm_cfg
+    config.model.decode_head.norm_cfg = norm_cfg
+    config.model.auxiliary_head.norm_cfg = norm_cfg
+
+    # Enable test time augmentation
+    config.test_pipeline[1].flip = True
+
+    checkpoint_file = None
+    model = init_segmentor(config, checkpoint_file, device='cpu')
+
+    img = mmcv.imread(osp.join(osp.dirname(__file__), 'data/color.jpg'), 'color')
+    result = inference_segmentor(model, img)
+    assert result[0].shape == (288, 512)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -16,7 +16,7 @@ def test_test_time_augmentation_on_cpu():
     config.model.auxiliary_head.norm_cfg = norm_cfg
 
     # Enable test time augmentation
-    config.test_pipeline[1].flip = True
+    config.data.test.pipeline[1].flip = True
 
     checkpoint_file = None
     model = init_segmentor(config, checkpoint_file, device='cpu')

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -9,6 +9,8 @@ def test_test_time_augmentation_on_cpu():
     config_file = 'configs/pspnet/pspnet_r50-d8_512x1024_40k_cityscapes.py'
     config = mmcv.Config.fromfile(config_file)
 
+    # Remove pretrain model download for testing
+    config.model.pretrained = None
     # Replace SyncBN with BN to inference on CPU
     norm_cfg = dict(type='BN', requires_grad=True)
     config.model.backbone.norm_cfg = norm_cfg

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,7 +1,8 @@
 import os.path as osp
 
-from mmseg.apis import inference_segmentor, init_segmentor
 import mmcv
+
+from mmseg.apis import inference_segmentor, init_segmentor
 
 
 def test_test_time_augmentation_on_cpu():
@@ -20,6 +21,7 @@ def test_test_time_augmentation_on_cpu():
     checkpoint_file = None
     model = init_segmentor(config, checkpoint_file, device='cpu')
 
-    img = mmcv.imread(osp.join(osp.dirname(__file__), 'data/color.jpg'), 'color')
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), 'data/color.jpg'), 'color')
     result = inference_segmentor(model, img)
     assert result[0].shape == (288, 512)


### PR DESCRIPTION
When running test time augmentation(TTA) on CPU, it will raise this Error:    `num of augmentations (2) != num of image meta (1)`. The test log is here: https://github.com/youqingxiaozhua/mmsegmentation/actions/runs/381178359

The reason is the  `inference_segmentor` function in `mmseg/apis/inference.py` always returns the first image meta when the model's parameters are located on CPU, which is not suited for augmentation cases.


