### PR TITLE
[Feature] Support ShuffleNetV1

### DIFF
--- a/mmseg/models/backbones/__init__.py
+++ b/mmseg/models/backbones/__init__.py
@@ -7,6 +7,7 @@ from .mobilenet_v3 import MobileNetV3
 from .resnest import ResNeSt
 from .resnet import ResNet, ResNetV1c, ResNetV1d
 from .resnext import ResNeXt
+from .shufflenet_v1 import ShuffleNetV1
 from .swin import SwinTransformer
 from .unet import UNet
 from .vit import VisionTransformer
@@ -14,5 +15,6 @@ from .vit import VisionTransformer
 __all__ = [
     'ResNet', 'ResNetV1c', 'ResNetV1d', 'ResNeXt', 'HRNet', 'FastSCNN',
     'ResNeSt', 'MobileNetV2', 'UNet', 'CGNet', 'MobileNetV3',
-    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer'
+    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer',
+    'ShuffleNetV1'
 ]

--- a/mmseg/models/backbones/shufflenet_v1.py
+++ b/mmseg/models/backbones/shufflenet_v1.py
@@ -1,0 +1,361 @@
+import copy
+
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint as cp
+from mmcv.cnn import (ConvModule, build_activation_layer, constant_init,
+                      normal_init)
+from mmcv.runner import BaseModule, load_checkpoint
+from torch.nn.modules.batchnorm import _BatchNorm
+
+from mmseg.utils import get_root_logger
+from ..builder import BACKBONES
+from ..utils import channel_shuffle, make_divisible
+
+
+class ShuffleUnit(BaseModule):
+    """ShuffleUnit block.
+
+    ShuffleNet unit with pointwise group convolution (GConv) and channel
+    shuffle.
+
+    Args:
+        in_channels (int): The input channels of the ShuffleUnit.
+        out_channels (int): The output channels of the ShuffleUnit.
+        groups (int, optional): The number of groups to be used in grouped 1x1
+            convolutions in each ShuffleUnit. Default: 3
+        first_block (bool, optional): Whether it is the first ShuffleUnit of a
+            sequential ShuffleUnits. Default: True, which means not using the
+            grouped 1x1 convolution.
+        combine (str, optional): The ways to combine the input and output
+            branches. Default: 'add'.
+        downsample (bool): Whether to downsample the feature map when combine
+            is 'concat'. Default: 'True'.
+        conv_cfg (dict): Config dict for convolution layer. Default: None,
+            which means using conv2d.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='BN').
+        act_cfg (dict): Config dict for activation layer.
+            Default: dict(type='ReLU').
+        with_cp (bool, optional): Use checkpoint or not. Using checkpoint
+            will save some memory while slowing down the training speed.
+            Default: False.
+
+    Returns:
+        Tensor: The output tensor.
+    """
+
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 groups=3,
+                 first_block=True,
+                 combine='add',
+                 downsample=True,
+                 conv_cfg=None,
+                 norm_cfg=dict(type='BN'),
+                 act_cfg=dict(type='ReLU'),
+                 with_cp=False):
+        super(ShuffleUnit, self).__init__()
+        # Protect mutable default arguments
+        norm_cfg = copy.deepcopy(norm_cfg)
+        act_cfg = copy.deepcopy(act_cfg)
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.first_block = first_block
+        self.combine = combine
+        self.downsample = downsample
+        self.groups = groups
+        self.bottleneck_channels = self.out_channels // 4
+        self.with_cp = with_cp
+
+        if self.combine == 'add':
+            self.depthwise_stride = 1
+            self._combine_func = self._add
+            assert in_channels == out_channels, (
+                'in_channels must be equal to out_channels when combine '
+                'is add')
+        elif self.combine == 'concat':
+            self._combine_func = self._concat
+            self.out_channels -= self.in_channels
+            if self.downsample:
+                self.depthwise_stride = 2
+                self.avgpool = nn.AvgPool2d(kernel_size=3, stride=2, padding=1)
+            else:
+                self.depthwise_stride = 1
+        else:
+            raise ValueError(f'Cannot combine tensors with {self.combine}. '
+                             'Only "add" and "concat" are supported')
+
+        self.first_1x1_groups = 1 if first_block else self.groups
+        self.g_conv_1x1_compress = ConvModule(
+            in_channels=self.in_channels,
+            out_channels=self.bottleneck_channels,
+            kernel_size=1,
+            groups=self.first_1x1_groups,
+            conv_cfg=conv_cfg,
+            norm_cfg=norm_cfg,
+            act_cfg=act_cfg)
+
+        self.depthwise_conv3x3_bn = ConvModule(
+            in_channels=self.bottleneck_channels,
+            out_channels=self.bottleneck_channels,
+            kernel_size=3,
+            stride=self.depthwise_stride,
+            padding=1,
+            groups=self.bottleneck_channels,
+            conv_cfg=conv_cfg,
+            norm_cfg=norm_cfg,
+            act_cfg=None)
+
+        self.g_conv_1x1_expand = ConvModule(
+            in_channels=self.bottleneck_channels,
+            out_channels=self.out_channels,
+            kernel_size=1,
+            groups=self.groups,
+            conv_cfg=conv_cfg,
+            norm_cfg=norm_cfg,
+            act_cfg=None)
+
+        self.act = build_activation_layer(act_cfg)
+
+    @staticmethod
+    def _add(x, out):
+        # residual connection
+        return x + out
+
+    @staticmethod
+    def _concat(x, out):
+        # concatenate along channel axis
+        return torch.cat((x, out), 1)
+
+    def forward(self, x):
+
+        def _inner_forward(x):
+            residual = x
+
+            out = self.g_conv_1x1_compress(x)
+            out = self.depthwise_conv3x3_bn(out)
+
+            if self.groups > 1:
+                out = channel_shuffle(out, self.groups)
+
+            out = self.g_conv_1x1_expand(out)
+
+            if self.combine == 'concat':
+                if self.downsample:
+                    residual = self.avgpool(residual)
+                out = self.act(out)
+                out = self._combine_func(residual, out)
+            else:
+                out = self._combine_func(residual, out)
+                out = self.act(out)
+            return out
+
+        if self.with_cp and x.requires_grad:
+            out = cp.checkpoint(_inner_forward, x)
+        else:
+            out = _inner_forward(x)
+
+        return out
+
+
+@BACKBONES.register_module()
+class ShuffleNetV1(BaseModule):
+    """ShuffleNetV1 backbone.
+
+    Args:
+        groups (int, optional): The number of groups to be used in grouped 1x1
+            convolutions in each ShuffleUnit. Default: 3.
+        widen_factor (float, optional): Width multiplier - adjusts the number
+            of channels in each layer by this amount. Default: 1.0.
+        out_indices (Sequence[int]): Output from which stages.
+            Default: (0, 1, 2).
+        stage_blocks (Sequence[int]): The number of blocks in each stage.
+            Default: (4, 8, 4).
+        downsamples (Sequence[bool]): Whether to downsample the feature map
+            at each stage when combine is 'concat' in the first ShuffleUnit.
+            Default: (True, True, True).
+        frozen_stages (int): Stages to be frozen (all param fixed).
+            Default: -1, which means not freezing any parameters.
+        conv_cfg (dict): Config dict for convolution layer. Default: None,
+            which means using conv2d.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='BN').
+        act_cfg (dict): Config dict for activation layer.
+            Default: dict(type='ReLU').
+        norm_eval (bool): Whether to set norm layers to eval mode, namely,
+            freeze running stats (mean and var). Note: Effect on Batch Norm
+            and its variants only. Default: False.
+        with_cp (bool): Use checkpoint or not. Using checkpoint will save some
+            memory while slowing down the training speed. Default: False.
+        pretrained (str, optional): model pretrained path. Default: None.
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+            Default: None.
+    """
+
+    def __init__(self,
+                 groups=3,
+                 widen_factor=1.0,
+                 out_indices=(0, 1, 2),
+                 stage_blocks=(4, 8, 4),
+                 downsamples=(True, True, True),
+                 frozen_stages=-1,
+                 conv_cfg=None,
+                 norm_cfg=dict(type='BN'),
+                 act_cfg=dict(type='ReLU'),
+                 norm_eval=False,
+                 with_cp=False,
+                 pretrained=None,
+                 init_cfg=None):
+        super(ShuffleNetV1, self).__init__(init_cfg)
+        assert len(stage_blocks) == len(downsamples)
+        self.pretrained = pretrained
+        self.init_cfg = init_cfg
+        # Protect mutable default arguments
+        norm_cfg = copy.deepcopy(norm_cfg)
+        act_cfg = copy.deepcopy(act_cfg)
+        self.stage_blocks = stage_blocks
+        self.groups = groups
+        self.downsamples = downsamples
+
+        for index in out_indices:
+            if index not in range(len(stage_blocks)):
+                raise ValueError(
+                    'the item in out_indices must in '
+                    f'range(0, {len(stage_blocks)}). But received {index}')
+
+        if frozen_stages not in range(-1, len(stage_blocks)):
+            raise ValueError(
+                f'frozen_stages must be in range(-1, {len(stage_blocks)}). '
+                f'But received {frozen_stages}')
+        self.out_indices = out_indices
+        self.frozen_stages = frozen_stages
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.act_cfg = act_cfg
+        self.norm_eval = norm_eval
+        self.with_cp = with_cp
+
+        if groups == 1:
+            channels = (144, 288, 576)
+        elif groups == 2:
+            channels = (200, 400, 800)
+        elif groups == 3:
+            channels = (240, 480, 960)
+        elif groups == 4:
+            channels = (272, 544, 1088)
+        elif groups == 8:
+            channels = (384, 768, 1536)
+        else:
+            raise ValueError(f'{groups} groups is not supported for 1x1 '
+                             'Grouped Convolutions')
+
+        channels = [make_divisible(ch * widen_factor, 8) for ch in channels]
+
+        self.in_channels = int(24 * widen_factor)
+
+        self.conv1 = ConvModule(
+            in_channels=3,
+            out_channels=self.in_channels,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+            conv_cfg=conv_cfg,
+            norm_cfg=norm_cfg,
+            act_cfg=act_cfg)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+        self.layers = nn.ModuleList()
+        for i, num_blocks in enumerate(self.stage_blocks):
+            first_block = (i == 0)
+            layer = self.make_layer(channels[i], num_blocks, first_block,
+                                    downsamples[i])
+            self.layers.append(layer)
+
+    def _freeze_stages(self):
+        if self.frozen_stages >= 0:
+            for param in self.conv1.parameters():
+                param.requires_grad = False
+        for i in range(self.frozen_stages):
+            layer = self.layers[i]
+            layer.eval()
+            for param in layer.parameters():
+                param.requires_grad = False
+
+    def make_layer(self,
+                   out_channels,
+                   num_blocks,
+                   first_block=False,
+                   downsample=True):
+        """Stack ShuffleUnit blocks to make a layer.
+
+        Args:
+            out_channels (int): out_channels of the block.
+            num_blocks (int): Number of blocks.
+            first_block (bool, optional): Whether is the first ShuffleUnit of a
+                sequential ShuffleUnits. Default: True, which means not using
+                the grouped 1x1 convolution.
+        """
+        layers = []
+        for i in range(num_blocks):
+            first_block = first_block if i == 0 else False
+            combine_mode = 'concat' if i == 0 else 'add'
+            layers.append(
+                ShuffleUnit(
+                    self.in_channels,
+                    out_channels,
+                    groups=self.groups,
+                    first_block=first_block,
+                    combine=combine_mode,
+                    downsample=downsample,
+                    conv_cfg=self.conv_cfg,
+                    norm_cfg=self.norm_cfg,
+                    act_cfg=self.act_cfg,
+                    with_cp=self.with_cp))
+            self.in_channels = out_channels
+
+        return nn.Sequential(*layers)
+
+    def init_weights(self):
+        """Initialize the weights in backbone."""
+        if isinstance(self.pretrained, str):
+            logger = get_root_logger()
+            load_checkpoint(self, self.pretrained, strict=False, logger=logger)
+        elif self.pretrained is None:
+            for name, m in self.named_modules():
+                if isinstance(m, nn.Conv2d):
+                    if 'conv1' in name:
+                        normal_init(m, mean=0, std=0.01)
+                    else:
+                        normal_init(m, mean=0, std=1.0 / m.weight.shape[1])
+                elif isinstance(m, (_BatchNorm, nn.GroupNorm)):
+                    constant_init(m, val=1, bias=0.0001)
+                    if isinstance(m, _BatchNorm):
+                        if m.running_mean is not None:
+                            nn.init.constant_(m.running_mean, 0)
+        else:
+            raise TypeError('pretrained must be a str or None. But received '
+                            f'{type(self.pretrained)}')
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.maxpool(x)
+
+        outs = []
+        for i, layer in enumerate(self.layers):
+            x = layer(x)
+            if i in self.out_indices:
+                outs.append(x)
+
+        return tuple(outs)
+
+    def train(self, mode=True):
+        """Convert the model into training mode while keep normalization layer
+        freezed."""
+        super(ShuffleNetV1, self).train(mode)
+        self._freeze_stages()
+        if mode and self.norm_eval:
+            for m in self.modules():
+                if isinstance(m, _BatchNorm):
+                    m.eval()

