### PR TITLE
Fix mIoU calculatiton range

### DIFF
--- a/mmseg/core/evaluation/metrics.py
+++ b/mmseg/core/evaluation/metrics.py
@@ -57,11 +57,11 @@ def intersect_and_union(pred_label,
 
     intersect = pred_label[pred_label == label]
     area_intersect = torch.histc(
-        intersect.float(), bins=(num_classes), min=0, max=num_classes)
+        intersect.float(), bins=(num_classes), min=0, max=num_classes - 1)
     area_pred_label = torch.histc(
-        pred_label.float(), bins=(num_classes), min=0, max=num_classes)
+        pred_label.float(), bins=(num_classes), min=0, max=num_classes - 1)
     area_label = torch.histc(
-        label.float(), bins=(num_classes), min=0, max=num_classes)
+        label.float(), bins=(num_classes), min=0, max=num_classes - 1)
     area_union = area_pred_label + area_label - area_intersect
     return area_intersect, area_union, area_pred_label, area_label
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -136,7 +136,7 @@ def test_metrics():
     num_classes = 59
     all_acc, acc, iou = eval_metrics(
         results, label, num_classes, ignore_index=255, metrics='mIoU')
-    assert np.sum(np.isnan(iou)) == 0
+    assert not np.any(np.isnan(iou))
 
 
 def test_mean_iou():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -64,7 +64,11 @@ def test_metrics():
     ignore_index = 255
     results = np.random.randint(0, num_classes, size=pred_size)
     label = np.random.randint(0, num_classes, size=pred_size)
+
+    # Test the availability of arg: ignore_index.
     label[:, 2, 5:10] = ignore_index
+
+    # Test the correctness of the implementation of mIoU calculation.
     all_acc, acc, iou = eval_metrics(
         results, label, num_classes, ignore_index, metrics='mIoU')
     all_acc_l, acc_l, iou_l = legacy_mean_iou(results, label, num_classes,
@@ -72,7 +76,7 @@ def test_metrics():
     assert all_acc == all_acc_l
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, iou_l)
-
+    # Test the correctness of the implementation of mDice calculation.
     all_acc, acc, dice = eval_metrics(
         results, label, num_classes, ignore_index, metrics='mDice')
     all_acc_l, acc_l, dice_l = legacy_mean_dice(results, label, num_classes,
@@ -80,7 +84,7 @@ def test_metrics():
     assert all_acc == all_acc_l
     assert np.allclose(acc, acc_l)
     assert np.allclose(dice, dice_l)
-
+    # Test the correctness of the implementation of joint calculation.
     all_acc, acc, iou, dice = eval_metrics(
         results, label, num_classes, ignore_index, metrics=['mIoU', 'mDice'])
     assert all_acc == all_acc_l
@@ -88,6 +92,8 @@ def test_metrics():
     assert np.allclose(iou, iou_l)
     assert np.allclose(dice, dice_l)
 
+    # Test the correctness of calculation when arg: num_classes is larger
+    # than the maximum value of input maps.
     results = np.random.randint(0, 5, size=pred_size)
     label = np.random.randint(0, 4, size=pred_size)
     all_acc, acc, iou = eval_metrics(
@@ -120,6 +126,17 @@ def test_metrics():
     assert acc[-1] == -1
     assert dice[-1] == -1
     assert iou[-1] == -1
+
+    # Test the bug which is caused by torch.histc.
+    # torch.histc:  https://pytorch.org/docs/stable/generated/torch.histc.html
+    # When the arg:bins is set to be same as arg:max,
+    # some channels of mIoU may be nan.
+    results = np.array([np.repeat(31, 59)])
+    label = np.array([np.arange(59)])
+    num_classes = 59
+    all_acc, acc, iou = eval_metrics(
+        results, label, num_classes, ignore_index=255, metrics='mIoU')
+    assert np.sum(np.isnan(iou)) == 0
 
 
 def test_mean_iou():
@@ -182,7 +199,7 @@ def test_filename_inputs():
             filenames.append(filename)
         return filenames
 
-    pred_size = (10, 512, 1024)
+    pred_size = (10, 30, 30)
     num_classes = 19
     ignore_index = 255
     results = np.random.randint(0, num_classes, size=pred_size)


### PR DESCRIPTION
1. Fix the bug about torch.histc function. When setting arg:max same as arg:bins for torch.histc, some channel of mIoU may be nan.
2. Modify tests/test_metrics.py. Add some abnormal num_classes test cases.

# Pascal Context Dataset
Single-scale, No flip, mIoU test result:

| model | num classes | Lr schd | after fix | before fix | readme |
| :--: | :--: | :--: | :--: | :--: | :--: |
| HRNetV2-W48(new) | 59 | 40000 | 50.37 | 50.13 | None |
| HRNetV2-w48(new) | 59 | 80000 | 51.12 | 50.85 | None |
| HRNetV2-W48(new) | 60 | 40000 | 45.55 | 45.55 | 45.14 |
| HRNetV2-W48(old) | 60 | 40000 | 45.14 | 45.14 | 45.14 |

before fix: 
* keyboard=nan

# Cityscapes Dataset

Single-scale, No flip, mIoU test result:

| model | Crop Size | Lr schd | after fix | before fix | readme |
| :--: | :--: | :--: | :--: | :--: | :--: |
| HRNetV2-W48(old) | 512x1024 | 40000 | 78.52 | 78.52 | 78.48 |
| HRNetV2-W48(old) | 512x1024 | 80000 | 79.98 | 79.98 | 79.93 |

# ADE20K Dataset

Single-scale, No flip, mIoU test result:

| model | Crop Size | Lr schd | after fix | before fix | readme |
| :--: | :--: | :--: | :--: | :--: | :--: |
| HRNetV2-W48(old) | 512x512 | 80000 | 41.9 | 41.76 | 41.9 |
| HRNetV2-W48(old) | 512x512 | 160000 | 42.02 | 41.82 | 42.02 |

before fix: 
* fireplace=nan; 
* blind=nan; 
* television receiver=nan;
* botle=nan; 
* cradle=nan; 
* animal=nan;