### PR TITLE
[Enhancement] support user inherit cityscapes dataset

### DIFF
--- a/mmseg/datasets/cityscapes.py
+++ b/mmseg/datasets/cityscapes.py
@@ -30,10 +30,9 @@ class CityscapesDataset(CustomDataset):
                [0, 80, 100], [0, 0, 230], [119, 11, 32]]
 
     def __init__(self, **kwargs):
-        super(CityscapesDataset, self).__init__(
-            img_suffix='_leftImg8bit.png',
-            seg_map_suffix='_gtFine_labelTrainIds.png',
-            **kwargs)
+        kwargs.setdefault('img_suffix', '_leftImg8bit.png')
+        kwargs.setdefault('seg_map_suffix', '_gtFine_labelTrainIds.png')
+        super(CityscapesDataset, self).__init__(**kwargs)
 
     @staticmethod
     def _convert_to_label_id(result):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support user custom dataset by inheriting `Cityscapes` class, the original implementation requires user's image suffix same with cityscapes, it's not flexible.

## Modification

Set default value to the constructor function parameter.

## Use cases (Optional)

```python
@DATASETS.register_module()
class MyDataset(CityscapesDataset):
    """MyDatasett."""

    def __init__(self, **kwargs):
        super().__init__(
            img_suffix='_train.png',
            seg_map_suffix='_gt_mask.png',
            **kwargs)
```
