### PR TITLE
Add Deit class with dist_token implemented

### DIFF
--- a/configs/vit/upernet_deit-b16_512x512_160k_ade20k.py
+++ b/configs/vit/upernet_deit-b16_512x512_160k_ade20k.py
@@ -2,5 +2,6 @@ _base_ = './upernet_vit-b16_mln_512x512_160k_ade20k.py'
 
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth',  # noqa
-    backbone=dict(drop_path_rate=0.1),
+    backbone=dict(type='Deit',
+                  drop_path_rate=0.1),
     neck=None)  # yapf: disable

--- a/configs/vit/upernet_deit-b16_512x512_80k_ade20k.py
+++ b/configs/vit/upernet_deit-b16_512x512_80k_ade20k.py
@@ -2,5 +2,6 @@ _base_ = './upernet_vit-b16_mln_512x512_80k_ade20k.py'
 
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth',  # noqa
-    backbone=dict(drop_path_rate=0.1),
+    backbone=dict(type='Deit', 
+                  drop_path_rate=0.1),
     neck=None)  # yapf: disable

--- a/configs/vit/upernet_deit-b16_ln_mln_512x512_160k_ade20k.py
+++ b/configs/vit/upernet_deit-b16_ln_mln_512x512_160k_ade20k.py
@@ -2,4 +2,4 @@ _base_ = './upernet_vit-b16_mln_512x512_160k_ade20k.py'
 
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth',  # noqa
-    backbone=dict(drop_path_rate=0.1, final_norm=True))  # yapf: disable
+    backbone=dict(type='Deit', drop_path_rate=0.1, final_norm=True))  # yapf: disable

--- a/configs/vit/upernet_deit-b16_mln_512x512_160k_ade20k.py
+++ b/configs/vit/upernet_deit-b16_mln_512x512_160k_ade20k.py
@@ -2,4 +2,4 @@ _base_ = './upernet_vit-b16_mln_512x512_160k_ade20k.py'
 
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_base_patch16_224-b5f2ef4d.pth',  # noqa
-    backbone=dict(drop_path_rate=0.1),)  # yapf: disable
+    backbone=dict(type='Deit', drop_path_rate=0.1),)  # yapf: disable

--- a/configs/vit/upernet_deit-s16_512x512_160k_ade20k.py
+++ b/configs/vit/upernet_deit-s16_512x512_160k_ade20k.py
@@ -2,7 +2,7 @@ _base_ = './upernet_vit-b16_mln_512x512_160k_ade20k.py'
 
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_small_patch16_224-cd65a155.pth',  # noqa
-    backbone=dict(num_heads=6, embed_dims=384, drop_path_rate=0.1),
+    backbone=dict(type='Deit', num_heads=6, embed_dims=384, drop_path_rate=0.1),
     decode_head=dict(num_classes=150, in_channels=[384, 384, 384, 384]),
     neck=None,
     auxiliary_head=dict(num_classes=150, in_channels=384))  # yapf: disable

--- a/configs/vit/upernet_deit-s16_512x512_80k_ade20k.py
+++ b/configs/vit/upernet_deit-s16_512x512_80k_ade20k.py
@@ -2,7 +2,7 @@ _base_ = './upernet_vit-b16_mln_512x512_80k_ade20k.py'
 
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_small_patch16_224-cd65a155.pth',  # noqa
-    backbone=dict(num_heads=6, embed_dims=384, drop_path_rate=0.1),
+    backbone=dict(type='Deit', num_heads=6, embed_dims=384, drop_path_rate=0.1),
     decode_head=dict(num_classes=150, in_channels=[384, 384, 384, 384]),
     neck=None,
     auxiliary_head=dict(num_classes=150, in_channels=384))  # yapf: disable

