### PR TITLE
Add fixes to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 lib
 RUN conda clean --all
 
 RUN pip install mmcv-full==latest+torch1.6.0+cu101 -f https://download.openmmlab.com/mmcv/dist/index.html
-RUN git clone https://github.com/open-mmlab/mmsegmenation.git /mmsegmentation
+RUN git clone https://github.com/open-mmlab/mmsegmentation.git /mmsegmentation
 WORKDIR /mmsegmentation
-RUN pip install -r requirements/build.txt
+RUN pip install -r requirements.txt
 RUN pip install --no-cache-dir -e .


### PR DESCRIPTION
This PR adds a couple of fixes to Dockerfile.

1. Fix typo in url to git repo in Dockerfile, while cloning
2. Fix pip install command to use requirements file in top level dir (requirements/build.txt does not exist)

Fixes #595 