### PR TITLE
[Fix] Fix error when class_weight file doesn't exist

### DIFF
--- a/mmseg/models/losses/utils.py
+++ b/mmseg/models/losses/utils.py
@@ -1,4 +1,5 @@
 import functools
+import warnings
 
 import mmcv
 import numpy as np
@@ -14,6 +15,15 @@ def get_class_weight(class_weight):
     """
     if isinstance(class_weight, str):
         # take it as a file path
+        try:
+            mmcv.check_file_exist(class_weight)
+        except FileNotFoundError:
+            # don't use class_weight if file not exist
+            warnings.warn(
+                f'class weight file "{class_weight}" does not exist, '
+                'set as None instead')
+            return None
+
         if class_weight.endswith('.npy'):
             class_weight = np.load(class_weight)
         else:

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -32,6 +32,14 @@ def test_ce_loss():
     import numpy as np
     tmp_file = tempfile.NamedTemporaryFile()
 
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        class_weight=f'{tmp_file.name}.pkl',  # file doesn't exist
+        loss_weight=1.0)
+    loss_cls = build_loss(loss_cls_cfg)
+    assert loss_cls.class_weight is None
+
     mmcv.dump([0.8, 0.2], f'{tmp_file.name}.pkl', 'pkl')  # from pkl file
     loss_cls_cfg = dict(
         type='CrossEntropyLoss',

--- a/tests/test_models/test_losses/test_dice_loss.py
+++ b/tests/test_models/test_losses/test_dice_loss.py
@@ -23,6 +23,15 @@ def test_dice_lose():
     import numpy as np
     tmp_file = tempfile.NamedTemporaryFile()
 
+    loss_cfg = dict(
+        type='DiceLoss',
+        reduction='none',
+        class_weight=f'{tmp_file.name}.pkl',  # file doesn't exist
+        loss_weight=1.0,
+        ignore_index=1)
+    dice_loss = build_loss(loss_cfg)
+    assert dice_loss.class_weight is None
+
     mmcv.dump([1.0, 2.0, 3.0], f'{tmp_file.name}.pkl', 'pkl')  # from pkl file
     loss_cfg = dict(
         type='DiceLoss',

--- a/tests/test_models/test_losses/test_lovasz_loss.py
+++ b/tests/test_models/test_losses/test_lovasz_loss.py
@@ -45,6 +45,15 @@ def test_lovasz_loss():
     import numpy as np
     tmp_file = tempfile.NamedTemporaryFile()
 
+    loss_cfg = dict(
+        type='LovaszLoss',
+        per_image=True,
+        reduction='mean',
+        class_weight=f'{tmp_file.name}.pkl',  # file doesn't exist
+        loss_weight=1.0)
+    lovasz_loss = build_loss(loss_cfg)
+    assert lovasz_loss.class_weight is None
+
     mmcv.dump([1.0, 2.0, 3.0], f'{tmp_file.name}.pkl', 'pkl')  # from pkl file
     loss_cfg = dict(
         type='LovaszLoss',


### PR DESCRIPTION
In MMDet3D, there is a config file that builds a loss reading `class_weight` from a file. However, this file is generated via data pre-processing, thus doesn't exist on the GitHub repo. So the pytest will report an error in GitHub CI. This PR is a workaround for this error, which uses `None` if class_weight file doesn't exist and raise a warning.