### PR TITLE
[fix] fix the bug of large seg map IoU calculation

### DIFF
--- a/mmseg/core/evaluation/metrics.py
+++ b/mmseg/core/evaluation/metrics.py
@@ -75,12 +75,9 @@ def intersect_and_union(pred_label,
     label = label[mask]
 
     intersect = pred_label[pred_label == label]
-    area_intersect = torch.histc(
-        intersect.float(), bins=(num_classes), min=0, max=num_classes - 1)
-    area_pred_label = torch.histc(
-        pred_label.float(), bins=(num_classes), min=0, max=num_classes - 1)
-    area_label = torch.histc(
-        label.float(), bins=(num_classes), min=0, max=num_classes - 1)
+    area_intersect = torch.bincount(intersect, minlength=num_classes)
+    area_pred_label = torch.bincount(pred_label, minlength=num_classes)
+    area_label = torch.bincount(label, minlength=num_classes)
     area_union = area_pred_label + area_label - area_intersect
     return area_intersect, area_union, area_pred_label, area_label
 


### PR DESCRIPTION
This PR is realated to #523.

Problem statement:
`torch.histc` may meet a trouble when inputting large size seg map. `torch.histc` may only be able to count 2^24. When pixels of single class exceed 2^24, `torch.histc` can't count exceeded part.

Fix:
We change `torch.histc` to `torch.bincount` when counting pixels of each class.

`torch.bincount` can only support 1-d non-negative integral inputs. Besides, the inference speed of `torch.bincount` is slower than `torch.histc`