### PR TITLE
[Fix] Fix mmcv version compatible in get_started.md

### DIFF
--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -11,7 +11,7 @@ The compatible MMSegmentation and MMCV versions are as below. Please install the
 
 | MMSegmentation version |    MMCV version     |
 |:-------------------:|:-------------------:|
-| master              | mmcv-full>=1.3.1, <1.4.0 |
+| master              | mmcv-full>=1.3.2, <1.4.0 |
 | 0.13.0              | mmcv-full>=1.3.1, <1.4.0 |
 | 0.12.0              | mmcv-full>=1.1.4, <1.4.0 |
 | 0.11.0              | mmcv-full>=1.1.4, <1.3.0 |

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -11,9 +11,11 @@ The compatible MMSegmentation and MMCV versions are as below. Please install the
 
 | MMSegmentation version |    MMCV version     |
 |:-------------------:|:-------------------:|
-| master              | mmcv-full>=1.3.2, <1.4.0 |
-| 0.13.0              | mmcv-full>=1.3.1, <1.4.0 |
-| 0.12.0              | mmcv-full>=1.1.4, <1.4.0 |
+| master              | mmcv-full>=1.3.7, <1.4.0 |
+| 0.14.1              | mmcv-full>=1.3.7, <1.4.0 |
+| 0.14.0              | mmcv-full>=1.3.1, <1.3.2 |
+| 0.13.0              | mmcv-full>=1.3.1, <1.3.2 |
+| 0.12.0              | mmcv-full>=1.1.4, <1.3.2 |
 | 0.11.0              | mmcv-full>=1.1.4, <1.3.0 |
 | 0.10.0              | mmcv-full>=1.1.4, <1.3.0 |
 | 0.9.0               | mmcv-full>=1.1.4, <1.3.0 |

--- a/mmseg/__init__.py
+++ b/mmseg/__init__.py
@@ -2,7 +2,7 @@ import mmcv
 
 from .version import __version__, version_info
 
-MMCV_MIN = '1.3.1'
+MMCV_MIN = '1.3.7'
 MMCV_MAX = '1.4.0'
 
 


### PR DESCRIPTION
## Motivation

 `init_weight`  in `BaseModule` has been changed to `init_weights` when MMCV >= V1.3.2
Fix #653 

## Modification

[get_started.md](https://github.com/open-mmlab/mmsegmentation/blob/master/docs/get_started.md#prerequisites)

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
No
