### PR TITLE
[Enhance] Add BaseSegmentor import to help support MMDet3D

### DIFF
--- a/mmseg/models/segmentors/__init__.py
+++ b/mmseg/models/segmentors/__init__.py
@@ -1,4 +1,5 @@
+from .base import BaseSegmentor
 from .cascade_encoder_decoder import CascadeEncoderDecoder
 from .encoder_decoder import EncoderDecoder
 
-__all__ = ['EncoderDecoder', 'CascadeEncoderDecoder']
+__all__ = ['BaseSegmentor', 'EncoderDecoder', 'CascadeEncoderDecoder']


### PR DESCRIPTION
Hi, I am Ziyi, a developer of mmdet3d, and I am planning to implement 3D segmentors for point cloud scene segmentation. To inherit BaseSegmentor3D from BaseSegmentor, I add the import of BaseSegmentor to `__init__.py` of `segmentors/`. Thanks.