### PR TITLE
[Enhance] Infer batch_size using len(result) to support MMDet3D

### DIFF
--- a/mmseg/apis/test.py
+++ b/mmseg/apis/test.py
@@ -149,7 +149,7 @@ def multi_gpu_test(model,
             results.append(result)
 
         if rank == 0:
-            batch_size = data['img'][0].size(0)
+            batch_size = len(result)
             for _ in range(batch_size * world_size):
                 prog_bar.update()
 


### PR DESCRIPTION
MMDet3D data doesn't have `'img'` term. Instead, we infer batch_size from `len(result)`. MMDet also adopts this fashion [here](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/apis/test.py#L105).