### PR TITLE
add metric mFscore

### DIFF
--- a/mmseg/core/evaluation/__init__.py
+++ b/mmseg/core/evaluation/__init__.py
@@ -1,8 +1,8 @@
 from .class_names import get_classes, get_palette
 from .eval_hooks import DistEvalHook, EvalHook
-from .metrics import eval_metrics, mean_dice, mean_iou
+from .metrics import eval_metrics, mean_dice, mean_iou, mean_fscore
 
 __all__ = [
-    'EvalHook', 'DistEvalHook', 'mean_dice', 'mean_iou', 'eval_metrics',
+    'EvalHook', 'DistEvalHook', 'mean_dice', 'mean_iou', 'mean_fscore', 'eval_metrics',
     'get_classes', 'get_palette'
 ]

--- a/mmseg/core/evaluation/metrics.py
+++ b/mmseg/core/evaluation/metrics.py
@@ -1,6 +1,25 @@
+from collections import OrderedDict
+
 import mmcv
 import numpy as np
 import torch
+
+
+def f_score(precision, recall, beta=1):
+    """calcuate the f-score value.
+
+    Args:
+        precision (float | torch.Tensor): The precision value.
+        recall (float | torch.Tensor): The recall value.
+        beta (int): Determines the weight of recall in the combined score.
+            Default: False.
+
+    Returns:
+        [torch.tensor]: The f-score value.
+    """
+    score = (1 + beta**2) * (precision * recall) / (
+        (beta**2 * precision) + recall)
+    return score
 
 
 def intersect_and_union(pred_label,
@@ -133,11 +152,12 @@ def mean_iou(results,
         reduce_zero_label (bool): Wether ignore zero label. Default: False.
 
      Returns:
-         float: Overall accuracy on all images.
-         ndarray: Per category accuracy, shape (num_classes, ).
-         ndarray: Per category IoU, shape (num_classes, ).
+        dict[str, float | ndarray]:
+        <aAcc> float: Overall accuracy on all images.
+        <Acc> ndarray: Per category accuracy, shape (num_classes, ).
+        <IoU> ndarray: Per category IoU, shape (num_classes, ).
     """
-    all_acc, acc, iou = eval_metrics(
+    mIoU_result = eval_metrics(
         results=results,
         gt_seg_maps=gt_seg_maps,
         num_classes=num_classes,
@@ -146,7 +166,7 @@ def mean_iou(results,
         nan_to_num=nan_to_num,
         label_map=label_map,
         reduce_zero_label=reduce_zero_label)
-    return all_acc, acc, iou
+    return mIoU_result
 
 
 def mean_dice(results,
@@ -171,12 +191,13 @@ def mean_dice(results,
         reduce_zero_label (bool): Wether ignore zero label. Default: False.
 
      Returns:
-         float: Overall accuracy on all images.
-         ndarray: Per category accuracy, shape (num_classes, ).
-         ndarray: Per category dice, shape (num_classes, ).
+        dict[str, float | ndarray]: Default metrics.
+        <aAcc> float: Overall accuracy on all images.
+        <Acc> ndarray: Per category accuracy, shape (num_classes, ).
+        <Dice> ndarray: Per category dice, shape (num_classes, ).
     """
 
-    all_acc, acc, dice = eval_metrics(
+    mDice_result = eval_metrics(
         results=results,
         gt_seg_maps=gt_seg_maps,
         num_classes=num_classes,
@@ -185,7 +206,52 @@ def mean_dice(results,
         nan_to_num=nan_to_num,
         label_map=label_map,
         reduce_zero_label=reduce_zero_label)
-    return all_acc, acc, dice
+    return mDice_result
+
+
+def mean_fscore(results,
+                gt_seg_maps,
+                num_classes,
+                ignore_index,
+                nan_to_num=None,
+                label_map=dict(),
+                reduce_zero_label=False,
+                beta=1):
+    """Calculate Mean Intersection and Union (mIoU)
+
+    Args:
+        results (list[ndarray] | list[str]): List of prediction segmentation
+            maps or list of prediction result filenames.
+        gt_seg_maps (list[ndarray] | list[str]): list of ground truth
+            segmentation maps or list of label filenames.
+        num_classes (int): Number of categories.
+        ignore_index (int): Index that will be ignored in evaluation.
+        nan_to_num (int, optional): If specified, NaN values will be replaced
+            by the numbers defined by the user. Default: None.
+        label_map (dict): Mapping old labels to new labels. Default: dict().
+        reduce_zero_label (bool): Wether ignore zero label. Default: False.
+        beta (int): Determines the weight of recall in the combined score.
+            Default: False.
+
+
+     Returns:
+        dict[str, float | ndarray]: Default metrics.
+         <aAcc> float: Overall accuracy on all images.
+         <Fscore> ndarray: Per category recall, shape (num_classes, ).
+         <Precision> ndarray: Per category precision, shape (num_classes, ).
+         <Recall> ndarray: Per category f-score, shape (num_classes, ).
+    """
+    mFscore_result = eval_metrics(
+        results=results,
+        gt_seg_maps=gt_seg_maps,
+        num_classes=num_classes,
+        ignore_index=ignore_index,
+        metrics=['mFscore'],
+        nan_to_num=nan_to_num,
+        label_map=label_map,
+        reduce_zero_label=reduce_zero_label,
+        beta=beta)
+    return mFscore_result
 
 
 def eval_metrics(results,
@@ -195,7 +261,8 @@ def eval_metrics(results,
                  metrics=['mIoU'],
                  nan_to_num=None,
                  label_map=dict(),
-                 reduce_zero_label=False):
+                 reduce_zero_label=False,
+                 beta=1):
     """Calculate evaluation metrics
     Args:
         results (list[ndarray] | list[str]): List of prediction segmentation
@@ -216,7 +283,7 @@ def eval_metrics(results,
     """
     if isinstance(metrics, str):
         metrics = [metrics]
-    allowed_metrics = ['mIoU', 'mDice']
+    allowed_metrics = ['mIoU', 'mDice', 'mFscore']
     if not set(metrics).issubset(set(allowed_metrics)):
         raise KeyError('metrics {} is not supported'.format(metrics))
 
@@ -225,19 +292,35 @@ def eval_metrics(results,
             results, gt_seg_maps, num_classes, ignore_index, label_map,
             reduce_zero_label)
     all_acc = total_area_intersect.sum() / total_area_label.sum()
-    acc = total_area_intersect / total_area_label
-    ret_metrics = [all_acc, acc]
+    ret_metrics = OrderedDict({'aAcc': all_acc})
     for metric in metrics:
         if metric == 'mIoU':
             iou = total_area_intersect / total_area_union
-            ret_metrics.append(iou)
+            acc = total_area_intersect / total_area_label
+            ret_metrics['IoU'] = iou
+            ret_metrics['Acc'] = acc
         elif metric == 'mDice':
             dice = 2 * total_area_intersect / (
                 total_area_pred_label + total_area_label)
-            ret_metrics.append(dice)
-    ret_metrics = [metric.numpy() for metric in ret_metrics]
+            acc = total_area_intersect / total_area_label
+            ret_metrics['Dice'] = dice
+            ret_metrics['Acc'] = acc
+        elif metric == 'mFscore':
+            precision = total_area_intersect / total_area_pred_label
+            recall = total_area_intersect / total_area_label
+            f_value = torch.tensor(
+                [f_score(x[0], x[1], beta) for x in zip(precision, recall)])
+            ret_metrics['Fscore'] = f_value
+            ret_metrics['Precision'] = precision
+            ret_metrics['Recall'] = recall
+
+    ret_metrics = {
+        metric: value.numpy()
+        for metric, value in ret_metrics.items()
+    }
     if nan_to_num is not None:
-        ret_metrics = [
-            np.nan_to_num(metric, nan=nan_to_num) for metric in ret_metrics
-        ]
+        ret_metrics = OrderedDict({
+            metric: np.nan_to_num(metric_value, nan=nan_to_num)
+            for metric, metric_value in ret_metrics.items()
+        })
     return ret_metrics

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -1,11 +1,12 @@
 import os
 import os.path as osp
+from collections import OrderedDict
 from functools import reduce
 
 import mmcv
 import numpy as np
 from mmcv.utils import print_log
-from terminaltables import AsciiTable
+from prettytable import PrettyTable
 from torch.utils.data import Dataset
 
 from mmseg.core import eval_metrics
@@ -312,8 +313,8 @@ class CustomDataset(Dataset):
 
         Args:
             results (list): Testing results of the dataset.
-            metric (str | list[str]): Metrics to be evaluated. 'mIoU' and
-                'mDice' are supported.
+            metric (str | list[str]): Metrics to be evaluated. 'mIoU',
+                'mDice' and 'mFscore' are supported.
             logger (logging.Logger | None | str): Logger used for printing
                 related information during evaluation. Default: None.
 
@@ -323,7 +324,7 @@ class CustomDataset(Dataset):
 
         if isinstance(metric, str):
             metric = [metric]
-        allowed_metrics = ['mIoU', 'mDice']
+        allowed_metrics = ['mIoU', 'mDice', 'mFscore']
         if not set(metric).issubset(set(allowed_metrics)):
             raise KeyError('metric {} is not supported'.format(metric))
         eval_results = {}
@@ -341,42 +342,54 @@ class CustomDataset(Dataset):
             metric,
             label_map=self.label_map,
             reduce_zero_label=self.reduce_zero_label)
-        class_table_data = [['Class'] + [m[1:] for m in metric] + ['Acc']]
+
         if self.CLASSES is None:
             class_names = tuple(range(num_classes))
         else:
             class_names = self.CLASSES
-        ret_metrics_round = [
-            np.round(ret_metric * 100, 2) for ret_metric in ret_metrics
-        ]
-        for i in range(num_classes):
-            class_table_data.append([class_names[i]] +
-                                    [m[i] for m in ret_metrics_round[2:]] +
-                                    [ret_metrics_round[1][i]])
-        summary_table_data = [['Scope'] +
-                              ['m' + head
-                               for head in class_table_data[0][1:]] + ['aAcc']]
-        ret_metrics_mean = [
-            np.round(np.nanmean(ret_metric) * 100, 2)
-            for ret_metric in ret_metrics
-        ]
-        summary_table_data.append(['global'] + ret_metrics_mean[2:] +
-                                  [ret_metrics_mean[1]] +
-                                  [ret_metrics_mean[0]])
-        print_log('per class results:', logger)
-        table = AsciiTable(class_table_data)
-        print_log('\n' + table.table, logger=logger)
-        print_log('Summary:', logger)
-        table = AsciiTable(summary_table_data)
-        print_log('\n' + table.table, logger=logger)
 
-        for i in range(1, len(summary_table_data[0])):
-            eval_results[summary_table_data[0]
-                         [i]] = summary_table_data[1][i] / 100.0
-        for idx, sub_metric in enumerate(class_table_data[0][1:], 1):
-            for item in class_table_data[1:]:
-                eval_results[str(sub_metric) + '.' +
-                             str(item[0])] = item[idx] / 100.0
+        # summary table
+        ret_metrics_summary = OrderedDict({
+            ret_metric: np.round(np.nanmean(ret_metric_value) * 100, 2)
+            for ret_metric, ret_metric_value in ret_metrics.items()
+        })
+
+        # each class table
+        ret_metrics.pop('aAcc', None)
+        ret_metrics_class = OrderedDict({
+            ret_metric: np.round(ret_metric_value * 100, 2)
+            for ret_metric, ret_metric_value in ret_metrics.items()
+        })
+        ret_metrics_class.update({'Class': class_names})
+        ret_metrics_class.move_to_end('Class', last=False)
+
+        # for logger
+        class_table_data = PrettyTable()
+        for key, val in ret_metrics_class.items():
+            class_table_data.add_column(key, val)
+
+        summary_table_data = PrettyTable()
+        for key, val in ret_metrics_summary.items():
+            summary_table_data.add_column(key, [val])
+
+        print_log('per class results:', logger)
+        print_log('\n' + class_table_data.get_string(), logger=logger)
+        print_log('Summary:', logger)
+        print_log('\n' + summary_table_data.get_string(), logger=logger)
+
+        # each metric dict
+        for key, value in ret_metrics_summary.items():
+            if key == 'aAcc':
+                eval_results[key] = value / 100.0
+            else:
+                eval_results['m' + key] = value / 100.0
+
+        ret_metrics_class.pop('Class', None)
+        for key, value in ret_metrics_class.items():
+            eval_results.update({
+                key + '.' + str(name): value[idx] / 100.0
+                for idx, name in enumerate(class_names)
+            })
 
         if mmcv.is_list_of(results, str):
             for file_name in results:

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,3 +1,3 @@
 matplotlib
 numpy
-terminaltables
+prettytable

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmseg
-known_third_party = PIL,cityscapesscripts,cv2,detail,matplotlib,mmcv,numpy,onnxruntime,oss2,pytest,scipy,seaborn,terminaltables,torch
+known_third_party = PIL,cityscapesscripts,cv2,detail,matplotlib,mmcv,numpy,onnxruntime,oss2,prettytable,pytest,scipy,seaborn,torch
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -159,7 +159,7 @@ def test_custom_dataset():
     for gt_seg_map in gt_seg_maps:
         h, w = gt_seg_map.shape
         pseudo_results.append(np.random.randint(low=0, high=7, size=(h, w)))
-    eval_results = train_dataset.evaluate(pseudo_results, metric='mIoU')
+    eval_results = train_dataset.evaluate(pseudo_results, metric=['mIoU'])
     assert isinstance(eval_results, dict)
     assert 'mIoU' in eval_results
     assert 'mAcc' in eval_results
@@ -193,13 +193,23 @@ def test_custom_dataset():
     assert 'mAcc' in eval_results
     assert 'aAcc' in eval_results
 
+    eval_results = train_dataset.evaluate(pseudo_results, metric='mFscore')
+    assert isinstance(eval_results, dict)
+    assert 'mRecall' in eval_results
+    assert 'mPrecision' in eval_results
+    assert 'mFscore' in eval_results
+    assert 'aAcc' in eval_results
+
     eval_results = train_dataset.evaluate(
-        pseudo_results, metric=['mIoU', 'mDice'])
+        pseudo_results, metric=['mIoU', 'mDice', 'mFscore'])
     assert isinstance(eval_results, dict)
     assert 'mIoU' in eval_results
     assert 'mDice' in eval_results
     assert 'mAcc' in eval_results
     assert 'aAcc' in eval_results
+    assert 'mFscore' in eval_results
+    assert 'mPrecision' in eval_results
+    assert 'mRecall' in eval_results
 
 
 @patch('mmseg.datasets.CustomDataset.load_annotations', MagicMock)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,24 @@
 import numpy as np
 
-from mmseg.core.evaluation import eval_metrics, mean_dice, mean_iou
+from mmseg.core.evaluation import (eval_metrics, mean_dice, mean_fscore,
+                                   mean_iou)
+
+
+def f_score(precision, recall, beta=1):
+    """calcuate the f-score value.
+
+    Args:
+        precision (float | torch.Tensor): The precision value.
+        recall (float | torch.Tensor): The recall value.
+        beta (int): Determines the weight of recall in the combined score.
+            Default: False.
+
+    Returns:
+        [torch.tensor]: The f-score value.
+    """
+    score = (1 + beta**2) * (precision * recall) / (
+        (beta**2 * precision) + recall)
+    return score
 
 
 def get_confusion_matrix(pred_label, label, num_classes, ignore_index):
@@ -58,6 +76,28 @@ def legacy_mean_dice(results, gt_seg_maps, num_classes, ignore_index):
     return all_acc, acc, dice
 
 
+# This func is deprecated since it's not memory efficient
+def legacy_mean_fscore(results,
+                       gt_seg_maps,
+                       num_classes,
+                       ignore_index,
+                       beta=1):
+    num_imgs = len(results)
+    assert len(gt_seg_maps) == num_imgs
+    total_mat = np.zeros((num_classes, num_classes), dtype=np.float)
+    for i in range(num_imgs):
+        mat = get_confusion_matrix(
+            results[i], gt_seg_maps[i], num_classes, ignore_index=ignore_index)
+        total_mat += mat
+    all_acc = np.diag(total_mat).sum() / total_mat.sum()
+    recall = np.diag(total_mat) / total_mat.sum(axis=1)
+    precision = np.diag(total_mat) / total_mat.sum(axis=0)
+    fv = np.vectorize(f_score)
+    fscore = fv(precision, recall, beta=beta)
+
+    return all_acc, recall, precision, fscore
+
+
 def test_metrics():
     pred_size = (10, 30, 30)
     num_classes = 19
@@ -69,63 +109,113 @@ def test_metrics():
     label[:, 2, 5:10] = ignore_index
 
     # Test the correctness of the implementation of mIoU calculation.
-    all_acc, acc, iou = eval_metrics(
+    ret_metrics = eval_metrics(
         results, label, num_classes, ignore_index, metrics='mIoU')
+    all_acc, acc, iou = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'IoU']
     all_acc_l, acc_l, iou_l = legacy_mean_iou(results, label, num_classes,
                                               ignore_index)
     assert all_acc == all_acc_l
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, iou_l)
     # Test the correctness of the implementation of mDice calculation.
-    all_acc, acc, dice = eval_metrics(
+    ret_metrics = eval_metrics(
         results, label, num_classes, ignore_index, metrics='mDice')
+    all_acc, acc, dice = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'Dice']
     all_acc_l, acc_l, dice_l = legacy_mean_dice(results, label, num_classes,
                                                 ignore_index)
     assert all_acc == all_acc_l
     assert np.allclose(acc, acc_l)
     assert np.allclose(dice, dice_l)
+    # Test the correctness of the implementation of mDice calculation.
+    ret_metrics = eval_metrics(
+        results, label, num_classes, ignore_index, metrics='mFscore')
+    all_acc, recall, precision, fscore = ret_metrics['aAcc'], ret_metrics[
+        'Recall'], ret_metrics['Precision'], ret_metrics['Fscore']
+    all_acc_l, recall_l, precision_l, fscore_l = legacy_mean_fscore(
+        results, label, num_classes, ignore_index)
+    assert all_acc == all_acc_l
+    assert np.allclose(recall, recall_l)
+    assert np.allclose(precision, precision_l)
+    assert np.allclose(fscore, fscore_l)
     # Test the correctness of the implementation of joint calculation.
-    all_acc, acc, iou, dice = eval_metrics(
-        results, label, num_classes, ignore_index, metrics=['mIoU', 'mDice'])
+    ret_metrics = eval_metrics(
+        results,
+        label,
+        num_classes,
+        ignore_index,
+        metrics=['mIoU', 'mDice', 'mFscore'])
+    all_acc, acc, iou, dice, precision, recall, fscore = ret_metrics[
+        'aAcc'], ret_metrics['Acc'], ret_metrics['IoU'], ret_metrics[
+            'Dice'], ret_metrics['Precision'], ret_metrics[
+                'Recall'], ret_metrics['Fscore']
     assert all_acc == all_acc_l
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, iou_l)
     assert np.allclose(dice, dice_l)
