### PR TITLE
[Feature] Support HourglassNet

### DIFF
--- a/configs/_base_/models/fcn-resize-concat_hourglass104.py
+++ b/configs/_base_/models/fcn-resize-concat_hourglass104.py
@@ -4,6 +4,7 @@ model = dict(
     decode_head=dict(
         in_channels=[256, 256],
         in_index=(0, 1),
-        channels=sum([256, 256], input_transform='resize_concat'),
+        channels=sum([256, 256]),
+        input_transform='resize_concat',
         num_convs=2,
         kernel_size=3))

--- a/configs/_base_/models/fcn-resize-concat_hourglass104.py
+++ b/configs/_base_/models/fcn-resize-concat_hourglass104.py
@@ -1,0 +1,9 @@
+# model settings
+_base_ = './fcn_hourglass104.py'
+model = dict(
+    decode_head=dict(
+        in_channels=[256, 256],
+        in_index=(0, 1),
+        channels=sum([256, 256], input_transform='resize_concat'),
+        num_convs=2,
+        kernel_size=3))

--- a/configs/_base_/models/fcn_hourglass104.py
+++ b/configs/_base_/models/fcn_hourglass104.py
@@ -1,0 +1,41 @@
+# model settings
+norm_cfg = dict(type='SyncBN', requires_grad=True)
+model = dict(
+    type='EncoderDecoder',
+    backbone=dict(
+        type='HourglassNet',
+        downsample_times=5,
+        num_stacks=2,
+        stage_channels=[256, 256, 384, 384, 384, 512],
+        stage_blocks=[2, 2, 2, 2, 2, 4],
+        feat_channel=256,
+        norm_cfg=norm_cfg),
+    decode_head=dict(
+        type='FCNHead',
+        in_channels=256,
+        in_index=1,
+        channels=256,
+        num_convs=2,
+        concat_input=True,
+        dropout_ratio=0.1,
+        num_classes=19,
+        norm_cfg=norm_cfg,
+        align_corners=False,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
+    auxiliary_head=dict(
+        type='FCNHead',
+        in_channels=256,
+        in_index=0,
+        channels=256,
+        num_convs=1,
+        concat_input=False,
+        dropout_ratio=0.1,
+        num_classes=19,
+        norm_cfg=norm_cfg,
+        align_corners=False,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=0.4)),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/hourglass/fcn-resize-concat_hourglass104_480x480_80k_pascal_context.py
+++ b/configs/hourglass/fcn-resize-concat_hourglass104_480x480_80k_pascal_context.py
@@ -1,0 +1,9 @@
+_base_ = [
+    '../_base_/models/fcn-resize-concat_hourglass104.py',
+    '../_base_/datasets/pascal_context.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=60),
+    test_cfg=dict(mode='slide', crop_size=(480, 480), stride=(320, 320)))
+optimizer = dict(type='SGD', lr=0.004, momentum=0.9, weight_decay=0.0001)

--- a/configs/hourglass/fcn-resize-concat_hourglass104_480x480_80k_pascal_context_59.py
+++ b/configs/hourglass/fcn-resize-concat_hourglass104_480x480_80k_pascal_context_59.py
@@ -1,0 +1,9 @@
+_base_ = [
+    '../_base_/models/fcn-resize-concat_hourglass104.py',
+    '../_base_/datasets/pascal_context_59.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=59),
+    test_cfg=dict(mode='slide', crop_size=(480, 480), stride=(320, 320)))
+optimizer = dict(type='SGD', lr=0.004, momentum=0.9, weight_decay=0.0001)

--- a/configs/hourglass/fcn-resize-concat_hourglass104_512x1024_160k_cityscapes.py
+++ b/configs/hourglass/fcn-resize-concat_hourglass104_512x1024_160k_cityscapes.py
@@ -1,0 +1,5 @@
+_base_ = [
+    '../_base_/models/fcn-resize-concat_hourglass104.py',
+    '../_base_/datasets/cityscapes.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_160k.py'
+]

--- a/configs/hourglass/fcn-resize-concat_hourglass104_512x512_160k_ade20k.py
+++ b/configs/hourglass/fcn-resize-concat_hourglass104_512x512_160k_ade20k.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/fcn-resize-concat_hourglass104.py',
+    '../_base_/datasets/ade20k.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_160k.py'
+]
+model = dict(decode_head=dict(num_classes=150))

--- a/configs/hourglass/fcn-resize-concat_hourglass104_512x512_40k_voc12aug.py
+++ b/configs/hourglass/fcn-resize-concat_hourglass104_512x512_40k_voc12aug.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/fcn-resize-concat_hourglass104.py',
+    '../_base_/datasets/pascal_voc12_aug.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_40k.py'
+]
+model = dict(decode_head=dict(num_classes=21))

