### PR TITLE
[Feature] Support ShuffleNetV2

### DIFF
--- a/mmseg/models/backbones/__init__.py
+++ b/mmseg/models/backbones/__init__.py
@@ -7,6 +7,7 @@ from .mobilenet_v3 import MobileNetV3
 from .resnest import ResNeSt
 from .resnet import ResNet, ResNetV1c, ResNetV1d
 from .resnext import ResNeXt
+from .shufflenet_v2 import ShuffleNetV2
 from .swin import SwinTransformer
 from .unet import UNet
 from .vit import VisionTransformer
@@ -14,5 +15,6 @@ from .vit import VisionTransformer
 __all__ = [
     'ResNet', 'ResNetV1c', 'ResNetV1d', 'ResNeXt', 'HRNet', 'FastSCNN',
     'ResNeSt', 'MobileNetV2', 'UNet', 'CGNet', 'MobileNetV3',
-    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer'
+    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer',
+    'ShuffleNetV2'
 ]

--- a/mmseg/models/backbones/shufflenet_v2.py
+++ b/mmseg/models/backbones/shufflenet_v2.py
@@ -262,8 +262,10 @@ class ShuffleNetV2(BaseModule):
         """Stack blocks to make a layer.
 
         Args:
-            out_channels (int): out_channels of the block.
-            num_blocks (int): number of blocks.
+            out_channels (int): The number of output channels of this stage.
+            num_blocks (int): The number of blocks of this stage.
+            stride (int): Stride of the first block.
+            dilation (int): Dilation of each block.
         """
         layers = []
         for i in range(num_blocks):