--- a/mmseg/models/utils/__init__.py
+++ b/mmseg/models/utils/__init__.py
@@ -1,3 +1,4 @@
+from .channel_shuffle import channel_shuffle
 from .ckpt_convert import mit_convert, swin_convert, vit_convert
 from .embed import PatchEmbed
 from .inverted_residual import InvertedResidual, InvertedResidualV3
@@ -11,5 +12,6 @@ from .up_conv_block import UpConvBlock
 __all__ = [
     'ResLayer', 'SelfAttentionBlock', 'make_divisible', 'InvertedResidual',
     'UpConvBlock', 'InvertedResidualV3', 'SELayer', 'vit_convert',
-    'mit_convert', 'swin_convert', 'PatchEmbed', 'nchw_to_nlc', 'nlc_to_nchw'
+    'mit_convert', 'swin_convert', 'PatchEmbed', 'nchw_to_nlc', 'nlc_to_nchw',
+    'channel_shuffle'
 ]

--- a/mmseg/models/utils/channel_shuffle.py
+++ b/mmseg/models/utils/channel_shuffle.py
@@ -1,0 +1,28 @@
+import torch
+
+
+def channel_shuffle(x, groups):
+    """Channel Shuffle operation.
+
+    This function enables cross-group information flow for multiple groups
+    convolution layers.
+
+    Args:
+        x (Tensor): The input tensor.
+        groups (int): The number of groups to divide the input tensor
+            in the channel dimension.
+
+    Returns:
+        Tensor: The output tensor after channel shuffle operation.
+    """
+
+    batch_size, num_channels, height, width = x.size()
+    assert (num_channels % groups == 0), ('num_channels should be '
+                                          'divisible by groups')
+    channels_per_group = num_channels // groups
+
+    x = x.view(batch_size, groups, channels_per_group, height, width)
+    x = torch.transpose(x, 1, 2).contiguous()
+    x = x.view(batch_size, -1, height, width)
+
+    return x

