### PR TITLE
[Enhancement] Change inference time from 'fps' to 'ms/im' in metafile

### DIFF
--- a/configs/ann/metafile.yml
+++ b/configs/ann/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: ann_r50-d8_512x1024_40k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps): 3.71
+      inference time (ms/im): 269.54
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: ann_r101-d8_512x1024_40k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps): 2.55
+      inference time (ms/im): 392.16
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: ann_r50-d8_769x769_40k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps): 1.70
+      inference time (ms/im): 588.24
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: ann_r101-d8_769x769_40k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps): 1.15
+      inference time (ms/im): 869.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: ann_r50-d8_512x1024_80k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps): 3.71
+      inference time (ms/im): 269.54
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: ann_r101-d8_512x1024_80k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps): 2.55
+      inference time (ms/im): 392.16
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: ann_r50-d8_769x769_80k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps): 1.70
+      inference time (ms/im): 588.24
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: ann_r101-d8_769x769_80k_cityscapes
     In Collection: ANN
     Metadata:
-      inference time (fps):
+      inference time (ms/im): 869.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: ann_r50-d8_512x512_80k_ade20k
     In Collection: ANN
     Metadata:
-      inference time (fps): 21.01
+      inference time (ms/im): 47.6
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: ann_r101-d8_512x512_80k_ade20k
     In Collection: ANN
     Metadata:
-      inference time (fps): 14.12
+      inference time (ms/im): 70.82
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: ann_r50-d8_512x512_160k_ade20k
     In Collection: ANN
     Metadata:
-      inference time (fps): 21.01
+      inference time (ms/im): 47.6
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: ann_r101-d8_512x512_160k_ade20k
     In Collection: ANN
     Metadata:
-      inference time (fps): 14.12
+      inference time (ms/im): 70.82
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -179,7 +179,7 @@ Models:
   - Name: ann_r50-d8_512x512_20k_voc12aug
     In Collection: ANN
     Metadata:
-      inference time (fps): 20.92
+      inference time (ms/im): 47.8
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -193,7 +193,7 @@ Models:
   - Name: ann_r101-d8_512x512_20k_voc12aug
     In Collection: ANN
     Metadata:
-      inference time (fps): 13.94
+      inference time (ms/im): 71.74
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -207,7 +207,7 @@ Models:
   - Name: ann_r50-d8_512x512_40k_voc12aug
     In Collection: ANN
     Metadata:
-      inference time (fps): 20.92
+      inference time (ms/im): 47.8
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -221,7 +221,7 @@ Models:
   - Name: ann_r101-d8_512x512_40k_voc12aug
     In Collection: ANN
     Metadata:
-      inference time (fps): 13.94
+      inference time (ms/im): 71.74
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug

--- a/configs/apcnet/metafile.yml
+++ b/configs/apcnet/metafile.yml
@@ -10,7 +10,7 @@ Models:
   - Name: apcnet_r50-d8_512x1024_40k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 3.57
+      inference time (ms/im): 280.11
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -24,7 +24,7 @@ Models:
   - Name: apcnet_r101-d8_512x1024_40k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 2.15
+      inference time (ms/im): 465.12
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -38,7 +38,7 @@ Models:
   - Name: apcnet_r50-d8_769x769_40k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 1.52
+      inference time (ms/im): 657.89
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -52,7 +52,7 @@ Models:
   - Name: apcnet_r101-d8_769x769_40k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 1.03
+      inference time (ms/im): 970.87
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -66,7 +66,7 @@ Models:
   - Name: apcnet_r50-d8_512x1024_80k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 3.57
+      inference time (ms/im): 280.11
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -80,7 +80,7 @@ Models:
   - Name: apcnet_r101-d8_512x1024_80k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 2.15
+      inference time (ms/im): 465.12
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
   - Name: apcnet_r50-d8_769x769_80k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 1.52
+      inference time (ms/im): 657.89
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -108,7 +108,7 @@ Models:
   - Name: apcnet_r101-d8_769x769_80k_cityscapes
     In Collection: APCNet
     Metadata:
-      inference time (fps): 1.03
+      inference time (ms/im): 970.87
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -122,7 +122,7 @@ Models:
   - Name: apcnet_r50-d8_512x512_80k_ade20k
     In Collection: APCNet
     Metadata:
-      inference time (fps): 19.61
+      inference time (ms/im): 50.99
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -136,7 +136,7 @@ Models:
   - Name: apcnet_r101-d8_512x512_80k_ade20k
     In Collection: APCNet
     Metadata:
-      inference time (fps): 13.10
+      inference time (ms/im): 76.34
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -150,7 +150,7 @@ Models:
   - Name: apcnet_r50-d8_512x512_160k_ade20k
     In Collection: APCNet
     Metadata:
-      inference time (fps): 19.61
+      inference time (ms/im): 50.99
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -164,7 +164,7 @@ Models:
   - Name: apcnet_r101-d8_512x512_160k_ade20k
     In Collection: APCNet
     Metadata:
-      inference time (fps): 13.10
+      inference time (ms/im): 76.34
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/ccnet/metafile.yml
+++ b/configs/ccnet/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: ccnet_r50-d8_512x1024_40k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 3.32
+      inference time (ms/im): 301.2
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: ccnet_r101-d8_512x1024_40k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 2.31
+      inference time (ms/im): 432.9
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: ccnet_r50-d8_769x769_40k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 1.43
+      inference time (ms/im): 699.3
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: ccnet_r101-d8_769x769_40k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 1.01
+      inference time (ms/im): 990.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: ccnet_r50-d8_512x1024_80k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 3.32
+      inference time (ms/im): 301.2
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: ccnet_r101-d8_512x1024_80k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 2.31
+      inference time (ms/im): 432.9
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: ccnet_r50-d8_769x769_80k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 1.43
+      inference time (ms/im): 699.3
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: ccnet_r101-d8_769x769_80k_cityscapes
     In Collection: CCNet
     Metadata:
-      inference time (fps): 1.01
+      inference time (ms/im): 990.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: ccnet_r50-d8_512x512_80k_ade20k
     In Collection: CCNet
     Metadata:
-      inference time (fps): 20.89
+      inference time (ms/im): 47.87
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: ccnet_r101-d8_512x512_80k_ade20k
     In Collection: CCNet
     Metadata:
-      inference time (fps): 14.11
+      inference time (ms/im): 70.87
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: ccnet_r50-d8_512x512_160k_ade20k
     In Collection: CCNet
     Metadata:
-      inference time (fps): 20.89
+      inference time (ms/im): 47.87
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: ccnet_r101-d8_512x512_160k_ade20k
     In Collection: CCNet
     Metadata:
-      inference time (fps): 14.11
+      inference time (ms/im): 70.87
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -179,7 +179,7 @@ Models:
   - Name: ccnet_r50-d8_512x512_20k_voc12aug
     In Collection: CCNet
     Metadata:
-      inference time (fps): 20.45
+      inference time (ms/im): 48.9
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -193,7 +193,7 @@ Models:
   - Name: ccnet_r101-d8_512x512_20k_voc12aug
     In Collection: CCNet
     Metadata:
-      inference time (fps): 13.64
+      inference time (ms/im): 73.31
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -207,7 +207,7 @@ Models:
   - Name: ccnet_r50-d8_512x512_40k_voc12aug
     In Collection: CCNet
     Metadata:
-      inference time (fps): 20.45
+      inference time (ms/im): 48.9
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -221,7 +221,7 @@ Models:
   - Name: ccnet_r101-d8_512x512_40k_voc12aug
     In Collection: CCNet
     Metadata:
-      inference time (fps): 13.64
+      inference time (ms/im): 73.31
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug

--- a/configs/cgnet/metafile.yml
+++ b/configs/cgnet/metafile.yml
@@ -9,7 +9,7 @@ Models:
   - Name: cgnet_680x680_60k_cityscapes
     In Collection: CGNet
     Metadata:
-      inference time (fps): 30.51
+      inference time (ms/im): 32.78
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -23,7 +23,7 @@ Models:
   - Name: cgnet_512x1024_60k_cityscapes
     In Collection: CGNet
     Metadata:
-      inference time (fps): 31.14
+      inference time (ms/im): 32.11
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes

--- a/configs/danet/metafile.yml
+++ b/configs/danet/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: danet_r50-d8_512x1024_40k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 2.66
+      inference time (ms/im): 375.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: danet_r101-d8_512x1024_40k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 1.99
+      inference time (ms/im): 502.51
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: danet_r50-d8_769x769_40k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 1.56
+      inference time (ms/im): 641.03
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: danet_r101-d8_769x769_40k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 1.07
+      inference time (ms/im): 934.58
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: danet_r50-d8_512x1024_80k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 2.66
+      inference time (ms/im): 375.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: danet_r101-d8_512x1024_80k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 1.99
+      inference time (ms/im): 502.51
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: danet_r50-d8_769x769_80k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 1.56
+      inference time (ms/im): 641.03
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: danet_r101-d8_769x769_80k_cityscapes
     In Collection: DANet
     Metadata:
-      inference time (fps): 1.07
+      inference time (ms/im): 934.58
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: danet_r50-d8_512x512_80k_ade20k
     In Collection: DANet
     Metadata:
-      inference time (fps): 21.20
+      inference time (ms/im): 47.17
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: danet_r101-d8_512x512_80k_ade20k
     In Collection: DANet
     Metadata:
-      inference time (fps): 14.18
+      inference time (ms/im): 70.52
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: danet_r50-d8_512x512_160k_ade20k
     In Collection: DANet
     Metadata:
-      inference time (fps): 21.20
+      inference time (ms/im): 47.17
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: danet_r101-d8_512x512_160k_ade20k
     In Collection: DANet
     Metadata:
-      inference time (fps): 14.18
+      inference time (ms/im): 70.52
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -179,7 +179,7 @@ Models:
   - Name: danet_r50-d8_512x512_20k_voc12aug
     In Collection: DANet
     Metadata:
-      inference time (fps): 20.94
+      inference time (ms/im): 47.76
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -193,7 +193,7 @@ Models:
   - Name: danet_r101-d8_512x512_20k_voc12aug
     In Collection: DANet
     Metadata:
-      inference time (fps): 13.76
+      inference time (ms/im): 72.67
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -207,7 +207,7 @@ Models:
   - Name: danet_r50-d8_512x512_40k_voc12aug
     In Collection: DANet
     Metadata:
-      inference time (fps): 20.94
+      inference time (ms/im): 47.76
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -221,7 +221,7 @@ Models:
   - Name: danet_r101-d8_512x512_40k_voc12aug
     In Collection: DANet
     Metadata:
-      inference time (fps): 13.76
+      inference time (ms/im): 72.67
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug

--- a/configs/deeplabv3/metafile.yml
+++ b/configs/deeplabv3/metafile.yml
@@ -12,7 +12,7 @@ Models:
   - Name: deeplabv3_r50-d8_512x1024_40k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 2.57
+      inference time (ms/im): 389.11
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -26,7 +26,7 @@ Models:
   - Name: deeplabv3_r101-d8_512x1024_40k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 1.92
+      inference time (ms/im): 520.83
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -40,7 +40,7 @@ Models:
   - Name: deeplabv3_r50-d8_769x769_40k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 1.11
+      inference time (ms/im): 900.9
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -54,7 +54,7 @@ Models:
   - Name: deeplabv3_r101-d8_769x769_40k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 0.83
+      inference time (ms/im): 1204.82
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -68,7 +68,7 @@ Models:
   - Name: deeplabv3_r18-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 13.78
+      inference time (ms/im): 72.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -82,7 +82,7 @@ Models:
   - Name: deeplabv3_r50-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 2.57
+      inference time (ms/im): 389.11
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -96,7 +96,7 @@ Models:
   - Name: deeplabv3_r101-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 1.92
+      inference time (ms/im): 520.83
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -110,7 +110,7 @@ Models:
   - Name: deeplabv3_r18-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 5.55
+      inference time (ms/im): 180.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -124,7 +124,7 @@ Models:
   - Name: deeplabv3_r50-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 1.11
+      inference time (ms/im): 900.9
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -138,7 +138,7 @@ Models:
   - Name: deeplabv3_r101-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 0.83
+      inference time (ms/im): 1204.82
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -152,7 +152,7 @@ Models:
   - Name: deeplabv3_r101-d16-mg124_512x1024_40k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 6.96
+      inference time (ms/im): 143.68
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -166,7 +166,7 @@ Models:
   - Name: deeplabv3_r101-d16-mg124_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 6.96
+      inference time (ms/im): 143.68
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -180,7 +180,7 @@ Models:
   - Name: deeplabv3_r18b-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 13.93
+      inference time (ms/im): 71.79
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -194,7 +194,7 @@ Models:
   - Name: deeplabv3_r50b-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 2.74
+      inference time (ms/im): 364.96
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -208,7 +208,7 @@ Models:
   - Name: deeplabv3_r101b-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 1.81
+      inference time (ms/im): 552.49
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -222,7 +222,7 @@ Models:
   - Name: deeplabv3_r18b-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 5.79
+      inference time (ms/im): 172.71
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -236,7 +236,7 @@ Models:
   - Name: deeplabv3_r50b-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 1.16
+      inference time (ms/im): 862.07
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -250,7 +250,7 @@ Models:
   - Name: deeplabv3_r101b-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 0.82
+      inference time (ms/im): 1219.51
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -264,7 +264,7 @@ Models:
   - Name: deeplabv3_r50-d8_512x512_80k_ade20k
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 14.76
+      inference time (ms/im): 67.75
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -278,7 +278,7 @@ Models:
   - Name: deeplabv3_r101-d8_512x512_80k_ade20k
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 10.14
+      inference time (ms/im): 98.62
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -292,7 +292,7 @@ Models:
   - Name: deeplabv3_r50-d8_512x512_160k_ade20k
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 14.76
+      inference time (ms/im): 67.75
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -306,7 +306,7 @@ Models:
   - Name: deeplabv3_r101-d8_512x512_160k_ade20k
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 10.14
+      inference time (ms/im): 98.62
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -320,7 +320,7 @@ Models:
   - Name: deeplabv3_r50-d8_512x512_20k_voc12aug
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 13.88
+      inference time (ms/im): 72.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -334,7 +334,7 @@ Models:
   - Name: deeplabv3_r101-d8_512x512_20k_voc12aug
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 9.81
+      inference time (ms/im): 101.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -348,7 +348,7 @@ Models:
   - Name: deeplabv3_r50-d8_512x512_40k_voc12aug
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 13.88
+      inference time (ms/im): 72.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -362,7 +362,7 @@ Models:
   - Name: deeplabv3_r101-d8_512x512_40k_voc12aug
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 9.81
+      inference time (ms/im): 101.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -376,7 +376,7 @@ Models:
   - Name: deeplabv3_r101-d8_480x480_40k_pascal_context
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 7.09
+      inference time (ms/im): 141.04
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -390,7 +390,7 @@ Models:
   - Name: deeplabv3_r101-d8_480x480_80k_pascal_context
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 7.09
+      inference time (ms/im): 141.04
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -404,7 +404,7 @@ Models:
   - Name: deeplabv3_r101-d8_480x480_40k_pascal_context
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -418,7 +418,7 @@ Models:
   - Name: deeplabv3_r101-d8_480x480_80k_pascal_context_59
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context

--- a/configs/deeplabv3plus/metafile.yml
+++ b/configs/deeplabv3plus/metafile.yml
@@ -12,7 +12,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_512x1024_40k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 3.94
+      inference time (ms/im): 253.81
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -26,7 +26,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_512x1024_40k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 2.60
+      inference time (ms/im): 384.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -40,7 +40,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_769x769_40k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 1.72
+      inference time (ms/im): 581.4
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -54,7 +54,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_769x769_40k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 1.15
+      inference time (ms/im): 869.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -68,7 +68,7 @@ Models:
   - Name: deeplabv3plus_r18-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 14.27