--- a/mmseg/models/backbones/shufflenet_v2.py
+++ b/mmseg/models/backbones/shufflenet_v2.py
@@ -1,0 +1,349 @@
+import copy
+
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint as cp
+from mmcv.cnn import ConvModule, constant_init, normal_init
+from mmcv.runner import BaseModule, load_checkpoint
+from torch.nn.modules.batchnorm import _BatchNorm
+
+from mmseg.utils import get_root_logger
+from ..builder import BACKBONES
+from ..utils import channel_shuffle
+
+
+class InvertedResidual(BaseModule):
+    """InvertedResidual block for ShuffleNetV2 backbone.
+
+    Args:
+        in_channels (int): The input channels of the block.
+        out_channels (int): The output channels of the block.
+        stride (int): Stride of the 3x3 convolution layer. Default: 1.
+        dilation (int): Dilation of the 3x3 convolution layer. Default: 1.
+        conv_cfg (dict, optional): Config dict for convolution layer.
+            Default: None, which means using conv2d.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='BN').
+        act_cfg (dict): Config dict for activation layer.
+            Default: dict(type='ReLU').
+        with_cp (bool): Use checkpoint or not. Using checkpoint will save some
+            memory while slowing down the training speed. Default: False.
+
+    Returns:
+        Tensor: The output tensor.
+    """
+
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 stride=1,
+                 dilation=1,
+                 conv_cfg=None,
+                 norm_cfg=dict(type='BN'),
+                 act_cfg=dict(type='ReLU'),
+                 with_cp=False,
+                 init_cfg=None):
+        super(InvertedResidual, self).__init__(init_cfg)
+        # Protect mutable default arguments
+        norm_cfg = copy.deepcopy(norm_cfg)
+        act_cfg = copy.deepcopy(act_cfg)
+        self.stride = stride
+        self.dilation = dilation
+        self.with_cp = with_cp
+
+        branch_features = out_channels // 2
+        if self.stride == 1:
+            assert in_channels == branch_features * 2, (
+                f'in_channels ({in_channels}) should equal to '
+                f'branch_features * 2 ({branch_features * 2}) '
+                'when stride is 1')
+
+        if in_channels != branch_features * 2:
+            assert self.stride != 1, (
+                f'stride ({self.stride}) should not equal 1 when '
+                f'in_channels != branch_features * 2')
+
+        if self.stride > 1:
+            self.branch1 = nn.Sequential(
+                ConvModule(
+                    in_channels,
+                    in_channels,
+                    kernel_size=3,
+                    stride=self.stride,
+                    dilation=self.dilation,
+                    padding=1,
+                    groups=in_channels,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    act_cfg=None),
+                ConvModule(
+                    in_channels,
+                    branch_features,
+                    kernel_size=1,
+                    stride=1,
+                    padding=0,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    act_cfg=act_cfg),
+            )
+
+        self.branch2 = nn.Sequential(
+            ConvModule(
+                in_channels if (self.stride > 1) else branch_features,
+                branch_features,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                conv_cfg=conv_cfg,
+                norm_cfg=norm_cfg,
+                act_cfg=act_cfg),
+            ConvModule(
+                branch_features,
+                branch_features,
+                kernel_size=3,
+                stride=self.stride,
+                dilation=self.dilation,
+                padding=1,
+                groups=branch_features,
+                conv_cfg=conv_cfg,
+                norm_cfg=norm_cfg,
+                act_cfg=None),
+            ConvModule(
+                branch_features,
+                branch_features,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                conv_cfg=conv_cfg,
+                norm_cfg=norm_cfg,
+                act_cfg=act_cfg))
+
+    def forward(self, x):
+
+        def _inner_forward(x):
+            if self.stride > 1:
+                out = torch.cat((self.branch1(x), self.branch2(x)), dim=1)
+            else:
+                x1, x2 = x.chunk(2, dim=1)
+                out = torch.cat((x1, self.branch2(x2)), dim=1)
+
+            out = channel_shuffle(out, 2)
+
+            return out
+
+        if self.with_cp and x.requires_grad:
+            out = cp.checkpoint(_inner_forward, x)
+        else:
+            out = _inner_forward(x)
+
+        return out
+
+
+@BACKBONES.register_module()
+class ShuffleNetV2(BaseModule):
+    """ShuffleNetV2 backbone.
+
+    Args:
+        widen_factor (float): Width multiplier - adjusts the number of
+            channels in each layer by this amount. Default: 1.0.
+        in_channels (int): Number of input image channels. Default: 3.
+        stem_channels (int): Number of stem channels. Default: 24.
+        out_indices (Sequence[int]): Output from which stages.
+            Default: (0, 1, 2, 3).
+        stage_blocks (Sequence[int]): The number of blocks in each stage.
+            Default: (4, 8, 4). num_stages = len(stage_blocks) +1, since an
+            extra conv will add to the last as one stage.
+        strides (Sequence[int]): Strides of the first block of each stage.
+            Default: (2, 2, 2).
+        dilations (Sequence[int]): Dilation of each stage.
+            Default: (1, 1, 1).
+        frozen_stages (int): Stages to be frozen (all param fixed).
+            Default: -1, which means not freezing any parameters.
+        conv_cfg (dict, optional): Config dict for convolution layer.
+            Default: None, which means using conv2d.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='BN').
+        act_cfg (dict): Config dict for activation layer.
+            Default: dict(type='ReLU').
+        norm_eval (bool): Whether to set norm layers to eval mode, namely,
+            freeze running stats (mean and var). Note: Effect on Batch Norm
+            and its variants only. Default: False.
+        contract_dilation (bool): Whether contract first dilation of each layer
+            Default: False.
+        with_cp (bool): Use checkpoint or not. Using checkpoint will save some
+            memory while slowing down the training speed. Default: False.
+        pretrained (str, optional): model pretrained path. Default: None.
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+            Default: None.
+    """
+
+    def __init__(self,
+                 widen_factor=1.0,
+                 in_channels=3,
+                 stem_channels=24,
+                 out_indices=(0, 1, 2, 3),
+                 stage_blocks=(4, 8, 4),
+                 strides=(2, 2, 2),
+                 dilations=(1, 1, 1),
+                 frozen_stages=-1,
+                 conv_cfg=None,
+                 norm_cfg=dict(type='BN'),
+                 act_cfg=dict(type='ReLU'),
+                 norm_eval=False,
+                 contract_dilation=False,
+                 with_cp=False,
+                 pretrained=None,
+                 init_cfg=None):
+        super(ShuffleNetV2, self).__init__(init_cfg)
+        self.pretrained = pretrained
+        # Protect mutable default arguments
+        self.init_cfg = copy.deepcopy(init_cfg)
+        norm_cfg = copy.deepcopy(norm_cfg)
+        act_cfg = copy.deepcopy(act_cfg)
+
+        self.out_indices = out_indices
+        self.stage_blocks = stage_blocks
+        self.strides = strides
+        self.dilations = dilations
+        assert len(strides) == len(dilations)
+        self.frozen_stages = frozen_stages
+        self.contract_dilation = contract_dilation
+        for index in out_indices:
+            if index not in range(len(stage_blocks) + 1):
+                raise ValueError(
+                    'the item in out_indices must in '
+                    f'range(0, {len(stage_blocks)+1}). But received {index}')
+
+        if frozen_stages not in range(-1, len(stage_blocks) + 2):
+            raise ValueError(
+                f'frozen_stages must be in range(-1, {len(stage_blocks)+2}). '
+                f'But received {frozen_stages}')
+
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.act_cfg = act_cfg
+        self.norm_eval = norm_eval
+        self.with_cp = with_cp
+
+        if widen_factor == 0.5:
+            channels = [48, 96, 192, 1024]
+        elif widen_factor == 1.0:
+            channels = [116, 232, 464, 1024]
+        elif widen_factor == 1.5:
+            channels = [176, 352, 704, 1024]
+        elif widen_factor == 2.0:
+            channels = [244, 488, 976, 2048]
+        else:
+            raise ValueError('widen_factor must be in [0.5, 1.0, 1.5, 2.0]. '
+                             f'But received {widen_factor}')
+
+        self.in_channels = stem_channels
+        self.conv1 = ConvModule(
+            in_channels=in_channels,
+            out_channels=stem_channels,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+            conv_cfg=conv_cfg,
+            norm_cfg=norm_cfg,
+            act_cfg=act_cfg)
+
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+        self.layers = nn.ModuleList()
+        for i, num_blocks in enumerate(self.stage_blocks):
+            layer = self._make_layer(channels[i], num_blocks, strides[i],
+                                     dilations[i])
+            self.layers.append(layer)
+
+        output_channels = channels[-1]
+        self.layers.append(
+            ConvModule(
+                in_channels=self.in_channels,
+                out_channels=output_channels,
+                kernel_size=1,
+                conv_cfg=conv_cfg,
+                norm_cfg=norm_cfg,
+                act_cfg=act_cfg))
+
+    def _make_layer(self, out_channels, num_blocks, stride, dilation):
+        """Stack blocks to make a layer.
+
+        Args:
+            out_channels (int): out_channels of the block.
+            num_blocks (int): number of blocks.
+        """
+        layers = []
+        for i in range(num_blocks):
+            stride_ = stride if i == 0 else 1
+            if i == 0 and dilation > 1 and self.contract_dilation:
+                dilation_ = dilation // 2
+            else:
+                dilation_ = dilation
+            layers.append(
+                InvertedResidual(
+                    in_channels=self.in_channels,
+                    out_channels=out_channels,
+                    stride=stride_,
+                    dilation=dilation_,
+                    conv_cfg=self.conv_cfg,
+                    norm_cfg=self.norm_cfg,
+                    act_cfg=self.act_cfg,
+                    with_cp=self.with_cp))
+            self.in_channels = out_channels
+
+        return nn.Sequential(*layers)
+
+    def _freeze_stages(self):
+        if self.frozen_stages >= 0:
+            for param in self.conv1.parameters():
+                param.requires_grad = False
+
+        for i in range(self.frozen_stages):
+            m = self.layers[i]
+            m.eval()
+            for param in m.parameters():
+                param.requires_grad = False
+
+    def init_weights(self):
+        """Initialize the weights in backbone."""
+        if isinstance(self.pretrained, str):
+            logger = get_root_logger()
+            load_checkpoint(self, self.pretrained, strict=False, logger=logger)
+        elif self.pretrained is None:
+            for name, m in self.named_modules():
+                if isinstance(m, nn.Conv2d):
+                    if 'conv1' in name:
+                        normal_init(m, mean=0, std=0.01)
+                    else:
+                        normal_init(m, mean=0, std=1.0 / m.weight.shape[1])
+                elif isinstance(m, (_BatchNorm, nn.GroupNorm)):
+                    constant_init(m, val=1, bias=0.0001)
+                    if isinstance(m, _BatchNorm):
+                        if m.running_mean is not None:
+                            nn.init.constant_(m.running_mean, 0)
+        else:
+            raise TypeError('pretrained must be a str or None. But received '
+                            f'{type(self.pretrained)}')
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.maxpool(x)
+
+        outs = []
+        for i, layer in enumerate(self.layers):
+            x = layer(x)
+            if i in self.out_indices:
+                outs.append(x)
+
+        return tuple(outs)
+
+    def train(self, mode=True):
+        """Convert the model into training mode while keep normalization layer
+        freezed."""
+        super(ShuffleNetV2, self).train(mode)
+        self._freeze_stages()
+        if mode and self.norm_eval:
+            for m in self.modules():
+                if isinstance(m, nn.BatchNorm2d):
+                    m.eval()

