### PR TITLE
[Fix] Update resource limit

### DIFF
--- a/mmseg/datasets/builder.py
+++ b/mmseg/datasets/builder.py
@@ -14,8 +14,9 @@ if platform.system() != 'Windows':
     # https://github.com/pytorch/pytorch/issues/973
     import resource
     rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    base_soft_limit = rlimit[0]
     hard_limit = rlimit[1]
-    soft_limit = min(4096, hard_limit)
+    soft_limit = min(max(4096, base_soft_limit), hard_limit)
     resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 DATASETS = Registry('dataset')


### PR DESCRIPTION
The limited resource [adjustment](https://github.com/open-mmlab/mmpose/blob/master/mmpose/datasets/builder.py#L13-L19)  will reduce the base file-open soft limit to 4096. Sometimes it will result in `'OSError: [Error 24] Too many open files' during training process` when large file-open needed (>4096).
