### PR TITLE
[Enhance] Replace data_dict calling 'img' key to support MMDet3D

### DIFF
--- a/mmseg/apis/test.py
+++ b/mmseg/apis/test.py
@@ -92,12 +92,13 @@ def single_gpu_test(model,
             if efficient_test:
                 result = [np2tmp(_) for _ in result]
             results.extend(result)
+            batch_size = len(result)
         else:
             if efficient_test:
                 result = np2tmp(result)
             results.append(result)
+            batch_size = 1
 
-        batch_size = data['img'][0].size(0)
         for _ in range(batch_size):
             prog_bar.update()
     return results

--- a/mmseg/apis/test.py
+++ b/mmseg/apis/test.py
@@ -97,7 +97,7 @@ def single_gpu_test(model,
                 result = np2tmp(result)
             results.append(result)
 
-        batch_size = len(data['img_metas'][0])
+        batch_size = len(result)
         for _ in range(batch_size):
             prog_bar.update()
     return results

--- a/mmseg/apis/test.py
+++ b/mmseg/apis/test.py
@@ -92,13 +92,12 @@ def single_gpu_test(model,
             if efficient_test:
                 result = [np2tmp(_) for _ in result]
             results.extend(result)
-            batch_size = len(result)
         else:
             if efficient_test:
                 result = np2tmp(result)
             results.append(result)
-            batch_size = 1
 
+        batch_size = len(data['img_metas'][0])
         for _ in range(batch_size):
             prog_bar.update()
     return results

--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -155,7 +155,7 @@ class BaseSegmentor(nn.Module):
         outputs = dict(
             loss=loss,
             log_vars=log_vars,
-            num_samples=len(data_batch['img'].data))
+            num_samples=len(data_batch['img_metas']))
 
         return outputs
 

--- a/tests/test_eval_hook.py
+++ b/tests/test_eval_hook.py
@@ -16,7 +16,7 @@ from mmseg.core import DistEvalHook, EvalHook
 class ExampleDataset(Dataset):
 
     def __getitem__(self, idx):
-        results = dict(img=torch.tensor([1]), img_metas=dict())
+        results = dict(img=torch.tensor([1]), img_metas=[dict()])
         return results
 
     def __len__(self):

--- a/tests/test_eval_hook.py
+++ b/tests/test_eval_hook.py
@@ -16,7 +16,7 @@ from mmseg.core import DistEvalHook, EvalHook
 class ExampleDataset(Dataset):
 
     def __getitem__(self, idx):
-        results = dict(img=torch.tensor([1]), img_metas=[dict()])
+        results = dict(img=torch.tensor([1]), img_metas=dict())
         return results
 
     def __len__(self):


### PR DESCRIPTION
Hi, I am Ziyi, a developer from MMDet3D. In order to train/test 3D seg algorithms, I need to call functions from MMSeg. However, some functions in MMSeg calls `data['img']`, which causes `KeyError` because we don't have `img`. I replace these calling with some workarounds and make it compatibility with MMDet3D. Hope you can approve it. Thanks.