--- a/mmseg/models/utils/__init__.py
+++ b/mmseg/models/utils/__init__.py
@@ -1,3 +1,4 @@
+from .channel_shuffle import channel_shuffle
 from .ckpt_convert import mit_convert, swin_convert, vit_convert
 from .embed import PatchEmbed
 from .inverted_residual import InvertedResidual, InvertedResidualV3
@@ -11,5 +12,6 @@ from .up_conv_block import UpConvBlock
 __all__ = [
     'ResLayer', 'SelfAttentionBlock', 'make_divisible', 'InvertedResidual',
     'UpConvBlock', 'InvertedResidualV3', 'SELayer', 'vit_convert',
-    'mit_convert', 'swin_convert', 'PatchEmbed', 'nchw_to_nlc', 'nlc_to_nchw'
+    'mit_convert', 'swin_convert', 'PatchEmbed', 'nchw_to_nlc', 'nlc_to_nchw',
+    'channel_shuffle'
 ]

--- a/mmseg/models/utils/channel_shuffle.py
+++ b/mmseg/models/utils/channel_shuffle.py
@@ -1,0 +1,28 @@
+import torch
+
+
+def channel_shuffle(x, groups):
+    """Channel Shuffle operation.
+
+    This function enables cross-group information flow for multiple groups
+    convolution layers.
+
+    Args:
+        x (Tensor): The input tensor.
+        groups (int): The number of groups to divide the input tensor
+            in the channel dimension.
+
+    Returns:
+        Tensor: The output tensor after channel shuffle operation.
+    """
+
+    batch_size, num_channels, height, width = x.size()
+    assert (num_channels % groups == 0), ('num_channels should be '
+                                          'divisible by groups')
+    channels_per_group = num_channels // groups
+
+    x = x.view(batch_size, groups, channels_per_group, height, width)
+    x = torch.transpose(x, 1, 2).contiguous()
+    x = x.view(batch_size, -1, height, width)
+
+    return x