--- a/configs/vit/upernet_deit-s16_ln_mln_512x512_160k_ade20k.py
+++ b/configs/vit/upernet_deit-s16_ln_mln_512x512_160k_ade20k.py
@@ -3,6 +3,7 @@ _base_ = './upernet_vit-b16_mln_512x512_160k_ade20k.py'
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_small_patch16_224-cd65a155.pth',  # noqa
     backbone=dict(
+        type='Deit',
         num_heads=6,
         embed_dims=384,
         drop_path_rate=0.1,

--- a/configs/vit/upernet_deit-s16_mln_512x512_160k_ade20k.py
+++ b/configs/vit/upernet_deit-s16_mln_512x512_160k_ade20k.py
@@ -2,7 +2,7 @@ _base_ = './upernet_vit-b16_mln_512x512_160k_ade20k.py'
 
 model = dict(
     pretrained='https://dl.fbaipublicfiles.com/deit/deit_small_patch16_224-cd65a155.pth',  # noqa
-    backbone=dict(num_heads=6, embed_dims=384, drop_path_rate=0.1),
+    backbone=dict(type='Deit', num_heads=6, embed_dims=384, drop_path_rate=0.1),
     decode_head=dict(num_classes=150, in_channels=[384, 384, 384, 384]),
     neck=dict(in_channels=[384, 384, 384, 384], out_channels=384),
     auxiliary_head=dict(num_classes=150, in_channels=384))  # yapf: disable

--- a/mmseg/models/backbones/__init__.py
+++ b/mmseg/models/backbones/__init__.py
@@ -10,9 +10,11 @@ from .resnext import ResNeXt
 from .swin import SwinTransformer
 from .unet import UNet
 from .vit import VisionTransformer
+from .deit import Deit
 
 __all__ = [
     'ResNet', 'ResNetV1c', 'ResNetV1d', 'ResNeXt', 'HRNet', 'FastSCNN',
     'ResNeSt', 'MobileNetV2', 'UNet', 'CGNet', 'MobileNetV3',
-    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer'
+    'VisionTransformer', 'SwinTransformer', 'MixVisionTransformer',
+    'Deit'
 ]

--- a/mmseg/models/backbones/deit.py
+++ b/mmseg/models/backbones/deit.py
@@ -1,0 +1,314 @@
+import math
+import warnings
+
+import torch
+import torch.nn as nn
+from mmcv.cnn import (build_norm_layer, constant_init, kaiming_init,
+                      normal_init, trunc_normal_init)
+from mmcv.cnn.bricks.transformer import FFN, MultiheadAttention
+from mmcv.runner import BaseModule, ModuleList, _load_checkpoint
+from torch.nn.modules.batchnorm import _BatchNorm
+from torch.nn.modules.utils import _pair as to_2tuple
+
+from mmseg.ops import resize
+from mmseg.utils import get_root_logger
+from ..builder import BACKBONES
+from ..utils import PatchEmbed, vit_convert
+
+from mmseg.models.backbones.vit import TransformerEncoderLayer, VisionTransformer
+
+@BACKBONES.register_module()
+class Deit(VisionTransformer):
+    """Vision Transformer variant. (Deit)
+
+    A PyTorch implement of : `DeiT: Data-efficient Image Transformers` -
+        https://arxiv.org/abs/2012.12877
+
+    Compared with ViT:
+        a) add self.dist_token attribute beside cls_token
+        b) init method of self.pos_embed: torch.zeros->torch.randn
+
+    Args:
+        img_size (int | tuple): Input image size. Default: 224.
+        patch_size (int): The patch size. Default: 16.
+        in_channels (int): Number of input channels. Default: 3.
+        embed_dims (int): embedding dimension. Default: 768.
+        num_layers (int): depth of transformer. Default: 12.
+        num_heads (int): number of attention heads. Default: 12.
+        mlp_ratio (int): ratio of mlp hidden dim to embedding dim.
+            Default: 4.
+        out_indices (list | tuple | int): Output from which stages.
+            Default: -1.
+        qkv_bias (bool): enable bias for qkv if True. Default: True.
+        drop_rate (float): Probability of an element to be zeroed.
+            Default 0.0
+        attn_drop_rate (float): The drop out rate for attention layer.
+            Default 0.0
+        drop_path_rate (float): stochastic depth rate. Default 0.0
+        with_cls_token (bool): Whether concatenating class token into image
+            tokens as transformer input. Default: True.
+        output_cls_token (bool): Whether output the cls_token. If set True,
+            `with_cls_token` must be True. Default: False.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='LN')
+        act_cfg (dict): The activation config for FFNs.
+            Defalut: dict(type='GELU').
+        patch_norm (bool): Whether to add a norm in PatchEmbed Block.
+            Default: False.
+        final_norm (bool): Whether to add a additional layer to normalize
+            final feature map. Default: False.
+        interpolate_mode (str): Select the interpolate mode for position
+            embeding vector resize. Default: bicubic.
+        num_fcs (int): The number of fully-connected layers for FFNs.
+            Default: 2.
+        norm_eval (bool): Whether to set norm layers to eval mode, namely,
+            freeze running stats (mean and var). Note: Effect on Batch Norm
+            and its variants only. Default: False.
+        with_cp (bool): Use checkpoint or not. Using checkpoint will save
+            some memory while slowing down the training speed. Default: False.
+        pretrain_style (str): Choose to use timm or mmcls pretrain weights.
+            Default: timm.
+        pretrained (str, optional): model pretrained path. Default: None.
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+            Default: None.
+    """
+
+    def __init__(self,
+                 img_size=224,
+                 patch_size=16,
+                 in_channels=3,
+                 embed_dims=768,
+                 num_layers=12,
+                 num_heads=12,
+                 mlp_ratio=4,
+                 out_indices=-1,
+                 qkv_bias=True,
+                 drop_rate=0.,
+                 attn_drop_rate=0.,
+                 drop_path_rate=0.,
+                 with_cls_token=True,
+                 output_cls_token=False,
+                 norm_cfg=dict(type='LN'),
+                 act_cfg=dict(type='GELU'),
+                 patch_norm=False,
+                 final_norm=False,
+                 interpolate_mode='bicubic',
+                 num_fcs=2,
+                 norm_eval=False,
+                 with_cp=False,
+                 pretrain_style='timm',
+                 pretrained=None,
+                 init_cfg=None):
+        super(Deit, self).__init__()
+
+        if isinstance(img_size, int):
+            img_size = to_2tuple(img_size)
+        elif isinstance(img_size, tuple):
+            if len(img_size) == 1:
+                img_size = to_2tuple(img_size[0])
+            assert len(img_size) == 2, \
+                f'The size of image should have length 1 or 2, ' \
+                f'but got {len(img_size)}'
+
+        assert pretrain_style in ['timm', 'mmcls']
+
+        if output_cls_token:
+            assert with_cls_token is True, f'with_cls_token must be True if' \
+                f'set output_cls_token to True, but got {with_cls_token}'
+
+        if isinstance(pretrained, str) or pretrained is None:
+            warnings.warn('DeprecationWarning: pretrained is a deprecated, '
+                          'please use "init_cfg" instead')
+        else:
+            raise TypeError('pretrained must be a str or None')
+
+        self.img_size = img_size
+        self.patch_size = patch_size
+        self.interpolate_mode = interpolate_mode
+        self.norm_eval = norm_eval
+        self.with_cp = with_cp
+        self.pretrain_style = pretrain_style
+        self.pretrained = pretrained
+        self.init_cfg = init_cfg
+
+        self.patch_embed = PatchEmbed(
+            in_channels=in_channels,
+            embed_dims=embed_dims,
+            conv_type='Conv2d',
+            kernel_size=patch_size,
+            stride=patch_size,
+            pad_to_patch_size=True,
+            norm_cfg=norm_cfg if patch_norm else None,
+            init_cfg=None,
+        )
+
+        num_patches = (img_size[0] // patch_size) * \
+            (img_size[1] // patch_size)
+
+        self.with_cls_token = with_cls_token
+        self.output_cls_token = output_cls_token
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dims))
+        self.dist_token = nn.Parameter(torch.zeros(1, 1, embed_dims))
+        self.pos_embed = nn.Parameter(torch.randn(1, num_patches + 2, embed_dims))
+        self.drop_after_pos = nn.Dropout(p=drop_rate)
+
+        if isinstance(out_indices, int):
+            if out_indices == -1:
+                out_indices = num_layers - 1
+            self.out_indices = [out_indices]
+        elif isinstance(out_indices, list) or isinstance(out_indices, tuple):
+            self.out_indices = out_indices
+        else:
+            raise TypeError('out_indices must be type of int, list or tuple')
+
+        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, num_layers)]  # stochastic depth decay rule
+
+        self.layers = ModuleList()
+        for i in range(num_layers):
+            self.layers.append(
+                TransformerEncoderLayer(
+                    embed_dims=embed_dims,
+                    num_heads=num_heads,
+                    feedforward_channels=mlp_ratio * embed_dims,
+                    attn_drop_rate=attn_drop_rate,
+                    drop_rate=drop_rate,
+                    drop_path_rate=dpr[i],
+                    num_fcs=num_fcs,
+                    qkv_bias=qkv_bias,
+                    act_cfg=act_cfg,
+                    norm_cfg=norm_cfg,
+                    batch_first=True))
+
+        self.final_norm = final_norm
+        if final_norm:
+            self.norm1_name, norm1 = build_norm_layer(
+                norm_cfg, embed_dims, postfix=1)
+            self.add_module(self.norm1_name, norm1)
+
+    def init_weights(self):
+        if isinstance(self.pretrained, str):
+            logger = get_root_logger()
+            checkpoint = _load_checkpoint(self.pretrained, logger=logger, map_location='cpu')
+            if 'state_dict' in checkpoint:
+                state_dict = checkpoint['state_dict']
+            elif 'model' in checkpoint:
+                state_dict = checkpoint['model']
+            else:
+                state_dict = checkpoint
+
+            if self.pretrain_style == 'timm':
+                # Because the refactor of vit is blocked by mmcls,
+                # so we firstly use timm pretrain weights to train
+                # downstream model.
+                state_dict = vit_convert(state_dict)
+
+            if 'pos_embed' in state_dict.keys():
+                if self.pos_embed.shape != state_dict['pos_embed'].shape:
+                    logger.info(msg=f'Resize the pos_embed shape from '
+                                f'{state_dict["pos_embed"].shape} to '
+                                f'{self.pos_embed.shape}')
+                    h, w = self.img_size
+                    pos_size = int(math.sqrt(state_dict['pos_embed'].shape[1] - 1))
+                    state_dict['pos_embed'] = self.resize_pos_embed(
+                        state_dict['pos_embed'],
+                        (h // self.patch_size, w // self.patch_size),
+                        (pos_size, pos_size),
+                        self.interpolate_mode)
+
+            self.load_state_dict(state_dict, False)
+
+    @staticmethod
+    def resize_pos_embed(pos_embed, input_shpae, pos_shape, mode):
+        """Resize pos_embed weights.
+
+        Resize pos_embed using bicubic interpolate method.
+        Args:
+            pos_embed (torch.Tensor): Position embedding weights.
+            input_shpae (tuple): Tuple for (downsampled input image height,
+                downsampled input image width).
+            pos_shape (tuple): The resolution of downsampled origin training
+                image.
+            mode (str): Algorithm used for upsampling:
+                ``'nearest'`` | ``'linear'`` | ``'bilinear'`` | ``'bicubic'`` |
+                ``'trilinear'``. Default: ``'nearest'``
+        Return:
+            torch.Tensor: The resized pos_embed of shape [B, L_new, C]
+        """
+        assert pos_embed.ndim == 3, 'shape of pos_embed must be [B, L, C]'
+        pos_h, pos_w = pos_shape
+        cls_token_weight = pos_embed[:, 0]
+        dist_token_weight = pos_embed[:, 1]
+        pos_embed_weight = pos_embed[:, (-1 * pos_h * pos_w):]
+        pos_embed_weight = pos_embed_weight.reshape(
+            1, pos_h, pos_w, pos_embed.shape[2]).permute(0, 3, 1, 2)
+        pos_embed_weight = resize(
+            pos_embed_weight, size=input_shpae, align_corners=False, mode=mode)
+        cls_token_weight = cls_token_weight.unsqueeze(1)
+        dist_token_weight = dist_token_weight.unsqueeze(1)
+        pos_embed_weight = torch.flatten(pos_embed_weight, 2).transpose(1, 2)
+        pos_embed = torch.cat((cls_token_weight, dist_token_weight, pos_embed_weight), dim=1)
+        return pos_embed
+
+    def _pos_embeding(self, patched_img, hw_shape, pos_embed):
+        """Positiong embeding method.
+
+        Resize the pos_embed, if the input image size doesn't match
+            the training size.
+        Args:
+            patched_img (torch.Tensor): The patched image, it should be
+                shape of [B, L1, C].
+            hw_shape (tuple): The downsampled image resolution.
+            pos_embed (torch.Tensor): The pos_embed weighs, it should be
+                shape of [B, L2, c].
+        Return:
+            torch.Tensor: The pos encoded image feature.
+        """
+        assert patched_img.ndim == 3 and pos_embed.ndim == 3, 'the shapes of patched_img and pos_embed must be [B, L, C]'
+        x_len, pos_len = patched_img.shape[1], pos_embed.shape[1]
+        if x_len != pos_len:
+            if pos_len == (self.img_size[0] // self.patch_size) * (self.img_size[1] // self.patch_size) + 2:
+                pos_h = self.img_size[0] // self.patch_size
+                pos_w = self.img_size[1] // self.patch_size
+            else:
+                raise ValueError('Unexpected shape of pos_embed, got {}.'.format(pos_embed.shape))
+            pos_embed = self.resize_pos_embed(pos_embed, hw_shape,
+                                              (pos_h, pos_w),
+                                              self.interpolate_mode)
+        return self.drop_after_pos(patched_img + pos_embed)
+
+    def forward(self, inputs):
+        B = inputs.shape[0]
+
+        x, hw_shape = self.patch_embed(inputs), (self.patch_embed.DH,
+                                                 self.patch_embed.DW)
+        # stole cls_tokens impl from Phil Wang, thanks
+        cls_tokens = self.cls_token.expand(B, -1, -1)
+        dist_tokens = self.dist_token.expand(B, -1, -1)
+        x = torch.cat((cls_tokens, dist_tokens, x), dim=1)
+        x = self._pos_embeding(x, hw_shape, self.pos_embed)
+
+        if not self.with_cls_token:
+            # Remove class token for transformer encoder input
+            x = x[:, 2:]
+
+        outs = []
+        for i, layer in enumerate(self.layers):
+            x = layer(x)
+            if i == len(self.layers) - 1:
+                if self.final_norm:
+                    x = self.norm1(x)
+            if i in self.out_indices:
+                if self.with_cls_token:
+                    # Remove class token and reshape token for decoder head
+                    out = x[:, 2:]
+                else:
+                    out = x
+                # print(f'index {i}: output.shape = {out.shape}')
+                B, _, C = out.shape
+                out = out.reshape(B, hw_shape[0], hw_shape[1],
+                                  C).permute(0, 3, 1, 2)
+                if self.output_cls_token:
+                    out = [out, x[:, 0]]
+                outs.append(out)
+
+        return tuple(outs)


### PR DESCRIPTION
## Motivation

Add Deit class explicitly. Because there are some papers implementd Transformer based on Deit with its ori structure.
"Few parameters in dist_toked may be not influential to the results, but may be useful for `obsessive` person 23333"

## Modification

	modified:   configs/vit/upernet_deit-b16_512x512_160k_ade20k.py
	modified:   configs/vit/upernet_deit-b16_512x512_80k_ade20k.py
	modified:   configs/vit/upernet_deit-b16_ln_mln_512x512_160k_ade20k.py
	modified:   configs/vit/upernet_deit-b16_mln_512x512_160k_ade20k.py
	modified:   configs/vit/upernet_deit-s16_512x512_160k_ade20k.py
	modified:   configs/vit/upernet_deit-s16_512x512_80k_ade20k.py
	modified:   configs/vit/upernet_deit-s16_ln_mln_512x512_160k_ade20k.py
	modified:   configs/vit/upernet_deit-s16_mln_512x512_160k_ade20k.py
	modified:   mmseg/models/backbones/__init__.py
	new file:   mmseg/models/backbones/deit.py