### PR TITLE
[Fix] Fix the log error 

### DIFF
--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -107,7 +107,8 @@ def train_segmentor(model,
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook
-        runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
+        runner.register_hook(
+            eval_hook(val_dataloader, **eval_cfg), priority='LOW')
 
     if cfg.resume_from:
         runner.resume(cfg.resume_from)

--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -107,6 +107,8 @@ def train_segmentor(model,
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook
+        # In this https://github.com/open-mmlab/mmcv/pull/1193, the priority
+        # of IterTimerHook has been changed from 'Normal' to 'LOW'.
         runner.register_hook(
             eval_hook(val_dataloader, **eval_cfg), priority='LOW')
 

--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -107,8 +107,8 @@ def train_segmentor(model,
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook
-        # In this https://github.com/open-mmlab/mmcv/pull/1193, the priority
-        # of IterTimerHook has been changed from 'Normal' to 'LOW'.
+        # In this PR (https://github.com/open-mmlab/mmcv/pull/1193), the
+        # priority of IterTimerHook has been modified from 'NORMAL' to 'LOW'.
         runner.register_hook(
             eval_hook(val_dataloader, **eval_cfg), priority='LOW')
 


### PR DESCRIPTION
## Motivation

If the priority of EvalHook is higher than IterTimerHook, it will cause `KeyError: 'data_time'` (#758).
Since the `time` key will add to the output of log_buffer after IterTimeHook, the TextLoggerHook will print the `time` and  `data_time` at the same time.

This PR is based on https://github.com/open-mmlab/mmcv/pull/1252.
## Modification

Set the priority of EvalHook to LOW.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
No.

