### PR TITLE
[Fix] Citations format of ANN

### DIFF
--- a/configs/ann/README.md
+++ b/configs/ann/README.md
@@ -5,16 +5,12 @@
 <!-- [ALGORITHM] -->
 
 ```latex
-@inproceedings{annn,
-  author    = {Zhen Zhu and
-               Mengde Xu and
-               Song Bai and
-               Tengteng Huang and
-               Xiang Bai},
-  title     = {Asymmetric Non-local Neural Networks for Semantic Segmentation},
-  booktitle={International Conference on Computer Vision},
-  year      = {2019},
-  url       = {http://arxiv.org/abs/1908.07678},
+@inproceedings{zhu2019asymmetric,
+  title={Asymmetric non-local neural networks for semantic segmentation},
+  author={Zhu, Zhen and Xu, Mengde and Bai, Song and Huang, Tengteng and Bai, Xiang},
+  booktitle={Proceedings of the IEEE/CVF International Conference on Computer Vision},
+  pages={593--602},
+  year={2019}
 }
 ```
 


### PR DESCRIPTION
Modification:
From 
```latex
@inproceedings{annn,
  author    = {Zhen Zhu and
               Mengde Xu and
               Song Bai and
               Tengteng Huang and
               Xiang Bai},
  title     = {Asymmetric Non-local Neural Networks for Semantic Segmentation},
  booktitle={International Conference on Computer Vision},
  year      = {2019},
  url       = {http://arxiv.org/abs/1908.07678},
}
```

to
```latex
@inproceedings{zhu2019asymmetric,
  title={Asymmetric non-local neural networks for semantic segmentation},
  author={Zhu, Zhen and Xu, Mengde and Bai, Song and Huang, Tengteng and Bai, Xiang},
  booktitle={Proceedings of the IEEE/CVF International Conference on Computer Vision},
  pages={593--602},
  year={2019}
}
```