### PR TITLE
[Fix] Ensure items in dataset have the same order across multi machine

### DIFF
--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -151,6 +151,7 @@ class CustomDataset(Dataset):
                     seg_map = img.replace(img_suffix, seg_map_suffix)
                     img_info['ann'] = dict(seg_map=seg_map)
                 img_infos.append(img_info)
+            img_infos = sorted(img_infos, key=lambda x: x['filename'])
 
         print_log(f'Loaded {len(img_infos)} images', logger=get_root_logger())
         return img_infos


### PR DESCRIPTION


## Motivation
ensure items in dataset have the same order across multi machine

## Modification
sort items according to their filenames when using scandir 