+      inference time (ms/im): 70.08
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -82,7 +82,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 3.94
+      inference time (ms/im): 253.81
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -96,7 +96,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 2.60
+      inference time (ms/im): 384.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -110,7 +110,7 @@ Models:
   - Name: deeplabv3plus_r18-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 5.74
+      inference time (ms/im): 174.22
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -124,7 +124,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 1.72
+      inference time (ms/im): 581.4
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -138,7 +138,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 1.15
+      inference time (ms/im): 869.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -152,7 +152,7 @@ Models:
   - Name: deeplabv3plus_r101-d16-mg124_512x1024_40k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 7.48
+      inference time (ms/im): 133.69
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -166,7 +166,7 @@ Models:
   - Name: deeplabv3plus_r101-d16-mg124_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 7.48
+      inference time (ms/im): 133.69
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -180,7 +180,7 @@ Models:
   - Name: deeplabv3plus_r18b-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 14.95
+      inference time (ms/im): 66.89
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -194,7 +194,7 @@ Models:
   - Name: deeplabv3plus_r50b-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 3.94
+      inference time (ms/im): 253.81
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -208,7 +208,7 @@ Models:
   - Name: deeplabv3plus_r101b-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 2.60
+      inference time (ms/im): 384.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -222,7 +222,7 @@ Models:
   - Name: deeplabv3plus_r18b-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 5.96
+      inference time (ms/im): 167.79
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -236,7 +236,7 @@ Models:
   - Name: deeplabv3plus_r50b-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 1.72
+      inference time (ms/im): 581.4
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -250,7 +250,7 @@ Models:
   - Name: deeplabv3plus_r101b-d8_769x769_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 1.10
+      inference time (ms/im): 909.09
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -264,7 +264,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_512x512_80k_ade20k
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 21.01
+      inference time (ms/im): 47.6
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -278,7 +278,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_512x512_80k_ade20k
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 14.16
+      inference time (ms/im): 70.62
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -292,7 +292,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_512x512_160k_ade20k
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 21.01
+      inference time (ms/im): 47.6
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -306,7 +306,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_512x512_160k_ade20k
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 14.16
+      inference time (ms/im): 70.62
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -320,7 +320,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_512x512_20k_voc12aug
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 21
+      inference time (ms/im): 47.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -334,7 +334,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_512x512_20k_voc12aug
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 13.88
+      inference time (ms/im): 72.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -348,7 +348,7 @@ Models:
   - Name: deeplabv3plus_r50-d8_512x512_40k_voc12aug
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 21
+      inference time (ms/im): 47.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -362,7 +362,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_512x512_40k_voc12aug
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 13.88
+      inference time (ms/im): 72.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -376,7 +376,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_480x480_40k_pascal_context
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 9.09
+      inference time (ms/im): 110.01
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -390,7 +390,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_480x480_80k_pascal_context
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 9.09
+      inference time (ms/im): 110.01
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -404,7 +404,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_480x480_40k_pascal_context
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -418,7 +418,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_480x480_80k_pascal_context
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context

--- a/configs/dmnet/metafile.yml
+++ b/configs/dmnet/metafile.yml
@@ -10,7 +10,7 @@ Models:
   - Name: dmnet_r50-d8_512x1024_40k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 3.66
+      inference time (ms/im): 273.22
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -24,7 +24,7 @@ Models:
   - Name: dmnet_r101-d8_512x1024_40k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 2.54
+      inference time (ms/im): 393.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -38,7 +38,7 @@ Models:
   - Name: dmnet_r50-d8_769x769_40k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 1.57
+      inference time (ms/im): 636.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -52,7 +52,7 @@ Models:
   - Name: dmnet_r101-d8_769x769_40k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 1.01
+      inference time (ms/im): 990.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -66,7 +66,7 @@ Models:
   - Name: dmnet_r50-d8_512x1024_80k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 3.66
+      inference time (ms/im): 273.22
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -80,7 +80,7 @@ Models:
   - Name: dmnet_r101-d8_512x1024_80k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 2.54
+      inference time (ms/im): 393.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
   - Name: dmnet_r50-d8_769x769_80k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 1.57
+      inference time (ms/im): 636.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -108,7 +108,7 @@ Models:
   - Name: dmnet_r101-d8_769x769_80k_cityscapes
     In Collection: DMNet
     Metadata:
-      inference time (fps): 1.01
+      inference time (ms/im): 990.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -122,7 +122,7 @@ Models:
   - Name: dmnet_r50-d8_512x512_80k_ade20k
     In Collection: DMNet
     Metadata:
-      inference time (fps): 20.95
+      inference time (ms/im): 47.73
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -136,7 +136,7 @@ Models:
   - Name: dmnet_r101-d8_512x512_80k_ade20k
     In Collection: DMNet
     Metadata:
-      inference time (fps): 13.88
+      inference time (ms/im): 72.05
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -150,7 +150,7 @@ Models:
   - Name: dmnet_r50-d8_512x512_160k_ade20k
     In Collection: DMNet
     Metadata:
-      inference time (fps): 20.95
+      inference time (ms/im): 47.73
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -164,7 +164,7 @@ Models:
   - Name: dmnet_r101-d8_512x512_160k_ade20k
     In Collection: DMNet
     Metadata:
-      inference time (fps): 13.88
+      inference time (ms/im): 72.05
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/dnlnet/metafile.yml
+++ b/configs/dnlnet/metafile.yml
@@ -10,7 +10,7 @@ Models:
   - Name: dnl_r50-d8_512x1024_40k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 2.56
+      inference time (ms/im): 390.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -24,7 +24,7 @@ Models:
   - Name: dnl_r101-d8_512x1024_40k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 1.96
+      inference time (ms/im): 510.2
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -38,7 +38,7 @@ Models:
   - Name: dnl_r50-d8_769x769_40k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 1.50
+      inference time (ms/im): 666.67
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -52,7 +52,7 @@ Models:
   - Name: dnl_r101-d8_769x769_40k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 1.02
+      inference time (ms/im): 980.39
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -66,7 +66,7 @@ Models:
   - Name: dnl_r50-d8_512x1024_80k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 2.56
+      inference time (ms/im): 390.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -80,7 +80,7 @@ Models:
   - Name: dnl_r101-d8_512x1024_80k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 1.96
+      inference time (ms/im): 510.2
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
   - Name: dnl_r50-d8_769x769_80k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 1.50
+      inference time (ms/im): 666.67
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -108,7 +108,7 @@ Models:
   - Name: dnl_r101-d8_769x769_80k_cityscapes
     In Collection: dnl
     Metadata:
-      inference time (fps): 1.02
+      inference time (ms/im): 980.39
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -122,7 +122,7 @@ Models:
   - Name: dnl_r50-d8_512x512_80k_ade20k
     In Collection: dnl
     Metadata:
-      inference time (fps): 20.66
+      inference time (ms/im): 48.4
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -136,7 +136,7 @@ Models:
   - Name: dnl_r101-d8_512x512_80k_ade20k
     In Collection: dnl
     Metadata:
-      inference time (fps): 12.54
+      inference time (ms/im): 79.74
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -150,7 +150,7 @@ Models:
   - Name: dnl_r50-d8_512x512_160k_ade20k
     In Collection: dnl
     Metadata:
-      inference time (fps): 20.66
+      inference time (ms/im): 48.4
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -164,7 +164,7 @@ Models:
   - Name: dnl_r101-d8_512x512_160k_ade20k
     In Collection: dnl
     Metadata:
-      inference time (fps): 12.54
+      inference time (ms/im): 79.74
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/emanet/metafile.yml
+++ b/configs/emanet/metafile.yml
@@ -9,7 +9,7 @@ Models:
   - Name: emanet_r50-d8_512x1024_80k_cityscapes
     In Collection: EMANet
     Metadata:
-      inference time (fps): 4.58
+      inference time (ms/im): 218.34
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -23,7 +23,7 @@ Models:
   - Name: emanet_r101-d8_512x1024_80k_cityscapes
     In Collection: EMANet
     Metadata:
-      inference time (fps): 2.87
+      inference time (ms/im): 348.43
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -37,7 +37,7 @@ Models:
   - Name: emanet_r50-d8_769x769_80k_cityscapes
     In Collection: EMANet
     Metadata:
-      inference time (fps): 1.97
+      inference time (ms/im): 507.61
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -51,7 +51,7 @@ Models:
   - Name: emanet_r101-d8_769x769_80k_cityscapes
     In Collection: EMANet
     Metadata:
-      inference time (fps): 1.22
+      inference time (ms/im): 819.67
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes

--- a/configs/encnet/metafile.yml
+++ b/configs/encnet/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: encnet_r50-d8_512x1024_40k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 4.58
+      inference time (ms/im): 218.34
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: encnet_r101-d8_512x1024_40k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 2.66
+      inference time (ms/im): 375.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: encnet_r50-d8_769x769_40k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 1.82
+      inference time (ms/im): 549.45
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: encnet_r101-d8_769x769_40k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 1.26
+      inference time (ms/im): 793.65
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: encnet_r50-d8_512x1024_80k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 4.58
+      inference time (ms/im): 218.34
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: encnet_r101-d8_512x1024_80k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 2.66
+      inference time (ms/im): 375.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: encnet_r50-d8_769x769_80k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 1.82
+      inference time (ms/im): 549.45
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: encnet_r101-d8_769x769_80k_cityscapes
     In Collection: encnet
     Metadata:
-      inference time (fps): 1.26
+      inference time (ms/im): 793.65
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: encnet_r50-d8_512x512_80k_ade20k
     In Collection: encnet
     Metadata:
-      inference time (fps): 22.81
+      inference time (ms/im): 43.84
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: encnet_r101-d8_512x512_80k_ade20k
     In Collection: encnet
     Metadata:
-      inference time (fps): 14.87
+      inference time (ms/im): 67.25
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: encnet_r50-d8_512x512_160k_ade20k
     In Collection: encnet
     Metadata:
-      inference time (fps): 22.81
+      inference time (ms/im): 43.84
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: encnet_r101-d8_512x512_160k_ade20k
     In Collection: encnet
     Metadata:
-      inference time (fps): 14.87
+      inference time (ms/im): 67.25
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/fastscnn/metafile.yml
+++ b/configs/fastscnn/metafile.yml
@@ -9,7 +9,7 @@ Models:
   - Name: fast_scnn_4x8_80k_lr0.12_cityscapes
     In Collection: Fast-SCNN
     Metadata:
-      inference time (fps): 63.61
+      inference time (ms/im): 15.72
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes

--- a/configs/fcn/metafile.yml
+++ b/configs/fcn/metafile.yml
@@ -19,7 +19,7 @@ Models:
   - Name: fcn_r50-d8_512x1024_40k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 4.17
+      inference time (ms/im): 239.81
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -33,7 +33,7 @@ Models:
   - Name: fcn_r101-d8_512x1024_40k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 2.66
+      inference time (ms/im): 375.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -47,7 +47,7 @@ Models:
   - Name: fcn_r50-d8_769x769_40k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 1.80
+      inference time (ms/im): 555.56
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -61,7 +61,7 @@ Models:
   - Name: fcn_r101-d8_769x769_40k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 1.19
+      inference time (ms/im): 840.34
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -75,7 +75,7 @@ Models:
   - Name: fcn_r18-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 14.65
+      inference time (ms/im): 68.26
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -89,7 +89,7 @@ Models:
   - Name: fcn_r50-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 4.17
+      inference time (ms/im): 239.81
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -103,7 +103,7 @@ Models:
   - Name: fcn_r101-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 2.66
+      inference time (ms/im): 375.94
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -117,7 +117,7 @@ Models:
   - Name: fcn_r18-d8_769x769_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 6.40
+      inference time (ms/im): 156.25
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -131,7 +131,7 @@ Models:
   - Name: fcn_r50-d8_769x769_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 1.80
+      inference time (ms/im): 555.56
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -145,7 +145,7 @@ Models:
   - Name: fcn_r101-d8_769x769_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 1.19
+      inference time (ms/im): 840.34
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -159,7 +159,7 @@ Models:
   - Name: fcn_r18b-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 16.74
+      inference time (ms/im): 59.74
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -173,7 +173,7 @@ Models:
   - Name: fcn_r50b-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 4.20
+      inference time (ms/im): 238.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -187,7 +187,7 @@ Models:
   - Name: fcn_r101b-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 2.73
+      inference time (ms/im): 366.3
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -201,7 +201,7 @@ Models:
   - Name: fcn_r18b-d8_769x769_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 6.70
+      inference time (ms/im): 149.25
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -215,7 +215,7 @@ Models:
   - Name: fcn_r50b-d8_769x769_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 1.82
+      inference time (ms/im): 549.45
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -229,7 +229,7 @@ Models:
   - Name: fcn_r101b-d8_769x769_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 1.15
+      inference time (ms/im): 869.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -243,7 +243,7 @@ Models:
   - Name: fcn_d6_r50-d16_512x1024_40k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 10.22
+      inference time (ms/im): 97.85
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -257,7 +257,7 @@ Models:
   - Name: fcn_d6_r50-d16_512x1024_80k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 10.35
+      inference time (ms/im): 96.62
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -271,7 +271,7 @@ Models:
   - Name: fcn_d6_r50-d16_769x769_40k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 4.17
+      inference time (ms/im): 239.81
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -285,7 +285,7 @@ Models:
   - Name: fcn_d6_r50-d16_769x769_80k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 4.15
+      inference time (ms/im): 240.96
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -299,7 +299,7 @@ Models:
   - Name: fcn_d6_r101-d16_512x1024_40k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 8.04
+      inference time (ms/im): 124.38
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -313,7 +313,7 @@ Models:
   - Name: fcn_d6_r101-d16_512x1024_80k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 8.26
+      inference time (ms/im): 121.07
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -327,7 +327,7 @@ Models:
   - Name: fcn_d6_r101-d16_769x769_40k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 3.12
+      inference time (ms/im): 320.51
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -341,7 +341,7 @@ Models:
   - Name: fcn_d6_r101-d16_769x769_80k_cityscapes
     In Collection: FCN-D6
     Metadata:
-      inference time (fps): 3.21
+      inference time (ms/im): 311.53
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -355,7 +355,7 @@ Models:
   - Name: fcn_r50-d8_512x512_80k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.49
+      inference time (ms/im): 42.57
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -369,7 +369,7 @@ Models:
   - Name: fcn_r101-d8_512x512_80k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 14.78
+      inference time (ms/im): 67.66
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -383,7 +383,7 @@ Models:
   - Name: fcn_r50-d8_512x512_160k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.49
+      inference time (ms/im): 42.57
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -397,7 +397,7 @@ Models:
   - Name: fcn_r101-d8_512x512_160k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 14.78
+      inference time (ms/im): 67.66
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -411,7 +411,7 @@ Models:
   - Name: fcn_r50-d8_512x512_20k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.28
+      inference time (ms/im): 42.96
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -425,7 +425,7 @@ Models:
   - Name: fcn_r101-d8_512x512_20k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 14.81
+      inference time (ms/im): 67.52
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -439,7 +439,7 @@ Models:
   - Name: fcn_r50-d8_512x512_40k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.28
+      inference time (ms/im): 42.96
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -453,7 +453,7 @@ Models:
   - Name: fcn_r101-d8_512x512_40k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 14.81
+      inference time (ms/im): 67.52
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -467,7 +467,7 @@ Models:
   - Name: fcn_r101-d8_480x480_40k_pascal_context
     In Collection: FCN
     Metadata:
-      inference time (fps): 9.93
+      inference time (ms/im): 100.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -481,7 +481,7 @@ Models:
   - Name: fcn_r101-d8_480x480_80k_pascal_context
     In Collection: FCN
     Metadata:
-      inference time (fps): 9.93
+      inference time (ms/im): 100.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -495,7 +495,7 @@ Models:
   - Name: fcn_r101-d8_480x480_40k_pascal_context_59
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -509,7 +509,7 @@ Models:
   - Name: fcn_r101-d8_480x480_80k_pascal_context_59
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context

--- a/configs/fp16/metafile.yml
+++ b/configs/fp16/metafile.yml
@@ -4,7 +4,7 @@ Models:
   - Name: fcn_r101-d8_512x1024_80k_fp16_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 8.64
+      inference time (ms/im): 115.74
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -18,7 +18,7 @@ Models:
   - Name: pspnet_r101-d8_512x1024_80k_fp16_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 8.77
+      inference time (ms/im): 114.03
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -32,7 +32,7 @@ Models:
   - Name: deeplabv3_r101-d8_512x1024_80k_fp16_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 3.86
+      inference time (ms/im): 259.07
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -46,7 +46,7 @@ Models:
   - Name: deeplabv3plus_r101-d8_512x1024_80k_fp16_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 7.87
+      inference time (ms/im): 127.06
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes

--- a/configs/gcnet/metafile.yml
+++ b/configs/gcnet/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: gcnet_r50-d8_512x1024_40k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 3.93
+      inference time (ms/im): 254.45
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: gcnet_r101-d8_512x1024_40k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 2.61
+      inference time (ms/im): 383.14
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: gcnet_r50-d8_769x769_40k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 1.67
+      inference time (ms/im): 598.8
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: gcnet_r101-d8_769x769_40k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 1.13
+      inference time (ms/im): 884.96
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: gcnet_r50-d8_512x1024_80k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 3.93
+      inference time (ms/im): 254.45
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: gcnet_r101-d8_512x1024_80k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 2.61
+      inference time (ms/im): 383.14
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: gcnet_r50-d8_769x769_80k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 1.67
+      inference time (ms/im): 598.8
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: gcnet_r101-d8_769x769_80k_cityscapes
     In Collection: GCNet
     Metadata:
-      inference time (fps): 1.13
+      inference time (ms/im): 884.96
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: gcnet_r50-d8_512x512_80k_ade20k
     In Collection: GCNet
     Metadata:
-      inference time (fps): 23.38
+      inference time (ms/im): 42.77
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: gcnet_r101-d8_512x512_80k_ade20k
     In Collection: GCNet
     Metadata:
-      inference time (fps): 15.20
+      inference time (ms/im): 65.79
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: gcnet_r50-d8_512x512_160k_ade20k
     In Collection: GCNet
     Metadata:
-      inference time (fps): 23.38
+      inference time (ms/im): 42.77
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: gcnet_r101-d8_512x512_160k_ade20k
     In Collection: GCNet
     Metadata:
-      inference time (fps): 15.20
+      inference time (ms/im): 65.79
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -179,7 +179,7 @@ Models:
   - Name: gcnet_r50-d8_512x512_20k_voc12aug
     In Collection: GCNet
     Metadata:
-      inference time (fps): 23.35
+      inference time (ms/im): 42.83
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -193,7 +193,7 @@ Models:
   - Name: gcnet_r101-d8_512x512_20k_voc12aug
     In Collection: GCNet
     Metadata:
-      inference time (fps): 14.80
+      inference time (ms/im): 67.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -207,7 +207,7 @@ Models:
   - Name: gcnet_r50-d8_512x512_40k_voc12aug
     In Collection: GCNet
     Metadata:
-      inference time (fps): 23.35
+      inference time (ms/im): 42.83
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -221,7 +221,7 @@ Models:
   - Name: gcnet_r101-d8_512x512_40k_voc12aug
     In Collection: GCNet
     Metadata:
-      inference time (fps): 14.80
+      inference time (ms/im): 67.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug

--- a/configs/hrnet/metafile.yml
+++ b/configs/hrnet/metafile.yml
@@ -2,7 +2,7 @@ Models:
   - Name: fcn_hr18s_512x1024_40k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.74
+      inference time (ms/im): 42.12
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -16,7 +16,7 @@ Models:
   - Name: fcn_hr18_512x1024_40k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 12.97
+      inference time (ms/im): 77.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -30,7 +30,7 @@ Models:
   - Name: fcn_hr48_512x1024_40k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 6.42
+      inference time (ms/im): 155.76
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -44,7 +44,7 @@ Models:
   - Name: fcn_hr18s_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.74
+      inference time (ms/im): 42.12
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -58,7 +58,7 @@ Models:
   - Name: fcn_hr18_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 12.97
+      inference time (ms/im): 77.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
   - Name: fcn_hr48_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 6.42
+      inference time (ms/im): 155.76
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -86,7 +86,7 @@ Models:
   - Name: fcn_hr18s_512x1024_160k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.74
+      inference time (ms/im): 42.12
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -100,7 +100,7 @@ Models:
   - Name: fcn_hr18_512x1024_160k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 12.97
+      inference time (ms/im): 77.1
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -114,7 +114,7 @@ Models:
   - Name: fcn_hr48_512x1024_160k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 6.42
+      inference time (ms/im): 155.76
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -128,7 +128,7 @@ Models:
   - Name: fcn_hr18s_512x512_80k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 38.66
+      inference time (ms/im): 25.87
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -142,7 +142,7 @@ Models:
   - Name: fcn_hr18_512x512_80k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 22.57
+      inference time (ms/im): 44.31
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -156,7 +156,7 @@ Models:
   - Name: fcn_hr48_512x512_80k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 21.23
+      inference time (ms/im): 47.1
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -170,7 +170,7 @@ Models:
   - Name: fcn_hr18s_512x512_160k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 38.66
+      inference time (ms/im): 25.87
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -184,7 +184,7 @@ Models:
   - Name: fcn_hr18_512x512_160k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 22.57
+      inference time (ms/im): 44.31
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -198,7 +198,7 @@ Models:
   - Name: fcn_hr48_512x512_160k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 21.23
+      inference time (ms/im): 47.1
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -212,7 +212,7 @@ Models:
   - Name: fcn_hr18s_512x512_20k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 43.36
+      inference time (ms/im): 23.06
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -226,7 +226,7 @@ Models:
   - Name: fcn_hr18_512x512_20k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.48
+      inference time (ms/im): 42.59
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -240,7 +240,7 @@ Models:
   - Name: fcn_hr48_512x512_20k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 22.05
+      inference time (ms/im): 45.35
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -254,7 +254,7 @@ Models:
   - Name: fcn_hr18s_512x512_40k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 43.36
+      inference time (ms/im): 23.06
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -268,7 +268,7 @@ Models:
   - Name: fcn_hr18_512x512_40k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 23.48
+      inference time (ms/im): 42.59
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -282,7 +282,7 @@ Models:
   - Name: fcn_hr48_512x512_40k_voc12aug
     In Collection: FCN
     Metadata:
-      inference time (fps): 22.05
+      inference time (ms/im): 45.35
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -296,7 +296,7 @@ Models:
   - Name: fcn_hr48_480x480_40k_pascal_context
     In Collection: FCN
     Metadata:
-      inference time (fps): 8.86
+      inference time (ms/im): 112.87
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -310,7 +310,7 @@ Models:
   - Name: fcn_hr48_480x480_80k_pascal_context
     In Collection: FCN
     Metadata:
-      inference time (fps): 8.86
+      inference time (ms/im): 112.87
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -324,7 +324,7 @@ Models:
   - Name: fcn_hr48_480x480_40k_pascal_context_59
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -338,7 +338,7 @@ Models:
   - Name: fcn_hr48_480x480_80k_pascal_context
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context

--- a/configs/mobilenet_v2/metafile.yml
+++ b/configs/mobilenet_v2/metafile.yml
@@ -4,7 +4,7 @@ Models:
   - Name: fcn_m-v2-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 14.2
