### PR TITLE
[Fix] Loss average over non-ignored elements in CE loss

### DIFF
--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -25,7 +25,7 @@ def cross_entropy(pred,
 
     # apply weights and do the reduction
     # pytorch's official cross_entropy average loss over non-ignored elements
-    # refer to https://github.com/pytorch/pytorch/blob/56b43f4fec1f76953f15a627694d4bba34588969/torch/nn/functional.py#L2660
+    # refer to https://github.com/pytorch/pytorch/blob/56b43f4fec1f76953f15a627694d4bba34588969/torch/nn/functional.py#L2660  # noqa
     if avg_factor is None:
         avg_factor = label.numel() - (label == ignore_index).sum().item()
 
@@ -89,8 +89,19 @@ def binary_cross_entropy(pred,
             'H, W], label shape [N, H, W] are supported'
         label, weight = _expand_onehot_labels(label, weight, pred.shape,
                                               ignore_index)
+    else:
+        # should mask out the ignored elements
+        valid_mask = ((label >= 0) & (label != ignore_index)).float()
+        if weight is not None:
+            weight *= valid_mask
+        else:
+            weight = valid_mask
 
     # weighted element-wise losses
+    # average loss over non-ignored elements
+    if avg_factor is None:
+        avg_factor = label.numel() - (label == ignore_index).sum().item()
+
     if weight is not None:
         weight = weight.float()
     loss = F.binary_cross_entropy_with_logits(

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -24,6 +24,11 @@ def cross_entropy(pred,
         ignore_index=ignore_index)
 
     # apply weights and do the reduction
+    # pytorch's official cross_entropy average loss over non-ignored elements
+    # refer to https://github.com/pytorch/pytorch/blob/56b43f4fec1f76953f15a627694d4bba34588969/torch/nn/functional.py#L2660
+    if avg_factor is None:
+        avg_factor = label.numel() - (label == ignore_index).sum().item()
+
     if weight is not None:
         weight = weight.float()
     loss = weight_reduce_loss(

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -90,10 +90,35 @@ def test_ce_loss():
     assert torch.allclose(loss, torch_loss)
 
     fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
-    fake_label[0, [0, 5, 8, 9]] = 10
+    fake_label[1, [0, 5, 8, 9]] = 10
     loss = loss_cls(fake_pred, fake_label, ignore_index=10)
     torch_loss = torch.nn.functional.cross_entropy(
         fake_pred, fake_label, ignore_index=10, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    # test bce loss
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 10).float()
+    fake_label = torch.rand(2, 10).float()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    fake_label[0, [1, 2, 5, 7]] = -1  # set ignore_index
+    fake_label[1, [0, 5, 8, 9]] = -1
+    loss = loss_cls(fake_pred, fake_label, ignore_index=-1)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred[fake_label != -1],
+        fake_label[fake_label != -1],
+        reduction='mean')
     assert torch.allclose(loss, torch_loss)
 
     # TODO test use_mask

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -96,6 +96,25 @@ def test_ce_loss():
         fake_pred, fake_label, ignore_index=10, reduction='mean')
     assert torch.allclose(loss, torch_loss)
 
+    # test ignore index and class_weight
+    class_weight = torch.rand(5)
+    class_weight /= class_weight.sum()
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=class_weight,
+        loss_weight=1.0)
+    loss_cls = build_loss(loss_cls_cfg)
+    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred,
+        fake_label,
+        ignore_index=10,
+        reduction='sum',
+        weight=class_weight) / 12.0
+    assert torch.allclose(loss, torch_loss)
+
     # test bce loss
     loss_cls_cfg = dict(
         type='CrossEntropyLoss',
@@ -119,6 +138,16 @@ def test_ce_loss():
         fake_pred[fake_label != -1],
         fake_label[fake_label != -1],
         reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    # test ignore index and weight
+    weight = torch.rand(2, 10)
+    loss = loss_cls(fake_pred, fake_label, weight=weight, ignore_index=-1)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred[fake_label != -1],
+        fake_label[fake_label != -1],
+        reduction='mean',
+        weight=weight[fake_label != -1])
     assert torch.allclose(loss, torch_loss)
 
     # TODO test use_mask


### PR DESCRIPTION
Fix issue #546. I modify `CrossEntropyLoss` to be consistent with pytorch's official `F.cross_entropy`.

However, for Dice and Lovasz loss, I am not sure if we should also modify them accordingly since there is no such **official** implementation. I guess these two losses are common in medical image segmentation? What are the common practice of other papers?
