### PR TITLE
[fix] fix loading deit weights

### DIFF
--- a/mmseg/models/backbones/vit.py
+++ b/mmseg/models/backbones/vit.py
@@ -325,6 +325,8 @@ class VisionTransformer(nn.Module):
             checkpoint = _load_checkpoint(pretrained, logger=logger)
             if 'state_dict' in checkpoint:
                 state_dict = checkpoint['state_dict']
+            elif 'model' in checkpoint:
+                state_dict = checkpoint['model']
             else:
                 state_dict = checkpoint
 

--- a/mmseg/models/necks/multilevel_neck.py
+++ b/mmseg/models/necks/multilevel_neck.py
@@ -54,7 +54,6 @@ class MultiLevelNeck(nn.Module):
 
     def forward(self, inputs):
         assert len(inputs) == len(self.in_channels)
-        print(inputs[0].shape)
         inputs = [
             lateral_conv(inputs[i])
             for i, lateral_conv in enumerate(self.lateral_convs)


### PR DESCRIPTION
[Ref implementation](https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision_transformer.py#L378)

Add `'model'` case at `init_weights()`function in vit backbone.

In addition, delete unnecessary code in multilevel neck.