+    assert np.allclose(precision, precision_l)
+    assert np.allclose(recall, recall_l)
+    assert np.allclose(fscore, fscore_l)
 
     # Test the correctness of calculation when arg: num_classes is larger
     # than the maximum value of input maps.
     results = np.random.randint(0, 5, size=pred_size)
     label = np.random.randint(0, 4, size=pred_size)
-    all_acc, acc, iou = eval_metrics(
+    ret_metrics = eval_metrics(
         results,
         label,
         num_classes,
         ignore_index=255,
         metrics='mIoU',
         nan_to_num=-1)
+    all_acc, acc, iou = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'IoU']
     assert acc[-1] == -1
     assert iou[-1] == -1
 
-    all_acc, acc, dice = eval_metrics(
+    ret_metrics = eval_metrics(
         results,
         label,
         num_classes,
         ignore_index=255,
         metrics='mDice',
         nan_to_num=-1)
+    all_acc, acc, dice = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'Dice']
     assert acc[-1] == -1
     assert dice[-1] == -1
 
-    all_acc, acc, dice, iou = eval_metrics(
+    ret_metrics = eval_metrics(
         results,
         label,
         num_classes,
         ignore_index=255,
-        metrics=['mDice', 'mIoU'],
+        metrics='mFscore',
         nan_to_num=-1)
+    all_acc, precision, recall, fscore = ret_metrics['aAcc'], ret_metrics[
+        'Precision'], ret_metrics['Recall'], ret_metrics['Fscore']
+    assert precision[-1] == -1
+    assert recall[-1] == -1
+    assert fscore[-1] == -1
+
+    ret_metrics = eval_metrics(
+        results,
+        label,
+        num_classes,
+        ignore_index=255,
+        metrics=['mDice', 'mIoU', 'mFscore'],
+        nan_to_num=-1)
+    all_acc, acc, iou, dice, precision, recall, fscore = ret_metrics[
+        'aAcc'], ret_metrics['Acc'], ret_metrics['IoU'], ret_metrics[
+            'Dice'], ret_metrics['Precision'], ret_metrics[
+                'Recall'], ret_metrics['Fscore']
     assert acc[-1] == -1
     assert dice[-1] == -1
     assert iou[-1] == -1
+    assert precision[-1] == -1
+    assert recall[-1] == -1
+    assert fscore[-1] == -1
 
     # Test the bug which is caused by torch.histc.
     # torch.histc:  https://pytorch.org/docs/stable/generated/torch.histc.html
@@ -134,8 +224,10 @@ def test_metrics():
     results = np.array([np.repeat(31, 59)])
     label = np.array([np.arange(59)])
     num_classes = 59
-    all_acc, acc, iou = eval_metrics(
+    ret_metrics = eval_metrics(
         results, label, num_classes, ignore_index=255, metrics='mIoU')
+    all_acc, acc, iou = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'IoU']
     assert not np.any(np.isnan(iou))
 
 
@@ -146,7 +238,9 @@ def test_mean_iou():
     results = np.random.randint(0, num_classes, size=pred_size)
     label = np.random.randint(0, num_classes, size=pred_size)
     label[:, 2, 5:10] = ignore_index
-    all_acc, acc, iou = mean_iou(results, label, num_classes, ignore_index)
+    ret_metrics = mean_iou(results, label, num_classes, ignore_index)
+    all_acc, acc, iou = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'IoU']
     all_acc_l, acc_l, iou_l = legacy_mean_iou(results, label, num_classes,
                                               ignore_index)
     assert all_acc == all_acc_l
