### PR TITLE
Add option for output shape of ViT

### DIFF
--- a/mmseg/models/backbones/vit.py
+++ b/mmseg/models/backbones/vit.py
@@ -306,7 +306,8 @@ class VisionTransformer(nn.Module):
                 with_cp=with_cp) for i in range(depth)
         ])
 
-        assert out_shape in ['NLC', 'NCHW']
+        assert out_shape in ['NLC',
+                             'NCHW'], 'output shape must be "NLC" or "NCHW".'
 
         self.out_shape = out_shape
 

--- a/mmseg/models/backbones/vit.py
+++ b/mmseg/models/backbones/vit.py
@@ -234,8 +234,8 @@ class VisionTransformer(nn.Module):
             and its variants only. Default: False.
         final_norm (bool):  Whether to add a additional layer to normalize
             final feature map. Default: False.
-        final_reshape (bool): Whether to reshape the output feature information
-            from NLC format to NCHW format. Default: True.
+        out_reshape (str): Select the output format of feature information.
+            Default: NCHW.
         interpolate_mode (str): Select the interpolate mode for position
             embeding vector resize. Default: bicubic.
         with_cls_token (bool): If concatenating class token into image tokens
@@ -263,7 +263,7 @@ class VisionTransformer(nn.Module):
                  act_cfg=dict(type='GELU'),
                  norm_eval=False,
                  final_norm=False,
-                 final_reshape=True,
+                 out_shape='NCHW',
                  with_cls_token=True,
                  interpolate_mode='bicubic',
                  with_cp=False):
@@ -306,9 +306,12 @@ class VisionTransformer(nn.Module):
                 with_cp=with_cp) for i in range(depth)
         ])
 
+        assert out_shape in ['NLC', 'NCHW']
+
+        self.out_shape = out_shape
+
         self.interpolate_mode = interpolate_mode
         self.final_norm = final_norm
-        self.final_reshape = final_reshape
         if final_norm:
             _, self.norm = build_norm_layer(norm_cfg, embed_dim)
 
@@ -447,7 +450,7 @@ class VisionTransformer(nn.Module):
                     out = x[:, 1:]
                 else:
                     out = x
-                if self.final_reshape:
+                if self.out_shape == 'NCHW':
                     B, _, C = out.shape
                     out = out.reshape(B, inputs.shape[2] // self.patch_size,
                                       inputs.shape[3] // self.patch_size,

--- a/mmseg/models/backbones/vit.py
+++ b/mmseg/models/backbones/vit.py
@@ -235,7 +235,7 @@ class VisionTransformer(nn.Module):
         final_norm (bool):  Whether to add a additional layer to normalize
             final feature map. Default: False.
         final_reshape (bool): Whether to reshape the output feature information
-            from NLC format to NCHW format. Default: False.
+            from NLC format to NCHW format. Default: True.
         interpolate_mode (str): Select the interpolate mode for position
             embeding vector resize. Default: bicubic.
         with_cls_token (bool): If concatenating class token into image tokens

--- a/tests/test_models/test_backbones/test_vit.py
+++ b/tests/test_models/test_backbones/test_vit.py
@@ -72,3 +72,9 @@ def test_vit_backbone():
     imgs = torch.randn(1, 3, 224, 224)
     feat = model(imgs)
     assert feat[-1].shape == (1, 768, 14, 14)
+
+    # Test final reshape arg
+    imgs = torch.randn(1, 3, 224, 224)
+    model = VisionTransformer(final_reshape=False)
+    feat = model(imgs)
+    assert feat[-1].shape == (1, 196, 768)

--- a/tests/test_models/test_backbones/test_vit.py
+++ b/tests/test_models/test_backbones/test_vit.py
@@ -30,6 +30,10 @@ def test_vit_backbone():
         model = VisionTransformer()
         model(x)
 
+    with pytest.raises(AssertionError):
+        # out_shape must be 'NLC' or 'NCHW;'
+        VisionTransformer(out_shape='NCL')
+
     # Test img_size isinstance int
     imgs = torch.randn(1, 3, 224, 224)
     model = VisionTransformer(img_size=224)
@@ -75,6 +79,6 @@ def test_vit_backbone():
 
     # Test final reshape arg
     imgs = torch.randn(1, 3, 224, 224)
-    model = VisionTransformer(final_reshape=False)
+    model = VisionTransformer(out_shape='NLC')
     feat = model(imgs)
     assert feat[-1].shape == (1, 196, 768)


### PR DESCRIPTION
Add arg:final_reshape for vit to control if converting output feature information from NLC to NCHW.