--- a/tests/test_models/test_backbones/test_shufflenet_v2.py
+++ b/tests/test_models/test_backbones/test_shufflenet_v2.py
@@ -1,0 +1,197 @@
+import pytest
+import torch
+from mmcv.utils import is_tuple_of
+from torch.nn.modules.batchnorm import _BatchNorm
+
+from mmseg.models.backbones import ShuffleNetV2
+from mmseg.models.backbones.shufflenet_v2 import InvertedResidual
+from .utils import check_norm_state, is_norm
+
+
+def is_block(modules):
+    """Check if is ResNet building block."""
+    if isinstance(modules, (InvertedResidual, )):
+        return True
+    return False
+
+
+def test_shufflenetv2_invertedresidual():
+
+    with pytest.raises(AssertionError):
+        # when stride==1, in_channels should be equal to out_channels // 2 * 2
+        InvertedResidual(24, 32, stride=1)
+
+    with pytest.raises(AssertionError):
+        # when in_channels !=  out_channels // 2 * 2, stride should not be
+        # equal to 1.
+        InvertedResidual(24, 32, stride=1)
+
+    # Test InvertedResidual forward
+    block = InvertedResidual(24, 48, stride=2)
+    x = torch.randn(1, 24, 56, 56)
+    x_out = block(x)
+    assert x_out.shape == torch.Size((1, 48, 28, 28))
+
+    # Test InvertedResidual with checkpoint forward
+    block = InvertedResidual(48, 48, stride=1, with_cp=True)
+    assert block.with_cp
+    x = torch.randn(1, 48, 56, 56)
+    x.requires_grad = True
+    x_out = block(x)
+    assert x_out.shape == torch.Size((1, 48, 56, 56))
+
+
+def test_shufflenetv2_backbone():
+
+    with pytest.raises(ValueError):
+        # groups must be in 0.5, 1.0, 1.5, 2.0]
+        ShuffleNetV2(widen_factor=3.0)
+
+    with pytest.raises(ValueError):
+        # frozen_stages must be in [0, 1, 2, 3, 4]
+        ShuffleNetV2(widen_factor=1.0, frozen_stages=5)
+
+    with pytest.raises(ValueError):
+        # out_indices must be in [0, 1, 2, 3]
+        ShuffleNetV2(widen_factor=1.0, out_indices=(4, ))
+
+    with pytest.raises(TypeError):
+        # pretrained must be str or None
+        model = ShuffleNetV2()
+        model.init_weights(pretrained=1)
+
+    # Test ShuffleNetV2 norm state
+    model = ShuffleNetV2()
+    model.init_weights()
+    model.train()
+    assert check_norm_state(model.modules(), True)
+
+    # Test ShuffleNetV2 with first stage frozen
+    frozen_stages = 1
+    model = ShuffleNetV2(frozen_stages=frozen_stages)
+    model.init_weights()
+    model.train()
+    for param in model.conv1.parameters():
+        assert param.requires_grad is False
+    for i in range(0, frozen_stages):
+        layer = model.layers[i]
+        for mod in layer.modules():
+            if isinstance(mod, _BatchNorm):
+                assert mod.training is False
+        for param in layer.parameters():
+            assert param.requires_grad is False
+
+    # Test ShuffleNetV2 with norm_eval
+    model = ShuffleNetV2(norm_eval=True)
+    model.init_weights()
+    model.train()
+
+    assert check_norm_state(model.modules(), False)
+
+    # Test ShuffleNetV2 forward with widen_factor=0.5
+    model = ShuffleNetV2(widen_factor=0.5, out_indices=(0, 1, 2, 3))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 4
+    assert is_tuple_of(feat, torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 48, 28, 28))
+    assert feat[1].shape == torch.Size((1, 96, 14, 14))
+    assert feat[2].shape == torch.Size((1, 192, 7, 7))
+    assert feat[3].shape == torch.Size((1, 1024, 7, 7))
+
+    # Test ShuffleNetV2 forward with widen_factor=1.0
+    model = ShuffleNetV2(widen_factor=1.0, out_indices=(0, 1, 2, 3))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 4
+    assert is_tuple_of(feat, torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 116, 28, 28))
+    assert feat[1].shape == torch.Size((1, 232, 14, 14))
+    assert feat[2].shape == torch.Size((1, 464, 7, 7))
+    assert feat[3].shape == torch.Size((1, 1024, 7, 7))
+
+    # Test ShuffleNetV2 forward with widen_factor=1.5
+    model = ShuffleNetV2(widen_factor=1.5, out_indices=(0, 1, 2, 3))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 4
+    assert is_tuple_of(feat, torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 176, 28, 28))
+    assert feat[1].shape == torch.Size((1, 352, 14, 14))
+    assert feat[2].shape == torch.Size((1, 704, 7, 7))
+    assert feat[3].shape == torch.Size((1, 1024, 7, 7))
+
+    # Test ShuffleNetV2 forward with widen_factor=2.0
+    model = ShuffleNetV2(widen_factor=2.0, out_indices=(0, 1, 2, 3))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 4
+    assert is_tuple_of(feat, torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 244, 28, 28))
+    assert feat[1].shape == torch.Size((1, 488, 14, 14))
+    assert feat[2].shape == torch.Size((1, 976, 7, 7))
+    assert feat[3].shape == torch.Size((1, 2048, 7, 7))
+
+    # Test ShuffleNetV2 forward with layers 3 forward
+    model = ShuffleNetV2(widen_factor=1.0, out_indices=(2, ))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert is_tuple_of(feat, torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 464, 7, 7))
+
+    # Test ShuffleNetV2 forward with layers 1 2 forward
+    model = ShuffleNetV2(widen_factor=1.0, out_indices=(1, 2))
+    model.init_weights()
+    model.train()
+
+    for m in model.modules():
+        if is_norm(m):
+            assert isinstance(m, _BatchNorm)
+
+    imgs = torch.randn(1, 3, 224, 224)
+    feat = model(imgs)
+    assert len(feat) == 2
+    assert is_tuple_of(feat, torch.Tensor)
+    assert feat[0].shape == torch.Size((1, 232, 14, 14))
+    assert feat[1].shape == torch.Size((1, 464, 7, 7))
+
+    # Test ShuffleNetV2 forward with checkpoint forward
+    model = ShuffleNetV2(widen_factor=1.0, with_cp=True)
+    for m in model.modules():
+        if is_block(m):
+            assert m.with_cp

--- a/tests/test_models/test_backbones/test_shufflenet_v2.py
+++ b/tests/test_models/test_backbones/test_shufflenet_v2.py
@@ -106,7 +106,7 @@ def test_shufflenetv2_backbone():
         for param in layer.parameters():
             assert param.requires_grad is False
 
-    # Test ShuffleNetV2 with first stage frozen, frozen_stages=4
+    # Test ShuffleNetV2 with all stages frozen, frozen_stages=4
     frozen_stages = 4
     model = ShuffleNetV2(frozen_stages=frozen_stages)
     model.init_weights()


### PR DESCRIPTION
## Motivation

Support more real-time semantic segmentation models.
In this PR, we add ShuffleNetV2.

## Modification

- [x] Add ShuffleNetV2 backbone and unitests
- [ ] Add configs for ShuffleNetV2
- [ ]  Add benchmarks for ShuffleNetV2

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos? 
No