+      inference time (ms/im): 70.42
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -18,7 +18,7 @@ Models:
   - Name: pspnet_m-v2-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 11.2
+      inference time (ms/im): 89.29
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -32,7 +32,7 @@ Models:
   - Name: deeplabv3_m-v2-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 8.4
+      inference time (ms/im): 119.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -46,7 +46,7 @@ Models:
   - Name: deeplabv3plus_m-v2-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 8.4
+      inference time (ms/im): 119.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -60,7 +60,7 @@ Models:
   - Name: fcn_m-v2-d8_512x512_160k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 64.4
+      inference time (ms/im): 15.53
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -74,7 +74,7 @@ Models:
   - Name: pspnet_m-v2-d8_512x512_160k_ade20k
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 57.7
+      inference time (ms/im): 17.33
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -88,7 +88,7 @@ Models:
   - Name: deeplabv3_m-v2-d8_512x512_160k_ade20k
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 39.9
+      inference time (ms/im): 25.06
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -102,7 +102,7 @@ Models:
   - Name: deeplabv3plus_m-v2-d8_512x512_160k_ade20k
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 43.1
+      inference time (ms/im): 23.2
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/mobilenet_v3/metafile.yml
+++ b/configs/mobilenet_v3/metafile.yml
@@ -9,7 +9,7 @@ Models:
   - Name: lraspp_m-v3-d8_512x1024_320k_cityscapes
     In Collection: LRASPP
     Metadata:
-      inference time (fps): 15.22
+      inference time (ms/im): 65.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -23,7 +23,7 @@ Models:
   - Name: lraspp_m-v3-d8_scratch_512x1024_320k_cityscapes
     In Collection: LRASPP
     Metadata:
-      inference time (fps): 14.77
+      inference time (ms/im): 67.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -37,7 +37,7 @@ Models:
   - Name: lraspp_m-v3s-d8_512x1024_320k_cityscapes
     In Collection: LRASPP
     Metadata:
-      inference time (fps): 23.64
+      inference time (ms/im): 42.3
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -51,7 +51,7 @@ Models:
   - Name: lraspp_m-v3s-d8_scratch_512x1024_320k_cityscapes
     In Collection: LRASPP
     Metadata:
-      inference time (fps): 24.50
+      inference time (ms/im): 40.82
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes

--- a/configs/nonlocal_net/metafile.yml
+++ b/configs/nonlocal_net/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: nonlocal_r50-d8_512x1024_40k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 2.72
+      inference time (ms/im): 367.65
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: nonlocal_r101-d8_512x1024_40k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 1.95
+      inference time (ms/im): 512.82
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: nonlocal_r50-d8_769x769_40k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 1.52
+      inference time (ms/im): 657.89
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: nonlocal_r101-d8_769x769_40k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 1.05
+      inference time (ms/im): 952.38
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: nonlocal_r50-d8_512x1024_80k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 2.72
+      inference time (ms/im): 367.65
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: nonlocal_r101-d8_512x1024_80k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 1.95
+      inference time (ms/im): 512.82
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: nonlocal_r50-d8_769x769_80k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 1.52
+      inference time (ms/im): 657.89
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: nonlocal_r101-d8_769x769_80k_cityscapes
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 1.05
+      inference time (ms/im): 952.38
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: nonlocal_r50-d8_512x512_80k_ade20k
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 21.37
+      inference time (ms/im): 46.79
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: nonlocal_r101-d8_512x512_80k_ade20k
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 13.97
+      inference time (ms/im): 71.58
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: nonlocal_r50-d8_512x512_160k_ade20k
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 21.37
+      inference time (ms/im): 46.79
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: nonlocal_r101-d8_512x512_160k_ade20k
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 13.97
+      inference time (ms/im): 71.58
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -179,7 +179,7 @@ Models:
   - Name: nonlocal_r50-d8_512x512_20k_voc12aug
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 21.21
+      inference time (ms/im): 47.15
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -193,7 +193,7 @@ Models:
   - Name: nonlocal_r101-d8_512x512_20k_voc12aug
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 14.01
+      inference time (ms/im): 71.38
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -207,7 +207,7 @@ Models:
   - Name: nonlocal_r50-d8_512x512_40k_voc12aug
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 21.21
+      inference time (ms/im): 47.15
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -221,7 +221,7 @@ Models:
   - Name: nonlocal_r101-d8_512x512_40k_voc12aug
     In Collection: NonLocal
     Metadata:
-      inference time (fps): 14.01
+      inference time (ms/im): 71.38
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug

--- a/configs/ocrnet/metafile.yml
+++ b/configs/ocrnet/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: ocrnet_hr18s_512x1024_40k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 10.45
+      inference time (ms/im): 95.69
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: ocrnet_hr18_512x1024_40k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 7.50
+      inference time (ms/im): 133.33
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: ocrnet_hr48_512x1024_40k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 4.22
+      inference time (ms/im): 236.97
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: ocrnet_hr18s_512x1024_80k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 10.45
+      inference time (ms/im): 95.69
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: ocrnet_hr18_512x1024_80k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 7.50
+      inference time (ms/im): 133.33
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: ocrnet_hr48_512x1024_80k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 4.22
+      inference time (ms/im): 236.97
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: ocrnet_hr18s_512x1024_160k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 10.45
+      inference time (ms/im): 95.69
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: ocrnet_hr18_512x1024_160k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 7.50
+      inference time (ms/im): 133.33
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: ocrnet_hr48_512x1024_160k_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 4.22
+      inference time (ms/im): 236.97
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -137,7 +137,7 @@ Models:
   - Name: ocrnet_r101-d8_512x1024_40k_b8_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -151,7 +151,7 @@ Models:
   - Name: ocrnet_r101-d8_512x1024_40k_b16_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 8.8
+      inference time (ms/im): 113.64
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -165,7 +165,7 @@ Models:
   - Name: ocrnet_r101-d8_512x1024_80k_b16_cityscapes
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 8.8
+      inference time (ms/im): 113.64
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -179,7 +179,7 @@ Models:
   - Name: ocrnet_hr18s_512x512_80k_ade20k
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 28.98
+      inference time (ms/im): 34.51
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -193,7 +193,7 @@ Models:
   - Name: ocrnet_hr18_512x512_80k_ade20k
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 18.93
+      inference time (ms/im): 52.83
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -207,7 +207,7 @@ Models:
   - Name: ocrnet_hr48_512x512_80k_ade20k
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 16.99
+      inference time (ms/im): 58.86
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -221,7 +221,7 @@ Models:
   - Name: ocrnet_hr18s_512x512_160k_ade20k
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 28.98
+      inference time (ms/im): 34.51
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -235,7 +235,7 @@ Models:
   - Name: ocrnet_hr18_512x512_160k_ade20k
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 18.93
+      inference time (ms/im): 52.83
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -249,7 +249,7 @@ Models:
   - Name: ocrnet_hr48_512x512_160k_ade20k
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 16.99
+      inference time (ms/im): 58.86
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -263,7 +263,7 @@ Models:
   - Name: ocrnet_hr18s_512x512_20k_voc12aug
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 31.55
+      inference time (ms/im): 31.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -277,7 +277,7 @@ Models:
   - Name: ocrnet_hr18_512x512_20k_voc12aug
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 19.91
+      inference time (ms/im): 50.23
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -291,7 +291,7 @@ Models:
   - Name: ocrnet_hr48_512x512_20k_voc12aug
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 17.83
+      inference time (ms/im): 56.09
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -305,7 +305,7 @@ Models:
   - Name: ocrnet_hr18s_512x512_40k_voc12aug
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 31.55
+      inference time (ms/im): 31.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -319,7 +319,7 @@ Models:
   - Name: ocrnet_hr18_512x512_40k_voc12aug
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 19.91
+      inference time (ms/im): 50.23
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -333,7 +333,7 @@ Models:
   - Name: ocrnet_hr48_512x512_40k_voc12aug
     In Collection: OCRNet
     Metadata:
