### PR TITLE
[Fix] Fix the README of Swin 

### DIFF
--- a/configs/swin/README.md
+++ b/configs/swin/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-[ALGORITHM]
+<!-- [ALGORITHM] -->
 
 ```latex
 @article{liu2021Swin,


### PR DESCRIPTION
Fix the README of Swin.

Motivation
Failed to build [Model Zoo Statistics](https://mmsegmentation.readthedocs.io/en/latest/).
[Fixed](https://mmsegmentation--764.org.readthedocs.build/en/764/modelzoo_statistics.html) in this PR.