--- a/tests/test_models/test_backbones/test_shufflenet_v1.py
+++ b/tests/test_models/test_backbones/test_shufflenet_v1.py
@@ -1,0 +1,335 @@
+import pytest
+import torch
+from mmcv.utils import is_tuple_of
+from torch.nn.modules import GroupNorm
+from torch.nn.modules.batchnorm import _BatchNorm
+
+from mmseg.models.backbones import ShuffleNetV1
+from mmseg.models.backbones.shufflenet_v1 import ShuffleUnit
+
+
+def is_block(modules):
+    """Check if is ResNet building block."""
+    if isinstance(modules, (ShuffleUnit, )):
+        return True
+    return False
+
+
+def is_norm(modules):
+    """Check if is one of the norms."""
+    if isinstance(modules, (GroupNorm, _BatchNorm)):
+        return True
+    return False
+
+
+def check_norm_state(modules, train_state):
+    """Check if norm layer is in correct train state."""
+    for mod in modules:
+        if isinstance(mod, _BatchNorm):
+            if mod.training != train_state:
+                return False
+    return True
+
+
+def test_shufflenetv1_shuffleuint():
+
+    with pytest.raises(ValueError):
+        # combine must be in ['add', 'concat']
+        ShuffleUnit(24, 16, groups=3, first_block=True, combine='test')
+
+    with pytest.raises(AssertionError):
+        # in_channels must be equal to out_channels when combine='add'
+        ShuffleUnit(64, 24, groups=4, first_block=True, combine='add')
+
+    # Test ShuffleUnit with combine='add'
+    block = ShuffleUnit(24, 24, groups=3, first_block=True, combine='add')
+    x = torch.randn(1, 24, 56, 56)
+    x_out = block(x)
+    assert x_out.shape == torch.Size((1, 24, 56, 56))
+
+    # Test ShuffleUnit with combine='concat'
+    block = ShuffleUnit(24, 240, groups=3, first_block=True, combine='concat')
+    x = torch.randn(1, 24, 56, 56)
+    x_out = block(x)
+    assert x_out.shape == torch.Size((1, 240, 28, 28))
+
+    # Test ShuffleUnit with checkpoint forward
+    block = ShuffleUnit(
+        24, 24, groups=3, first_block=True, combine='add', with_cp=True)
+    assert block.with_cp
+    x = torch.randn(1, 24, 56, 56)
+    x.requires_grad = True
+    x_out = block(x)
+    assert x_out.shape == torch.Size((1, 24, 56, 56))
+
+
+def test_shufflenetv1_backbone():
+    # The default stage_blocks is (4, 8, 4), so the number of stages is 3.
+    with pytest.raises(ValueError):
+        # frozen_stages must be in  range(-1, 3)
+        ShuffleNetV1(frozen_stages=3)
+
+    with pytest.raises(ValueError):
+        # the item in out_indices must be in  range(0, 3)
+        ShuffleNetV1(out_indices=[5])
+
+    with pytest.raises(ValueError):
+        # groups must be in  [1, 2, 3, 4, 8]
+        ShuffleNetV1(groups=10)
+
+    with pytest.raises(TypeError):
+        # pretrained must be str or None
+        model = ShuffleNetV1(pretrained=1)
+        model.init_weights()
+
+    # Test ShuffleNetV1 norm state, the default pretrained is None.
+    model = ShuffleNetV1()
+    model.init_weights()
+    model.train()
+    assert check_norm_state(model.modules(), True)
+
+    # Test ShuffleNetV1 with first stage frozen
+    frozen_stages = 1
+    model = ShuffleNetV1(frozen_stages=frozen_stages, out_indices=(0, 1, 2))
+    model.init_weights()
+    model.train()
+    for param in model.conv1.parameters():
+        assert param.requires_grad is False
+    for i in range(frozen_stages):
+        layer = model.layers[i]
+        for mod in layer.modules():
+            if isinstance(mod, _BatchNorm):
+                assert mod.training is False
+        for param in layer.parameters():
+            assert param.requires_grad is False
+
+    # Test ShuffleNetV1 forward with groups=1
+    model = ShuffleNetV1(groups=1, out_indices=(0, 1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 144, 28, 28))
+    assert feat[1].shape == torch.Size((1, 288, 14, 14))
+    assert feat[2].shape == torch.Size((1, 576, 7, 7))
+
+    # Test ShuffleNetV1 forward with groups=2
+    model = ShuffleNetV1(groups=2, out_indices=(0, 1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 200, 28, 28))
+    assert feat[1].shape == torch.Size((1, 400, 14, 14))
+    assert feat[2].shape == torch.Size((1, 800, 7, 7))
+
+    # Test ShuffleNetV1 forward with groups=3
+    model = ShuffleNetV1(groups=3, out_indices=(0, 1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 240, 28, 28))
+    assert feat[1].shape == torch.Size((1, 480, 14, 14))
+    assert feat[2].shape == torch.Size((1, 960, 7, 7))
+
+    # Test ShuffleNetV1 forward with groups=4
+    model = ShuffleNetV1(groups=4, out_indices=(0, 1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 272, 28, 28))
+    assert feat[1].shape == torch.Size((1, 544, 14, 14))
+    assert feat[2].shape == torch.Size((1, 1088, 7, 7))
+
+    # Test ShuffleNetV1 forward with groups=8
+    model = ShuffleNetV1(groups=8, out_indices=(0, 1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 384, 28, 28))
+    assert feat[1].shape == torch.Size((1, 768, 14, 14))
+    assert feat[2].shape == torch.Size((1, 1536, 7, 7))
+
+    # Test ShuffleNetV1 forward with GroupNorm forward
+    model = ShuffleNetV1(
+        groups=3,
+        norm_cfg=dict(type='GN', num_groups=2, requires_grad=True),
+        out_indices=(0, 1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, GroupNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 240, 28, 28))
+    assert feat[1].shape == torch.Size((1, 480, 14, 14))
+    assert feat[2].shape == torch.Size((1, 960, 7, 7))
+
+    # Test ShuffleNetV1 forward with layers 1, 2 forward
+    model = ShuffleNetV1(groups=3, out_indices=(1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 2
+    assert feat[0].shape == torch.Size((1, 480, 14, 14))
+    assert feat[1].shape == torch.Size((1, 960, 7, 7))
+
+    # Test ShuffleNetV1 forward with layers 2 forward
+    model = ShuffleNetV1(groups=3, out_indices=(2, ))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert is_tuple_of(feat, torch.Tensor)
+    assert feat[-1].shape == torch.Size((1, 960, 7, 7))
+
+    # Test ShuffleNetV1 forward with checkpoint forward
+    model = ShuffleNetV1(groups=3, with_cp=True)
+    for m in model.modules():
+        if is_block(m):
+            assert m.with_cp
+
+    # Test ShuffleNetV1 with norm_eval
+    model = ShuffleNetV1(norm_eval=True)
+    model.init_weights()
+    model.train()
+
+    assert check_norm_state(model.modules(), False)
+
+    # Test ShuffleNetV1 forward with groups=3,
+    # downsamples=(False, False, False)
+    model = ShuffleNetV1(
+        groups=3, out_indices=(0, 1, 2), downsamples=(False, False, False))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 240, 56, 56))
+    assert feat[1].shape == torch.Size((1, 480, 56, 56))
+    assert feat[2].shape == torch.Size((1, 960, 56, 56))
+
+    # Test ShuffleNetV1 forward with groups=3,
+    # downsamples=(False, True, True)
+    model = ShuffleNetV1(
+        groups=3, out_indices=(0, 1, 2), downsamples=(False, True, True))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 240, 56, 56))
+    assert feat[1].shape == torch.Size((1, 480, 28, 28))
+    assert feat[2].shape == torch.Size((1, 960, 14, 14))
+
+    # Test ShuffleNetV1 forward with groups=3,
+    # downsamples=(False, True, False)
+    model = ShuffleNetV1(
+        groups=3, out_indices=(0, 1, 2), downsamples=(False, True, False))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 240, 56, 56))
+    assert feat[1].shape == torch.Size((1, 480, 28, 28))
+    assert feat[2].shape == torch.Size((1, 960, 28, 28))
+
+    # Test ShuffleNetV1 forward with groups=3,
+    # downsamples=(True, True, False)
+    model = ShuffleNetV1(
+        groups=3, out_indices=(0, 1, 2), downsamples=(True, True, False))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 240, 28, 28))
+    assert feat[1].shape == torch.Size((1, 480, 14, 14))
+    assert feat[2].shape == torch.Size((1, 960, 14, 14))
+
+    # Test ShuffleNetV1 forward with groups=3,
+    # downsamples=(True, False, False)
+    model = ShuffleNetV1(
+        groups=3, out_indices=(0, 1, 2), downsamples=(True, False, False))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 3
+    assert feat[0].shape == torch.Size((1, 240, 28, 28))
+    assert feat[1].shape == torch.Size((1, 480, 28, 28))
+    assert feat[2].shape == torch.Size((1, 960, 28, 28))


### PR DESCRIPTION
## Motivation

Support more real-time semantic segmentation models.
In this PR, we add ShuffleNetV1.

## Modification

- [x] Add ShuffleNetV1 backbone and unitests
- [ ] Add configs for ShuffleNetV1
- [ ]  Add benchmarks for ShuffleNetV1

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos? 
No