-      inference time (fps): 17.83
+      inference time (ms/im): 56.09
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug

--- a/configs/point_rend/metafile.yml
+++ b/configs/point_rend/metafile.yml
@@ -10,7 +10,7 @@ Models:
   - Name: pointrend_r50_512x1024_80k_cityscapes
     In Collection: PointRend
     Metadata:
-      inference time (fps): 8.48
+      inference time (ms/im): 117.92
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -24,7 +24,7 @@ Models:
   - Name: pointrend_r101_512x1024_80k_cityscapes
     In Collection: PointRend
     Metadata:
-      inference time (fps): 7.00
+      inference time (ms/im): 142.86
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -38,7 +38,7 @@ Models:
   - Name: pointrend_r50_512x512_160k_ade20k
     In Collection: PointRend
     Metadata:
-      inference time (fps): 17.31
+      inference time (ms/im): 57.77
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -52,7 +52,7 @@ Models:
   - Name: pointrend_r101_512x512_160k_ade20k
     In Collection: PointRend
     Metadata:
-      inference time (fps): 15.50
+      inference time (ms/im): 64.52
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/psanet/metafile.yml
+++ b/configs/psanet/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: psanet_r50-d8_512x1024_40k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 3.17
+      inference time (ms/im): 315.46
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: psanet_r101-d8_512x1024_40k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 2.20
+      inference time (ms/im): 454.55
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: psanet_r50-d8_769x769_40k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 1.40
+      inference time (ms/im): 714.29
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: psanet_r101-d8_769x769_40k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 0.98
+      inference time (ms/im): 1020.41
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: psanet_r50-d8_512x1024_80k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 3.17
+      inference time (ms/im): 315.46
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: psanet_r101-d8_512x1024_80k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 2.20
+      inference time (ms/im): 454.55
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: psanet_r50-d8_769x769_80k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 1.40
+      inference time (ms/im): 714.29
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: psanet_r101-d8_769x769_80k_cityscapes
     In Collection: PSANet
     Metadata:
-      inference time (fps): 0.98
+      inference time (ms/im): 1020.41
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: psanet_r50-d8_512x512_80k_ade20k
     In Collection: PSANet
     Metadata:
-      inference time (fps): 18.91
+      inference time (ms/im): 52.88
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: psanet_r101-d8_512x512_80k_ade20k
     In Collection: PSANet
     Metadata:
-      inference time (fps): 13.13
+      inference time (ms/im): 76.16
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: psanet_r50-d8_512x512_160k_ade20k
     In Collection: PSANet
     Metadata:
-      inference time (fps): 18.91
+      inference time (ms/im): 52.88
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: psanet_r101-d8_512x512_160k_ade20k
     In Collection: PSANet
     Metadata:
-      inference time (fps): 13.13
+      inference time (ms/im): 76.16
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -179,7 +179,7 @@ Models:
   - Name: psanet_r50-d8_512x512_20k_voc12aug
     In Collection: PSANet
     Metadata:
-      inference time (fps): 18.24
+      inference time (ms/im): 54.82
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -193,7 +193,7 @@ Models:
   - Name: psanet_r101-d8_512x512_20k_voc12aug
     In Collection: PSANet
     Metadata:
-      inference time (fps): 12.63
+      inference time (ms/im): 79.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -207,7 +207,7 @@ Models:
   - Name: psanet_r50-d8_512x512_40k_voc12aug
     In Collection: PSANet
     Metadata:
-      inference time (fps): 18.24
+      inference time (ms/im): 54.82
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -221,7 +221,7 @@ Models:
   - Name: psanet_r101-d8_512x512_40k_voc12aug
     In Collection: PSANet
     Metadata:
-      inference time (fps): 12.63
+      inference time (ms/im): 79.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug

--- a/configs/pspnet/metafile.yml
+++ b/configs/pspnet/metafile.yml
@@ -12,7 +12,7 @@ Models:
   - Name: pspnet_r50-d8_512x1024_40k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 4.07
+      inference time (ms/im): 245.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -26,7 +26,7 @@ Models:
   - Name: pspnet_r101-d8_512x1024_40k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 2.68
+      inference time (ms/im): 373.13
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -40,7 +40,7 @@ Models:
   - Name: pspnet_r50-d8_769x769_40k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 1.76
+      inference time (ms/im): 568.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -54,7 +54,7 @@ Models:
   - Name: pspnet_r101-d8_769x769_40k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 1.15
+      inference time (ms/im): 869.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -68,7 +68,7 @@ Models:
   - Name: pspnet_r18-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 15.71
+      inference time (ms/im): 63.65
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -82,7 +82,7 @@ Models:
   - Name: pspnet_r50-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 4.07
+      inference time (ms/im): 245.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -96,7 +96,7 @@ Models:
   - Name: pspnet_r101-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 2.68
+      inference time (ms/im): 373.13
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -110,7 +110,7 @@ Models:
   - Name: pspnet_r18-d8_769x769_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 6.20
+      inference time (ms/im): 161.29
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -124,7 +124,7 @@ Models:
   - Name: pspnet_r50-d8_769x769_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 1.76
+      inference time (ms/im): 568.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -138,7 +138,7 @@ Models:
   - Name: pspnet_r101-d8_769x769_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 1.15
+      inference time (ms/im): 869.57
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -152,7 +152,7 @@ Models:
   - Name: pspnet_r18b-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 16.28
+      inference time (ms/im): 61.43
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -166,7 +166,7 @@ Models:
   - Name: pspnet_r50b-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 4.30
+      inference time (ms/im): 232.56
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -180,7 +180,7 @@ Models:
   - Name: pspnet_r101b-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 2.76
+      inference time (ms/im): 362.32
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -194,7 +194,7 @@ Models:
   - Name: pspnet_r18b-d8_769x769_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 6.41
+      inference time (ms/im): 156.01
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -208,7 +208,7 @@ Models:
   - Name: pspnet_r50b-d8_769x769_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 1.88
+      inference time (ms/im): 531.91
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -222,7 +222,7 @@ Models:
   - Name: pspnet_r101b-d8_769x769_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 1.17
+      inference time (ms/im): 854.7
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -236,7 +236,7 @@ Models:
   - Name: pspnet_r50-d8_512x512_80k_ade20k
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 23.53
+      inference time (ms/im): 42.5
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -250,7 +250,7 @@ Models:
   - Name: pspnet_r101-d8_512x512_80k_ade20k
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 15.30
+      inference time (ms/im): 65.36
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -264,7 +264,7 @@ Models:
   - Name: pspnet_r50-d8_512x512_160k_ade20k
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 23.53
+      inference time (ms/im): 42.5
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -278,7 +278,7 @@ Models:
   - Name: pspnet_r101-d8_512x512_160k_ade20k
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 15.30
+      inference time (ms/im): 65.36
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -292,7 +292,7 @@ Models:
   - Name: pspnet_r50-d8_512x512_20k_voc12aug
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 23.59
+      inference time (ms/im): 42.39
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -306,7 +306,7 @@ Models:
   - Name: pspnet_r101-d8_512x512_20k_voc12aug
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 15.02
+      inference time (ms/im): 66.58
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -320,7 +320,7 @@ Models:
   - Name: pspnet_r50-d8_512x512_40k_voc12aug
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 23.59
+      inference time (ms/im): 42.39
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -334,7 +334,7 @@ Models:
   - Name: pspnet_r101-d8_512x512_40k_voc12aug
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 15.02
+      inference time (ms/im): 66.58
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -348,7 +348,7 @@ Models:
   - Name: pspnet_r101-d8_480x480_40k_pascal_context
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 9.68
+      inference time (ms/im): 103.31
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -362,7 +362,7 @@ Models:
   - Name: pspnet_r101-d8_480x480_80k_pascal_context
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 9.68
+      inference time (ms/im): 103.31
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -376,7 +376,7 @@ Models:
   - Name: pspnet_r101-d8_480x480_40k_pascal_context
     In Collection: PSPNet
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context
@@ -390,7 +390,7 @@ Models:
   - Name: pspnet_r101-d8_480x480_80k_pascal_context_59
     In Collection: PSPNet
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal Context

