### PR TITLE
[fix]: fix docstring

### DIFF
--- a/mmseg/datasets/pipelines/loading.py
+++ b/mmseg/datasets/pipelines/loading.py
@@ -91,7 +91,7 @@ class LoadAnnotations(object):
     """Load annotations for semantic segmentation.
 
     Args:
-        reduct_zero_label (bool): Whether reduce all label value by 1.
+        reduce_zero_label (bool): Whether reduce all label value by 1.
             Usually used for datasets where 0 is background label.
             Default: False.
         file_client_args (dict): Arguments to instantiate a FileClient.


### PR DESCRIPTION
Fix doctring misspelled in `loading.py`.