@@ -155,10 +249,12 @@ def test_mean_iou():
 
     results = np.random.randint(0, 5, size=pred_size)
     label = np.random.randint(0, 4, size=pred_size)
-    all_acc, acc, iou = mean_iou(
+    ret_metrics = mean_iou(
         results, label, num_classes, ignore_index=255, nan_to_num=-1)
+    all_acc, acc, iou = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'IoU']
     assert acc[-1] == -1
-    assert iou[-1] == -1
+    assert acc[-1] == -1
 
 
 def test_mean_dice():
@@ -168,19 +264,62 @@ def test_mean_dice():
     results = np.random.randint(0, num_classes, size=pred_size)
     label = np.random.randint(0, num_classes, size=pred_size)
     label[:, 2, 5:10] = ignore_index
-    all_acc, acc, iou = mean_dice(results, label, num_classes, ignore_index)
-    all_acc_l, acc_l, iou_l = legacy_mean_dice(results, label, num_classes,
-                                               ignore_index)
+    ret_metrics = mean_dice(results, label, num_classes, ignore_index)
+    all_acc, acc, iou = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'Dice']
+    all_acc_l, acc_l, dice_l = legacy_mean_dice(results, label, num_classes,
+                                                ignore_index)
     assert all_acc == all_acc_l
     assert np.allclose(acc, acc_l)