--- a/configs/resnest/metafile.yml
+++ b/configs/resnest/metafile.yml
@@ -10,7 +10,7 @@ Models:
   - Name: fcn_s101-d8_512x1024_80k_cityscapes
     In Collection: FCN
     Metadata:
-      inference time (fps): 2.39
+      inference time (ms/im): 418.41
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -24,7 +24,7 @@ Models:
   - Name: pspnet_s101-d8_512x1024_80k_cityscapes
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 2.52
+      inference time (ms/im): 396.83
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -38,7 +38,7 @@ Models:
   - Name: deeplabv3_s101-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 1.88
+      inference time (ms/im): 531.91
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -52,7 +52,7 @@ Models:
   - Name: deeplabv3plus_s101-d8_512x1024_80k_cityscapes
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 2.36
+      inference time (ms/im): 423.73
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -66,7 +66,7 @@ Models:
   - Name: fcn_s101-d8_512x512_160k_ade20k
     In Collection: FCN
     Metadata:
-      inference time (fps): 12.86
+      inference time (ms/im): 77.76
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -80,7 +80,7 @@ Models:
   - Name: pspnet_s101-d8_512x512_160k_ade20k
     In Collection: PSPNet
     Metadata:
-      inference time (fps): 13.02
+      inference time (ms/im): 76.8
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -94,7 +94,7 @@ Models:
   - Name: deeplabv3_s101-d8_512x512_160k_ade20k
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): 9.28
+      inference time (ms/im): 107.76
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -108,7 +108,7 @@ Models:
   - Name: deeplabv3plus_s101-d8_512x512_160k_ade20k
     In Collection: DeepLabV3+
     Metadata:
-      inference time (fps): 11.96
+      inference time (ms/im): 83.61
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/sem_fpn/metafile.yml
+++ b/configs/sem_fpn/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: fpn_r50_512x1024_80k_cityscapes
     In Collection: FPN
     Metadata:
-      inference time (fps): 13.54
+      inference time (ms/im): 73.86
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: fpn_r101_512x1024_80k_cityscapes
     In Collection: FPN
     Metadata:
-      inference time (fps): 10.29
+      inference time (ms/im): 97.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: fpn_r50_512x512_160k_ade20k
     In Collection: FPN
     Metadata:
-      inference time (fps): 55.77
+      inference time (ms/im): 17.93
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -53,7 +53,7 @@ Models:
   - Name: fpn_r101_512x512_160k_ade20k
     In Collection: FPN
     Metadata:
-      inference time (fps): 40.58
+      inference time (ms/im): 24.64
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K

--- a/configs/unet/metafile.yml
+++ b/configs/unet/metafile.yml
@@ -3,7 +3,7 @@ Models:
   - Name: fcn_unet_s5-d16_64x64_40k_drive
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: DRIVE
@@ -17,7 +17,7 @@ Models:
   - Name: pspnet_unet_s5-d16_64x64_40k_drive
     In Collection: PSPNet
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: DRIVE
@@ -31,7 +31,7 @@ Models:
   - Name: deeplabv3_unet_s5-d16_64x64_40k_drive
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: DRIVE
@@ -45,7 +45,7 @@ Models:
   - Name: fcn_unet_s5-d16_128x128_40k_stare
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: STARE
@@ -59,7 +59,7 @@ Models:
   - Name: pspnet_unet_s5-d16_128x128_40k_stare
     In Collection: PSPNet
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: STARE
@@ -73,7 +73,7 @@ Models:
   - Name: deeplabv3_unet_s5-d16_128x128_40k_stare
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: STARE
@@ -87,7 +87,7 @@ Models:
   - Name: fcn_unet_s5-d16_128x128_40k_chase_db1
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: CHASE_DB1
@@ -101,7 +101,7 @@ Models:
   - Name: pspnet_unet_s5-d16_128x128_40k_chase_db1
     In Collection: PSPNet
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: CHASE_DB1
@@ -115,7 +115,7 @@ Models:
   - Name: deeplabv3_unet_s5-d16_128x128_40k_chase_db1
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: CHASE_DB1
@@ -129,7 +129,7 @@ Models:
   - Name: fcn_unet_s5-d16_256x256_40k_hrf
     In Collection: FCN
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: HRF
@@ -143,7 +143,7 @@ Models:
   - Name: pspnet_unet_s5-d16_256x256_40k_hrf
     In Collection: PSPNet
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: HRF
@@ -157,7 +157,7 @@ Models:
   - Name: deeplabv3_unet_s5-d16_256x256_40k_hrf
     In Collection: DeepLabV3
     Metadata:
-      inference time (fps): None
+      inference time (ms/im): None
     Results:
       - Task: Semantic Segmentation
         Dataset: HRF

--- a/configs/upernet/metafile.yml
+++ b/configs/upernet/metafile.yml
@@ -11,7 +11,7 @@ Models:
   - Name: upernet_r50_512x1024_40k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 4.25
+      inference time (ms/im): 235.29
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -25,7 +25,7 @@ Models:
   - Name: upernet_r101_512x1024_40k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 3.79
+      inference time (ms/im): 263.85
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -39,7 +39,7 @@ Models:
   - Name: upernet_r50_769x769_40k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 1.76
+      inference time (ms/im): 568.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
   - Name: upernet_r101_769x769_40k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 1.56
+      inference time (ms/im): 641.03
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -67,7 +67,7 @@ Models:
   - Name: upernet_r50_512x1024_80k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 4.25
+      inference time (ms/im): 235.29
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -81,7 +81,7 @@ Models:
   - Name: upernet_r101_512x1024_80k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 3.79
+      inference time (ms/im): 263.85
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -95,7 +95,7 @@ Models:
   - Name: upernet_r50_769x769_80k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 1.76
+      inference time (ms/im): 568.18
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -109,7 +109,7 @@ Models:
   - Name: upernet_r101_769x769_80k_cityscapes
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 1.56
+      inference time (ms/im): 641.03
     Results:
       - Task: Semantic Segmentation
         Dataset: Cityscapes
@@ -123,7 +123,7 @@ Models:
   - Name: upernet_r50_512x512_80k_ade20k
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 23.40
+      inference time (ms/im): 42.74
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -137,7 +137,7 @@ Models:
   - Name: upernet_r101_512x512_80k_ade20k
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 20.34
+      inference time (ms/im): 49.16
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -151,7 +151,7 @@ Models:
   - Name: upernet_r50_512x512_160k_ade20k
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 23.40
+      inference time (ms/im): 42.74
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -165,7 +165,7 @@ Models:
   - Name: upernet_r101_512x512_160k_ade20k
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 20.34
+      inference time (ms/im): 49.16
     Results:
       - Task: Semantic Segmentation
         Dataset: ADE20K
@@ -179,7 +179,7 @@ Models:
   - Name: upernet_r50_512x512_20k_voc12aug
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 23.17
+      inference time (ms/im): 43.16
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -193,7 +193,7 @@ Models:
   - Name: upernet_r101_512x512_20k_voc12aug
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 19.98
+      inference time (ms/im): 50.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -207,7 +207,7 @@ Models:
   - Name: upernet_r50_512x512_40k_voc12aug
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 23.17
+      inference time (ms/im): 43.16
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug
@@ -221,7 +221,7 @@ Models:
   - Name: upernet_r101_512x512_40k_voc12aug
     In Collection: UPerNet
     Metadata:
-      inference time (fps): 19.98
+      inference time (ms/im): 50.05
     Results:
       - Task: Semantic Segmentation
         Dataset: Pascal VOC 2012 + Aug


### PR DESCRIPTION
Change inference time from 'fps' to 'ms/im' in metafile to meet the requirement of PWC Model-index Format.