--- a/configs/hourglass/fcn_hourglass104_480x480_80k_pascal_context.py
+++ b/configs/hourglass/fcn_hourglass104_480x480_80k_pascal_context.py
@@ -1,0 +1,9 @@
+_base_ = [
+    '../_base_/models/fcn_hourglass104.py',
+    '../_base_/datasets/pascal_context.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=60),
+    test_cfg=dict(mode='slide', crop_size=(480, 480), stride=(320, 320)))
+optimizer = dict(type='SGD', lr=0.004, momentum=0.9, weight_decay=0.0001)

--- a/configs/hourglass/fcn_hourglass104_480x480_80k_pascal_context_59.py
+++ b/configs/hourglass/fcn_hourglass104_480x480_80k_pascal_context_59.py
@@ -1,0 +1,9 @@
+_base_ = [
+    '../_base_/models/fcn_hourglass104.py',
+    '../_base_/datasets/pascal_context_59.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=59),
+    test_cfg=dict(mode='slide', crop_size=(480, 480), stride=(320, 320)))
+optimizer = dict(type='SGD', lr=0.004, momentum=0.9, weight_decay=0.0001)

--- a/configs/hourglass/fcn_hourglass104_512x1024_160k_cityscapes.py
+++ b/configs/hourglass/fcn_hourglass104_512x1024_160k_cityscapes.py
@@ -1,0 +1,4 @@
+_base_ = [
+    '../_base_/models/fcn_hourglass104.py', '../_base_/datasets/cityscapes.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]

--- a/configs/hourglass/fcn_hourglass104_512x512_160k_ade20k.py
+++ b/configs/hourglass/fcn_hourglass104_512x512_160k_ade20k.py
@@ -1,0 +1,5 @@
+_base_ = [
+    '../_base_/models/fcn_hourglass104.py', '../_base_/datasets/ade20k.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+model = dict(decode_head=dict(num_classes=150))

--- a/configs/hourglass/fcn_hourglass104_512x512_40k_voc12aug.py
+++ b/configs/hourglass/fcn_hourglass104_512x512_40k_voc12aug.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/fcn_hourglass104.py',
+    '../_base_/datasets/pascal_voc12_aug.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_40k.py'
+]
+model = dict(decode_head=dict(num_classes=21))

--- a/mmseg/models/backbones/__init__.py
+++ b/mmseg/models/backbones/__init__.py
@@ -1,5 +1,6 @@
 from .cgnet import CGNet
 from .fast_scnn import FastSCNN
+from .hourglass import HourglassNet
 from .hrnet import HRNet
 from .mit import MixVisionTransformer
 from .mobilenet_v2 import MobileNetV2
@@ -14,5 +15,6 @@ from .vit import VisionTransformer
 __all__ = [
     'ResNet', 'ResNetV1c', 'ResNetV1d', 'ResNeXt', 'HRNet', 'FastSCNN',
     'ResNeSt', 'MobileNetV2', 'UNet', 'CGNet', 'MobileNetV3',
-    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer'
+    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer',
+    'HourglassNet'
 ]

--- a/mmseg/models/backbones/hourglass.py
+++ b/mmseg/models/backbones/hourglass.py
@@ -123,7 +123,7 @@ class HourglassNet(BaseModule):
             Default: `None`.
 
     Example:
-        >>> from mmdet.models import HourglassNet
+        >>> from mmseg.models import HourglassNet
         >>> import torch
         >>> self = HourglassNet()
         >>> self.eval()

--- a/mmseg/models/backbones/hourglass.py
+++ b/mmseg/models/backbones/hourglass.py
@@ -1,0 +1,219 @@
+import torch.nn as nn
+import torch.nn.functional as F
+from mmcv.cnn import ConvModule
+from mmcv.runner import BaseModule
+
+from ..builder import BACKBONES
+from ..utils import ResLayer
+from .resnet import BasicBlock
+
+
+class HourglassModule(BaseModule):
+    """Hourglass Module for HourglassNet backbone.
+
+    Generate module recursively and use BasicBlock as the base unit.
+
+    Args:
+        depth (int): Depth of current HourglassModule. This is also the
+            downsampling times. len(stage_channels) should lagrer than
+            downsample_times.
+        stage_channels (list[int]): The number of feature channels of each
+            stage in the current HourglassModule. len(stage_channels) should
+            equal to len(stage_blocks).
+        stage_blocks (list[int]): The number of stacked blocks of each stage in
+            the current HourglassModule.
+        norm_cfg (dict): Dictionary to construct and config norm layer.
+            Default: `dict(type='BN', requires_grad=True)`.
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+            Default: `None`.
+        upsample_cfg (dict, optional): Config dict for interpolate layer.
+            Default: `dict(mode='nearest')`.
+    """
+
+    def __init__(self,
+                 depth,
+                 stage_channels,
+                 stage_blocks,
+                 norm_cfg=dict(type='BN', requires_grad=True),
+                 init_cfg=None,
+                 upsample_cfg=dict(mode='nearest')):
+        super(HourglassModule, self).__init__(init_cfg)
+
+        self.depth = depth
+
+        cur_block = stage_blocks[0]
+        next_block = stage_blocks[1]
+
+        cur_channel = stage_channels[0]
+        next_channel = stage_channels[1]
+
+        self.up1 = ResLayer(
+            BasicBlock, cur_channel, cur_channel, cur_block, norm_cfg=norm_cfg)
+
+        self.low1 = ResLayer(
+            BasicBlock,
+            cur_channel,
+            next_channel,
+            cur_block,
+            stride=2,
+            norm_cfg=norm_cfg)
+
+        if self.depth > 1:
+            self.low2 = HourglassModule(depth - 1, stage_channels[1:],
+                                        stage_blocks[1:])
+        else:
+            self.low2 = ResLayer(
+                BasicBlock,
+                next_channel,
+                next_channel,
+                next_block,
+                norm_cfg=norm_cfg)
+
+        self.low3 = ResLayer(
+            BasicBlock,
+            next_channel,
+            cur_channel,
+            cur_block,
+            norm_cfg=norm_cfg)
+
+        self.up2 = F.interpolate
+        self.upsample_cfg = upsample_cfg
+
+    def forward(self, x):
+        """Forward function."""
+        up1 = self.up1(x)
+        low1 = self.low1(x)
+        low2 = self.low2(low1)
+        low3 = self.low3(low2)
+        # Fixing `scale factor` (e.g. 2) is common for upsampling, but
+        # in some cases the spatial size is mismatched and error will arise.
+        if 'scale_factor' in self.upsample_cfg:
+            up2 = self.up2(low3, **self.upsample_cfg)
+        else:
+            shape = up1.shape[2:]
+            up2 = self.up2(low3, size=shape, **self.upsample_cfg)
+        return up1 + up2
+
+
+@BACKBONES.register_module()
+class HourglassNet(BaseModule):
+    """HourglassNet backbone.
+
+    Stacked Hourglass Networks for Human Pose Estimation.
+    More details can be found in the `paper
+    <https://arxiv.org/abs/1603.06937>`_ .
+
+    Args:
+        downsample_times (int): The number of downsample times in a
+            HourglassModule. Default: `5`.
+        num_stacks (int): The number of stacked HourglassModule in
+            HourglassNet, 1 for Hourglass-52, 2 for Hourglass-104.
+            Default: `2`.
+        stage_channels (list[int]): The number of feature channels of each
+            stage in a HourglassModule.
+            Default: `(256, 256, 384, 384, 384, 512)`.
+        stage_blocks (list[int]): The number of stacked blocks of each stage in
+            a HourglassModule. Default: `(2, 2, 2, 2, 2, 4)`.
+        feat_channel (int): The number of output feature channels each
+            HourglassModule. Default: `256`.
+        norm_cfg (dict): Dictionary to construct and config norm layer.
+            Default: `dict(type='BN', requires_grad=True)`.
+        pretrained (str, optional): model pretrained path. Default: `None`.
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+            Default: `None`.
+
+    Example:
+        >>> from mmdet.models import HourglassNet
+        >>> import torch
+        >>> self = HourglassNet()
+        >>> self.eval()
+        >>> inputs = torch.rand(1, 3, 511, 511)
+        >>> level_outputs = self.forward(inputs)
+        >>> for level_output in level_outputs:
+        ...     print(tuple(level_output.shape))
+        (1, 256, 128, 128)
+        (1, 256, 128, 128)
+    """
+
+    def __init__(self,
+                 downsample_times=5,
+                 num_stacks=2,
+                 stage_channels=(256, 256, 384, 384, 384, 512),
+                 stage_blocks=(2, 2, 2, 2, 2, 4),
+                 feat_channel=256,
+                 norm_cfg=dict(type='BN', requires_grad=True),
+                 pretrained=None,
+                 init_cfg=None):
+        assert init_cfg is None, 'To prevent abnormal initialization ' \
+                                 'behavior, init_cfg is not allowed to be set'
+        super(HourglassNet, self).__init__(init_cfg)
+
+        self.num_stacks = num_stacks
+        assert self.num_stacks >= 1
+        assert len(stage_channels) == len(stage_blocks)
+        assert len(stage_channels) > downsample_times
+
+        cur_channel = stage_channels[0]
+
+        self.stem = nn.Sequential(
+            ConvModule(3, 128, 7, padding=3, stride=2, norm_cfg=norm_cfg),
+            ResLayer(
+                BasicBlock, 128, cur_channel, 1, stride=2, norm_cfg=norm_cfg))
+
+        self.hourglass_modules = nn.ModuleList([
+            HourglassModule(downsample_times, stage_channels, stage_blocks)
+            for _ in range(num_stacks)
+        ])
+
+        self.inters = ResLayer(
+            BasicBlock,
+            cur_channel,
+            cur_channel,
+            num_stacks - 1,
+            norm_cfg=norm_cfg)
+
+        self.conv1x1s = nn.ModuleList([
+            ConvModule(
+                cur_channel, cur_channel, 1, norm_cfg=norm_cfg, act_cfg=None)
+            for _ in range(num_stacks - 1)
+        ])
+
+        self.out_convs = nn.ModuleList([
+            ConvModule(
+                cur_channel, feat_channel, 3, padding=1, norm_cfg=norm_cfg)
+            for _ in range(num_stacks)
+        ])
+
+        self.remap_convs = nn.ModuleList([
+            ConvModule(
+                feat_channel, cur_channel, 1, norm_cfg=norm_cfg, act_cfg=None)
+            for _ in range(num_stacks - 1)
+        ])
+
+        self.relu = nn.ReLU(inplace=True)
+
+    def init_weights(self):
+        """Init module weights."""
+        # Training Centripetal Model needs to reset parameters for Conv2d
+        super(HourglassNet, self).init_weights()
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                m.reset_parameters()
+
+    def forward(self, x):
+        """Forward function."""
+        inter_feat = self.stem(x)
+        out_feats = []
+
+        for idx in range(self.num_stacks):
+            hourglass_feat = self.hourglass_modules[idx](inter_feat)
+            out_feat = self.out_convs[idx](hourglass_feat)
+            out_feats.append(out_feat)
+
+            if idx < self.num_stacks - 1:
+                inter_feat = self.conv1x1s[idx](
+                    inter_feat) + self.remap_convs[idx](
+                        out_feat)
+                inter_feat = self.inters[idx](self.relu(inter_feat))
+
+        return out_feats

--- a/tests/test_models/test_backbones/test_hourglass.py
+++ b/tests/test_models/test_backbones/test_hourglass.py
@@ -1,0 +1,44 @@
+import pytest
+import torch
+
+from mmseg.models.backbones.hourglass import HourglassNet
+
+
+def test_hourglass_backbone():
+    with pytest.raises(AssertionError):
+        # HourglassNet's num_stacks should larger than 0
+        HourglassNet(num_stacks=0)
+
+    with pytest.raises(AssertionError):
+        # len(stage_channels) should equal len(stage_blocks)
+        HourglassNet(
+            stage_channels=[256, 256, 384, 384, 384],
+            stage_blocks=[2, 2, 2, 2, 2, 4])
+
+    with pytest.raises(AssertionError):
+        # len(stage_channels) should lagrer than downsample_times
+        HourglassNet(
+            downsample_times=5,
+            stage_channels=[256, 256, 384, 384, 384],
+            stage_blocks=[2, 2, 2, 2, 2])
+
+    # Test HourglassNet-52
+    model = HourglassNet(num_stacks=1)
+    model.init_weights()
+    model.train()
+
+    imgs = torch.randn(1, 3, 256, 256)
+    feat = model(imgs)
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size([1, 256, 64, 64])
+
+    # Test HourglassNet-104
+    model = HourglassNet(num_stacks=2)
+    model.init_weights()
+    model.train()
+
+    imgs = torch.randn(1, 3, 256, 256)
+    feat = model(imgs)
+    assert len(feat) == 2
+    assert feat[0].shape == torch.Size([1, 256, 64, 64])
+    assert feat[1].shape == torch.Size([1, 256, 64, 64])


### PR DESCRIPTION
## Motivation

Support more backbones for semantic segmentation.
In this PR, we add HourglassNet, which may train from scratch without ImageNet pre-train.

## Modification

- [x] Add HourglassNet backbone and unitests
- [x] Add configs for HourglassNet
- [ ]  Add benchmarks for HourglassNet

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos? 
No