-    assert np.allclose(iou, iou_l)
+    assert np.allclose(iou, dice_l)
 
     results = np.random.randint(0, 5, size=pred_size)
     label = np.random.randint(0, 4, size=pred_size)
-    all_acc, acc, iou = mean_dice(
+    ret_metrics = mean_dice(
         results, label, num_classes, ignore_index=255, nan_to_num=-1)
+    all_acc, acc, dice = ret_metrics['aAcc'], ret_metrics['Acc'], ret_metrics[
+        'Dice']
     assert acc[-1] == -1
-    assert iou[-1] == -1
+    assert dice[-1] == -1
+
+
+def test_mean_fscore():
+    pred_size = (10, 30, 30)
+    num_classes = 19
+    ignore_index = 255
+    results = np.random.randint(0, num_classes, size=pred_size)
+    label = np.random.randint(0, num_classes, size=pred_size)
+    label[:, 2, 5:10] = ignore_index
+    ret_metrics = mean_fscore(results, label, num_classes, ignore_index)
+    all_acc, recall, precision, fscore = ret_metrics['aAcc'], ret_metrics[
+        'Recall'], ret_metrics['Precision'], ret_metrics['Fscore']
+    all_acc_l, recall_l, precision_l, fscore_l = legacy_mean_fscore(
+        results, label, num_classes, ignore_index)
+    assert all_acc == all_acc_l
+    assert np.allclose(recall, recall_l)
+    assert np.allclose(precision, precision_l)
+    assert np.allclose(fscore, fscore_l)
+
+    ret_metrics = mean_fscore(
+        results, label, num_classes, ignore_index, beta=2)
+    all_acc, recall, precision, fscore = ret_metrics['aAcc'], ret_metrics[
+        'Recall'], ret_metrics['Precision'], ret_metrics['Fscore']
+    all_acc_l, recall_l, precision_l, fscore_l = legacy_mean_fscore(
+        results, label, num_classes, ignore_index, beta=2)
+    assert all_acc == all_acc_l
+    assert np.allclose(recall, recall_l)
+    assert np.allclose(precision, precision_l)
+    assert np.allclose(fscore, fscore_l)
+
+    results = np.random.randint(0, 5, size=pred_size)
+    label = np.random.randint(0, 4, size=pred_size)
+    ret_metrics = mean_fscore(
+        results, label, num_classes, ignore_index=255, nan_to_num=-1)
+    all_acc, recall, precision, fscore = ret_metrics['aAcc'], ret_metrics[
+        'Recall'], ret_metrics['Precision'], ret_metrics['Fscore']
+    assert recall[-1] == -1
+    assert precision[-1] == -1
+    assert fscore[-1] == -1
 
 
 def test_filename_inputs():
@@ -211,13 +350,14 @@ def test_filename_inputs():
         result_files = save_arr(results, 'pred', False, temp_dir)
         label_files = save_arr(labels, 'label', True, temp_dir)
 
-        all_acc, acc, iou = eval_metrics(
+        ret_metrics = eval_metrics(
             result_files,
             label_files,
             num_classes,
             ignore_index,
             metrics='mIoU')
-
+        all_acc, acc, iou = ret_metrics['aAcc'], ret_metrics[
+            'Acc'], ret_metrics['IoU']
         all_acc_l, acc_l, iou_l = legacy_mean_iou(results, labels, num_classes,
                                                   ignore_index)
         assert all_acc == all_acc_l


### PR DESCRIPTION
This PR contributed a new feature: support for `f-score`, `recall` and `precision` evaluation metrics. Issued by #420 

There are three main modifications:
1. add `mFscore` metric, it contain three sub-metrics, `f-score`, `recall` and `precision`.
2. refactor the `metrics.py` return value from tuple to dict.
3. modify the datasets `custom.py` `evaluate` method log using `prettytable` package instead of `terminaltables`, because the `terminaltables` is archived and no longer maintained.

And the logs look like this:

- metrics: mFscore
```
2021-04-23 21:38:04,723 - mmseg - INFO - Loaded 1464 images
2021-04-23 21:38:06,282 - mmseg - INFO - Loaded 1449 images
2021-04-23 21:38:06,282 - mmseg - INFO - load checkpoint from fcn_hr18s_512x512_40k_voc12aug_20200614_000648-4f8d6e7f.pth
2021-04-23 21:38:06,282 - mmseg - INFO - Use load_from_local loader
2021-04-23 21:38:06,391 - mmseg - INFO - Start running, host: SENSETIME\wangshuai4@cn0214003864u, work_dir: /home/SENSETIME/wangshuai4/sensetime/mmlab-original/mmsegmentation/work_dirs/fcn_hr18s_512x512_20k_voc12aug
2021-04-23 21:38:06,391 - mmseg - INFO - workflow: [('train', 1)], max: 20000 iters
2021-04-23 21:39:47,464 - mmseg - INFO - per class results:
2021-04-23 21:39:47,465 - mmseg - INFO - 
+-------------+--------+-----------+--------+
|    Class    | Fscore | Precision | Recall |
+-------------+--------+-----------+--------+
|  background | 65.54  |   93.38   | 50.48  |
|  aeroplane  | 18.95  |   51.12   | 11.63  |
|   bicycle   |  0.37  |   29.35   |  0.18  |
|     bird    |  6.52  |   60.97   |  3.45  |
|     boat    | 10.62  |    16.4   |  7.85  |
|    bottle   |  9.14  |    46.5   |  5.07  |
|     bus     |  4.57  |   42.93   |  2.41  |
|     car     |  3.24  |    7.61   |  2.06  |
|     cat     | 39.83  |   29.06   | 63.27  |
|    chair    |  0.17  |    0.16   |  0.2   |
|     cow     | 18.06  |   27.51   | 13.44  |
| diningtable |  1.41  |   19.76   |  0.73  |
|     dog     |  39.4  |    29.2   | 60.55  |
|    horse    |  1.93  |   65.64   |  0.98  |
|  motorbike  |  1.08  |   23.88   |  0.55  |
|    person   | 32.29  |   20.72   | 73.17  |
| pottedplant |  22.2  |   22.54   | 21.87  |
|    sheep    | 25.17  |   29.76   |  21.8  |
|     sofa    |  8.28  |    4.36   | 81.81  |
|    train    | 11.72  |    11.5   | 11.96  |
|  tvmonitor  |  0.17  |    2.48   |  0.09  |
+-------------+--------+-----------+--------+
2021-04-23 21:39:47,465 - mmseg - INFO - Summary:
2021-04-23 21:39:47,465 - mmseg - INFO - 
+-------+--------+-----------+--------+
|  aAcc | Fscore | Precision | Recall |
+-------+--------+-----------+--------+
| 45.72 | 15.27  |   30.23   | 20.64  |
+-------+--------+-----------+--------+
2021-04-23 21:39:47,468 - mmseg - INFO - Iter(val) [10]	aAcc: 0.4572, mFscore: 0.1527, mPrecision: 0.3023, mRecall: 0.2064, Fscore.background: 0.6554, Fscore.aeroplane: 0.1895, Fscore.bicycle: 0.0037, Fscore.bird: 0.0652, Fscore.boat: 0.1062, Fscore.bottle: 0.0914, Fscore.bus: 0.0457, Fscore.car: 0.0324, Fscore.cat: 0.3983, Fscore.chair: 0.0017, Fscore.cow: 0.1806, Fscore.diningtable: 0.0141, Fscore.dog: 0.3940, Fscore.horse: 0.0193, Fscore.motorbike: 0.0108, Fscore.person: 0.3229, Fscore.pottedplant: 0.2220, Fscore.sheep: 0.2517, Fscore.sofa: 0.0828, Fscore.train: 0.1172, Fscore.tvmonitor: 0.0017, Precision.background: 0.9338, Precision.aeroplane: 0.5112, Precision.bicycle: 0.2935, Precision.bird: 0.6097, Precision.boat: 0.1640, Precision.bottle: 0.4650, Precision.bus: 0.4293, Precision.car: 0.0761, Precision.cat: 0.2906, Precision.chair: 0.0016, Precision.cow: 0.2751, Precision.diningtable: 0.1976, Precision.dog: 0.2920, Precision.horse: 0.6564, Precision.motorbike: 0.2388, Precision.person: 0.2072, Precision.pottedplant: 0.2254, Precision.sheep: 0.2976, Precision.sofa: 0.0436, Precision.train: 0.1150, Precision.tvmonitor: 0.0248, Recall.background: 0.5048, Recall.aeroplane: 0.1163, Recall.bicycle: 0.0018, Recall.bird: 0.0345, Recall.boat: 0.0785, Recall.bottle: 0.0507, Recall.bus: 0.0241, Recall.car: 0.0206, Recall.cat: 0.6327, Recall.chair: 0.0020, Recall.cow: 0.1344, Recall.diningtable: 0.0073, Recall.dog: 0.6055, Recall.horse: 0.0098, Recall.motorbike: 0.0055, Recall.person: 0.7317, Recall.pottedplant: 0.2187, Recall.sheep: 0.2180, Recall.sofa: 0.8181, Recall.train: 0.1196, Recall.tvmonitor: 0.0009
```

- metrics: mIoU, mDice, mFscore
``` 
2021-04-23 21:34:50,731 - mmseg - INFO - Loaded 1464 images
2021-04-23 21:34:52,282 - mmseg - INFO - Loaded 1449 images
2021-04-23 21:34:52,282 - mmseg - INFO - load checkpoint from fcn_hr18s_512x512_40k_voc12aug_20200614_000648-4f8d6e7f.pth
2021-04-23 21:34:52,283 - mmseg - INFO - Use load_from_local loader
2021-04-23 21:34:52,369 - mmseg - INFO - Start running, host: SENSETIME\wangshuai4@cn0214003864u, work_dir: /home/SENSETIME/wangshuai4/sensetime/mmlab-original/mmsegmentation/work_dirs/fcn_hr18s_512x512_20k_voc12aug
2021-04-23 21:34:52,369 - mmseg - INFO - workflow: [('train', 1)], max: 20000 iters
2021-04-23 21:36:31,405 - mmseg - INFO - per class results:
2021-04-23 21:36:31,408 - mmseg - INFO - 
+-------------+-------+-------+-------+--------+-----------+--------+
|    Class    |  IoU  |  Acc  |  Dice | Fscore | Precision | Recall |
+-------------+-------+-------+-------+--------+-----------+--------+
|  background | 46.73 | 48.97 | 63.69 | 63.69  |   91.09   | 48.97  |
|  aeroplane  |  8.74 | 11.37 | 16.07 | 16.07  |   27.43   | 11.37  |
|   bicycle   |  2.5  |  4.81 |  4.88 |  4.88  |    4.95   |  4.81  |
|     bird    |  0.76 |  0.77 |  1.51 |  1.51  |    38.7   |  0.77  |
|     boat    |  0.0  |  0.0  |  0.0  |  nan   |    0.0    |  0.0   |
|    bottle   |  0.77 |  0.82 |  1.54 |  1.54  |   13.25   |  0.82  |
|     bus     |  1.2  |  1.24 |  2.37 |  2.37  |   29.58   |  1.24  |
|     car     |  9.13 | 21.37 | 16.73 | 16.73  |   13.74   | 21.37  |
|     cat     | 10.07 | 81.01 |  18.3 |  18.3  |   10.32   | 81.01  |
|    chair    |  0.0  |  0.0  |  0.0  |  0.0   |    0.18   |  0.0   |
|     cow     |  0.0  |  0.0  |  0.01 |  0.01  |    0.93   |  0.0   |
| diningtable |  0.0  |  0.0  |  0.0  |  nan   |    0.0    |  0.0   |
|     dog     |  4.54 | 15.24 |  8.69 |  8.69  |    6.08   | 15.24  |
|    horse    |  0.92 |  1.47 |  1.83 |  1.83  |    2.43   |  1.47  |
|  motorbike  |  5.97 | 81.26 | 11.26 | 11.26  |    6.05   | 81.26  |
|    person   |  21.2 | 43.11 | 34.98 | 34.98  |   29.43   | 43.11  |
| pottedplant |  0.06 |  0.06 |  0.11 |  0.11  |    33.1   |  0.06  |
|    sheep    |  3.19 | 34.18 |  6.19 |  6.19  |    3.4    | 34.18  |
|     sofa    |  0.87 |  1.12 |  1.73 |  1.73  |    3.82   |  1.12  |
|    train    | 11.56 | 21.46 | 20.73 | 20.73  |   20.05   | 21.46  |
|  tvmonitor  |  6.72 |  17.6 |  12.6 |  12.6  |    9.81   |  17.6  |
+-------------+-------+-------+-------+--------+-----------+--------+
2021-04-23 21:36:31,408 - mmseg - INFO - Summary:
2021-04-23 21:36:31,408 - mmseg - INFO - 
+-------+------+-------+-------+--------+-----------+--------+
|  aAcc | IoU  |  Acc  |  Dice | Fscore | Precision | Recall |
+-------+------+-------+-------+--------+-----------+--------+
| 42.48 | 6.43 | 18.37 | 10.63 | 11.75  |    16.4   | 18.37  |
+-------+------+-------+-------+--------+-----------+--------+
2021-04-23 21:36:31,410 - mmseg - INFO - Iter(val) [10]	aAcc: 0.4248, mIoU: 0.0643, mAcc: 0.1837, mDice: 0.1063, mFscore: 0.1175, mPrecision: 0.1640, mRecall: 0.1837, IoU.background: 0.4673, IoU.aeroplane: 0.0874, IoU.bicycle: 0.0250, IoU.bird: 0.0076, IoU.boat: 0.0000, IoU.bottle: 0.0077, IoU.bus: 0.0120, IoU.car: 0.0913, IoU.cat: 0.1007, IoU.chair: 0.0000, IoU.cow: 0.0000, IoU.diningtable: 0.0000, IoU.dog: 0.0454, IoU.horse: 0.0092, IoU.motorbike: 0.0597, IoU.person: 0.2120, IoU.pottedplant: 0.0006, IoU.sheep: 0.0319, IoU.sofa: 0.0087, IoU.train: 0.1156, IoU.tvmonitor: 0.0672, Acc.background: 0.4897, Acc.aeroplane: 0.1137, Acc.bicycle: 0.0481, Acc.bird: 0.0077, Acc.boat: 0.0000, Acc.bottle: 0.0082, Acc.bus: 0.0124, Acc.car: 0.2137, Acc.cat: 0.8101, Acc.chair: 0.0000, Acc.cow: 0.0000, Acc.diningtable: 0.0000, Acc.dog: 0.1524, Acc.horse: 0.0147, Acc.motorbike: 0.8126, Acc.person: 0.4311, Acc.pottedplant: 0.0006, Acc.sheep: 0.3418, Acc.sofa: 0.0112, Acc.train: 0.2146, Acc.tvmonitor: 0.1760, Dice.background: 0.6369, Dice.aeroplane: 0.1607, Dice.bicycle: 0.0488, Dice.bird: 0.0151, Dice.boat: 0.0000, Dice.bottle: 0.0154, Dice.bus: 0.0237, Dice.car: 0.1673, Dice.cat: 0.1830, Dice.chair: 0.0000, Dice.cow: 0.0001, Dice.diningtable: 0.0000, Dice.dog: 0.0869, Dice.horse: 0.0183, Dice.motorbike: 0.1126, Dice.person: 0.3498, Dice.pottedplant: 0.0011, Dice.sheep: 0.0619, Dice.sofa: 0.0173, Dice.train: 0.2073, Dice.tvmonitor: 0.1260, Fscore.background: 0.6369, Fscore.aeroplane: 0.1607, Fscore.bicycle: 0.0488, Fscore.bird: 0.0151, Fscore.boat: nan, Fscore.bottle: 0.0154, Fscore.bus: 0.0237, Fscore.car: 0.1673, Fscore.cat: 0.1830, Fscore.chair: 0.0000, Fscore.cow: 0.0001, Fscore.diningtable: nan, Fscore.dog: 0.0869, Fscore.horse: 0.0183, Fscore.motorbike: 0.1126, Fscore.person: 0.3498, Fscore.pottedplant: 0.0011, Fscore.sheep: 0.0619, Fscore.sofa: 0.0173, Fscore.train: 0.2073, Fscore.tvmonitor: 0.1260, Precision.background: 0.9109, Precision.aeroplane: 0.2743, Precision.bicycle: 0.0495, Precision.bird: 0.3870, Precision.boat: 0.0000, Precision.bottle: 0.1325, Precision.bus: 0.2958, Precision.car: 0.1374, Precision.cat: 0.1032, Precision.chair: 0.0018, Precision.cow: 0.0093, Precision.diningtable: 0.0000, Precision.dog: 0.0608, Precision.horse: 0.0243, Precision.motorbike: 0.0605, Precision.person: 0.2943, Precision.pottedplant: 0.3310, Precision.sheep: 0.0340, Precision.sofa: 0.0382, Precision.train: 0.2005, Precision.tvmonitor: 0.0981, Recall.background: 0.4897, Recall.aeroplane: 0.1137, Recall.bicycle: 0.0481, Recall.bird: 0.0077, Recall.boat: 0.0000, Recall.bottle: 0.0082, Recall.bus: 0.0124, Recall.car: 0.2137, Recall.cat: 0.8101, Recall.chair: 0.0000, Recall.cow: 0.0000, Recall.diningtable: 0.0000, Recall.dog: 0.1524, Recall.horse: 0.0147, Recall.motorbike: 0.8126, Recall.person: 0.4311, Recall.pottedplant: 0.0006, Recall.sheep: 0.3418, Recall.sofa: 0.0112, Recall.train: 0.2146, Recall.tvmonitor: 0.1760

```