### PR TITLE
[Fix] Fix random behavior of update_model_index in pre-commit hook

### DIFF
--- a/.dev/md2yml.py
+++ b/.dev/md2yml.py
@@ -25,17 +25,23 @@ def dump_yaml_and_check_difference(obj, filename):
     Returns:
         Bool: If the target YAML file is different from the original.
     """
-    original = None
+
+    str_dump = mmcv.dump(obj, None, file_format='yaml', sort_keys=True)
     if osp.isfile(filename):
+        file_exists = True
         with open(filename, 'r', encoding='utf-8') as f:
-            original = f.read()
-    with open(filename, 'w', encoding='utf-8') as f:
-        mmcv.dump(obj, f, file_format='yaml', sort_keys=False)
-    is_different = True
-    if original is not None:
-        with open(filename, 'r') as f:
-            new = f.read()
-        is_different = (original != new)
+            str_orig = f.read()
+    else:
+        file_exists = False
+        str_orig = None
+
+    if file_exists and str_orig == str_dump:
+        is_different = False
+    else:
+        is_different = True
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write(str_dump)
+
     return is_different
 
 
@@ -183,11 +189,11 @@ def update_model_index():
 if __name__ == '__main__':
     file_list = [fn for fn in sys.argv[1:] if osp.basename(fn) == 'README.md']
     if not file_list:
-        exit(0)
+        sys.exit(0)
     file_modified = False
     for fn in file_list:
         file_modified |= parse_md(fn)
 
     file_modified |= update_model_index()
 
-    exit(1 if file_modified else 0)
+    sys.exit(1 if file_modified else 0)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,4 @@ repos:
         additional_dependencies: [mmcv]
         language: python
         files: ^configs/.*\.md$
+        require_serial: true

--- a/configs/ann/ann.yml
+++ b/configs/ann/ann.yml
@@ -1,296 +1,296 @@
 Collections:
-- Name: ann
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: ann
 Models:
-- Name: ann_r50-d8_512x1024_40k_cityscapes
+- Config: configs/ann/ann_r50-d8_512x1024_40k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 269.54
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 269.54
+    lr schd: 40000
     memory (GB): 6.0
+  Name: ann_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.4
       mIoU(ms+flip): 78.57
-  Config: configs/ann/ann_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_512x1024_40k_cityscapes/ann_r50-d8_512x1024_40k_cityscapes_20200605_095211-049fc292.pth
-- Name: ann_r101-d8_512x1024_40k_cityscapes
+- Config: configs/ann/ann_r101-d8_512x1024_40k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 392.16
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 392.16
+    lr schd: 40000
     memory (GB): 9.5
+  Name: ann_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.55
       mIoU(ms+flip): 78.85
-  Config: configs/ann/ann_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_512x1024_40k_cityscapes/ann_r101-d8_512x1024_40k_cityscapes_20200605_095243-adf6eece.pth
-- Name: ann_r50-d8_769x769_40k_cityscapes
+- Config: configs/ann/ann_r50-d8_769x769_40k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 588.24
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 588.24
+    lr schd: 40000
     memory (GB): 6.8
+  Name: ann_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.89
       mIoU(ms+flip): 80.46
-  Config: configs/ann/ann_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_769x769_40k_cityscapes/ann_r50-d8_769x769_40k_cityscapes_20200530_025712-2b46b04d.pth
-- Name: ann_r101-d8_769x769_40k_cityscapes
+- Config: configs/ann/ann_r101-d8_769x769_40k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 869.57
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 869.57
+    lr schd: 40000
     memory (GB): 10.7
+  Name: ann_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.32
       mIoU(ms+flip): 80.94
-  Config: configs/ann/ann_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_769x769_40k_cityscapes/ann_r101-d8_769x769_40k_cityscapes_20200530_025720-059bff28.pth
-- Name: ann_r50-d8_512x1024_80k_cityscapes
+- Config: configs/ann/ann_r50-d8_512x1024_80k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: ann_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.34
       mIoU(ms+flip): 78.65
-  Config: configs/ann/ann_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_512x1024_80k_cityscapes/ann_r50-d8_512x1024_80k_cityscapes_20200607_101911-5a9ad545.pth
-- Name: ann_r101-d8_512x1024_80k_cityscapes
+- Config: configs/ann/ann_r101-d8_512x1024_80k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: ann_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.14
       mIoU(ms+flip): 78.81
-  Config: configs/ann/ann_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_512x1024_80k_cityscapes/ann_r101-d8_512x1024_80k_cityscapes_20200607_013728-aceccc6e.pth
-- Name: ann_r50-d8_769x769_80k_cityscapes
+- Config: configs/ann/ann_r50-d8_769x769_80k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: ann_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.88
       mIoU(ms+flip): 80.57
-  Config: configs/ann/ann_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_769x769_80k_cityscapes/ann_r50-d8_769x769_80k_cityscapes_20200607_044426-cc7ff323.pth
-- Name: ann_r101-d8_769x769_80k_cityscapes
+- Config: configs/ann/ann_r101-d8_769x769_80k_cityscapes.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: ann_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.8
       mIoU(ms+flip): 80.34
-  Config: configs/ann/ann_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_769x769_80k_cityscapes/ann_r101-d8_769x769_80k_cityscapes_20200607_013713-a9d4be8d.pth
-- Name: ann_r50-d8_512x512_80k_ade20k
+- Config: configs/ann/ann_r50-d8_512x512_80k_ade20k.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 47.6
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.6
+    lr schd: 80000
     memory (GB): 9.1
+  Name: ann_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.01
       mIoU(ms+flip): 42.3
-  Config: configs/ann/ann_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_512x512_80k_ade20k/ann_r50-d8_512x512_80k_ade20k_20200615_014818-26f75e11.pth
-- Name: ann_r101-d8_512x512_80k_ade20k
+- Config: configs/ann/ann_r101-d8_512x512_80k_ade20k.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 70.82
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 70.82
+    lr schd: 80000
     memory (GB): 12.5
+  Name: ann_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.94
       mIoU(ms+flip): 44.18
-  Config: configs/ann/ann_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_512x512_80k_ade20k/ann_r101-d8_512x512_80k_ade20k_20200615_014818-c0153543.pth
-- Name: ann_r50-d8_512x512_160k_ade20k
+- Config: configs/ann/ann_r50-d8_512x512_160k_ade20k.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: ann_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.74
       mIoU(ms+flip): 42.62
-  Config: configs/ann/ann_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_512x512_160k_ade20k/ann_r50-d8_512x512_160k_ade20k_20200615_231733-892247bc.pth
-- Name: ann_r101-d8_512x512_160k_ade20k
+- Config: configs/ann/ann_r101-d8_512x512_160k_ade20k.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: ann_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.94
       mIoU(ms+flip): 44.06
-  Config: configs/ann/ann_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_512x512_160k_ade20k/ann_r101-d8_512x512_160k_ade20k_20200615_231733-955eb1ec.pth
-- Name: ann_r50-d8_512x512_20k_voc12aug
+- Config: configs/ann/ann_r50-d8_512x512_20k_voc12aug.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 47.8
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.8
+    lr schd: 20000
     memory (GB): 6.0
+  Name: ann_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 74.86
       mIoU(ms+flip): 76.13
-  Config: configs/ann/ann_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_512x512_20k_voc12aug/ann_r50-d8_512x512_20k_voc12aug_20200617_222246-dfcb1c62.pth
-- Name: ann_r101-d8_512x512_20k_voc12aug
+- Config: configs/ann/ann_r101-d8_512x512_20k_voc12aug.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 71.74
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 71.74
+    lr schd: 20000
     memory (GB): 9.5
+  Name: ann_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.47
       mIoU(ms+flip): 78.7
-  Config: configs/ann/ann_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_512x512_20k_voc12aug/ann_r101-d8_512x512_20k_voc12aug_20200617_222246-2fad0042.pth
-- Name: ann_r50-d8_512x512_40k_voc12aug
+- Config: configs/ann/ann_r50-d8_512x512_40k_voc12aug.py
   In Collection: ann
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: ann_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.56
       mIoU(ms+flip): 77.51
-  Config: configs/ann/ann_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r50-d8_512x512_40k_voc12aug/ann_r50-d8_512x512_40k_voc12aug_20200613_231314-b5dac322.pth
-- Name: ann_r101-d8_512x512_40k_voc12aug
+- Config: configs/ann/ann_r101-d8_512x512_40k_voc12aug.py
   In Collection: ann
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: ann_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.7
       mIoU(ms+flip): 78.06
-  Config: configs/ann/ann_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ann/ann_r101-d8_512x512_40k_voc12aug/ann_r101-d8_512x512_40k_voc12aug_20200613_231314-bd205bbe.pth

--- a/configs/apcnet/apcnet.yml
+++ b/configs/apcnet/apcnet.yml
@@ -1,223 +1,223 @@
 Collections:
-- Name: apcnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
+  Name: apcnet
 Models:
-- Name: apcnet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/apcnet/apcnet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 280.11
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 280.11
+    lr schd: 40000
     memory (GB): 7.7
+  Name: apcnet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.02
       mIoU(ms+flip): 79.26
-  Config: configs/apcnet/apcnet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r50-d8_512x1024_40k_cityscapes/apcnet_r50-d8_512x1024_40k_cityscapes_20201214_115717-5e88fa33.pth
-- Name: apcnet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/apcnet/apcnet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 465.12
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 465.12
+    lr schd: 40000
     memory (GB): 11.2
+  Name: apcnet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.08
       mIoU(ms+flip): 80.34
-  Config: configs/apcnet/apcnet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r101-d8_512x1024_40k_cityscapes/apcnet_r101-d8_512x1024_40k_cityscapes_20201214_115716-abc9d111.pth
-- Name: apcnet_r50-d8_769x769_40k_cityscapes
+- Config: configs/apcnet/apcnet_r50-d8_769x769_40k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 657.89
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 657.89
+    lr schd: 40000
     memory (GB): 8.7
+  Name: apcnet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.89
       mIoU(ms+flip): 79.75
-  Config: configs/apcnet/apcnet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r50-d8_769x769_40k_cityscapes/apcnet_r50-d8_769x769_40k_cityscapes_20201214_115717-2a2628d7.pth
-- Name: apcnet_r101-d8_769x769_40k_cityscapes
+- Config: configs/apcnet/apcnet_r101-d8_769x769_40k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 970.87
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 970.87
+    lr schd: 40000
     memory (GB): 12.7
+  Name: apcnet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.96
       mIoU(ms+flip): 79.24
-  Config: configs/apcnet/apcnet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r101-d8_769x769_40k_cityscapes/apcnet_r101-d8_769x769_40k_cityscapes_20201214_115718-b650de90.pth
-- Name: apcnet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/apcnet/apcnet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: apcnet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.96
       mIoU(ms+flip): 79.94
-  Config: configs/apcnet/apcnet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r50-d8_512x1024_80k_cityscapes/apcnet_r50-d8_512x1024_80k_cityscapes_20201214_115716-987f51e3.pth
-- Name: apcnet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/apcnet/apcnet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: apcnet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.64
       mIoU(ms+flip): 80.61
-  Config: configs/apcnet/apcnet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r101-d8_512x1024_80k_cityscapes/apcnet_r101-d8_512x1024_80k_cityscapes_20201214_115705-b1ff208a.pth
-- Name: apcnet_r50-d8_769x769_80k_cityscapes
+- Config: configs/apcnet/apcnet_r50-d8_769x769_80k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: apcnet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.79
       mIoU(ms+flip): 80.35
-  Config: configs/apcnet/apcnet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r50-d8_769x769_80k_cityscapes/apcnet_r50-d8_769x769_80k_cityscapes_20201214_115718-7ea9fa12.pth
-- Name: apcnet_r101-d8_769x769_80k_cityscapes
+- Config: configs/apcnet/apcnet_r101-d8_769x769_80k_cityscapes.py
   In Collection: apcnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: apcnet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.45
       mIoU(ms+flip): 79.91
-  Config: configs/apcnet/apcnet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r101-d8_769x769_80k_cityscapes/apcnet_r101-d8_769x769_80k_cityscapes_20201214_115716-a7fbc2ab.pth
-- Name: apcnet_r50-d8_512x512_80k_ade20k
+- Config: configs/apcnet/apcnet_r50-d8_512x512_80k_ade20k.py
   In Collection: apcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 50.99
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 50.99
+    lr schd: 80000
     memory (GB): 10.1
+  Name: apcnet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.2
       mIoU(ms+flip): 43.3
-  Config: configs/apcnet/apcnet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r50-d8_512x512_80k_ade20k/apcnet_r50-d8_512x512_80k_ade20k_20201214_115705-a8626293.pth
-- Name: apcnet_r101-d8_512x512_80k_ade20k
+- Config: configs/apcnet/apcnet_r101-d8_512x512_80k_ade20k.py
   In Collection: apcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 76.34
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 76.34
+    lr schd: 80000
     memory (GB): 13.6
+  Name: apcnet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.54
       mIoU(ms+flip): 46.65
-  Config: configs/apcnet/apcnet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r101-d8_512x512_80k_ade20k/apcnet_r101-d8_512x512_80k_ade20k_20201214_115704-c656c3fb.pth
-- Name: apcnet_r50-d8_512x512_160k_ade20k
+- Config: configs/apcnet/apcnet_r50-d8_512x512_160k_ade20k.py
   In Collection: apcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: apcnet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.4
       mIoU(ms+flip): 43.94
-  Config: configs/apcnet/apcnet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r50-d8_512x512_160k_ade20k/apcnet_r50-d8_512x512_160k_ade20k_20201214_115706-25fb92c2.pth
-- Name: apcnet_r101-d8_512x512_160k_ade20k
+- Config: configs/apcnet/apcnet_r101-d8_512x512_160k_ade20k.py
   In Collection: apcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: apcnet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.41
       mIoU(ms+flip): 46.63
-  Config: configs/apcnet/apcnet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/apcnet/apcnet_r101-d8_512x512_160k_ade20k/apcnet_r101-d8_512x512_160k_ade20k_20201214_115705-73f9a8d7.pth

--- a/configs/ccnet/ccnet.yml
+++ b/configs/ccnet/ccnet.yml
@@ -1,296 +1,296 @@
 Collections:
-- Name: ccnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: ccnet
 Models:
-- Name: ccnet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/ccnet/ccnet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 301.2
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 301.2
+    lr schd: 40000
     memory (GB): 6.0
+  Name: ccnet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.76
       mIoU(ms+flip): 78.87
-  Config: configs/ccnet/ccnet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_512x1024_40k_cityscapes/ccnet_r50-d8_512x1024_40k_cityscapes_20200616_142517-4123f401.pth
-- Name: ccnet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/ccnet/ccnet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 432.9
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 432.9
+    lr schd: 40000
     memory (GB): 9.5
+  Name: ccnet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.35
       mIoU(ms+flip): 78.19
-  Config: configs/ccnet/ccnet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_512x1024_40k_cityscapes/ccnet_r101-d8_512x1024_40k_cityscapes_20200616_142540-a3b84ba6.pth
-- Name: ccnet_r50-d8_769x769_40k_cityscapes
+- Config: configs/ccnet/ccnet_r50-d8_769x769_40k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 699.3
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 699.3
+    lr schd: 40000
     memory (GB): 6.8
+  Name: ccnet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.46
       mIoU(ms+flip): 79.93
-  Config: configs/ccnet/ccnet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_769x769_40k_cityscapes/ccnet_r50-d8_769x769_40k_cityscapes_20200616_145125-76d11884.pth
-- Name: ccnet_r101-d8_769x769_40k_cityscapes
+- Config: configs/ccnet/ccnet_r101-d8_769x769_40k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 990.1
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 990.1
+    lr schd: 40000
     memory (GB): 10.7
+  Name: ccnet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.94
       mIoU(ms+flip): 78.62
-  Config: configs/ccnet/ccnet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_769x769_40k_cityscapes/ccnet_r101-d8_769x769_40k_cityscapes_20200617_101428-4f57c8d0.pth
-- Name: ccnet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/ccnet/ccnet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: ccnet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.03
       mIoU(ms+flip): 80.16
-  Config: configs/ccnet/ccnet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_512x1024_80k_cityscapes/ccnet_r50-d8_512x1024_80k_cityscapes_20200617_010421-869a3423.pth
-- Name: ccnet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/ccnet/ccnet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: ccnet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.87
       mIoU(ms+flip): 79.9
-  Config: configs/ccnet/ccnet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_512x1024_80k_cityscapes/ccnet_r101-d8_512x1024_80k_cityscapes_20200617_203935-ffae8917.pth
-- Name: ccnet_r50-d8_769x769_80k_cityscapes
+- Config: configs/ccnet/ccnet_r50-d8_769x769_80k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: ccnet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.29
       mIoU(ms+flip): 81.08
-  Config: configs/ccnet/ccnet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_769x769_80k_cityscapes/ccnet_r50-d8_769x769_80k_cityscapes_20200617_010421-73eed8ca.pth
-- Name: ccnet_r101-d8_769x769_80k_cityscapes
+- Config: configs/ccnet/ccnet_r101-d8_769x769_80k_cityscapes.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: ccnet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.45
       mIoU(ms+flip): 80.66
-  Config: configs/ccnet/ccnet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_769x769_80k_cityscapes/ccnet_r101-d8_769x769_80k_cityscapes_20200618_011502-ad3cd481.pth
-- Name: ccnet_r50-d8_512x512_80k_ade20k
+- Config: configs/ccnet/ccnet_r50-d8_512x512_80k_ade20k.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 47.87
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.87
+    lr schd: 80000
     memory (GB): 8.8
+  Name: ccnet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.78
       mIoU(ms+flip): 42.98
-  Config: configs/ccnet/ccnet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_512x512_80k_ade20k/ccnet_r50-d8_512x512_80k_ade20k_20200615_014848-aa37f61e.pth
-- Name: ccnet_r101-d8_512x512_80k_ade20k
+- Config: configs/ccnet/ccnet_r101-d8_512x512_80k_ade20k.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 70.87
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 70.87
+    lr schd: 80000
     memory (GB): 12.2
+  Name: ccnet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.97
       mIoU(ms+flip): 45.13
-  Config: configs/ccnet/ccnet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_512x512_80k_ade20k/ccnet_r101-d8_512x512_80k_ade20k_20200615_014848-1f4929a3.pth
-- Name: ccnet_r50-d8_512x512_160k_ade20k
+- Config: configs/ccnet/ccnet_r50-d8_512x512_160k_ade20k.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: ccnet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.08
       mIoU(ms+flip): 43.13
-  Config: configs/ccnet/ccnet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_512x512_160k_ade20k/ccnet_r50-d8_512x512_160k_ade20k_20200616_084435-7c97193b.pth
-- Name: ccnet_r101-d8_512x512_160k_ade20k
+- Config: configs/ccnet/ccnet_r101-d8_512x512_160k_ade20k.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: ccnet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.71
       mIoU(ms+flip): 45.04
-  Config: configs/ccnet/ccnet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_512x512_160k_ade20k/ccnet_r101-d8_512x512_160k_ade20k_20200616_000644-e849e007.pth
-- Name: ccnet_r50-d8_512x512_20k_voc12aug
+- Config: configs/ccnet/ccnet_r50-d8_512x512_20k_voc12aug.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 48.9
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 48.9
+    lr schd: 20000
     memory (GB): 6.0
+  Name: ccnet_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.17
       mIoU(ms+flip): 77.51
-  Config: configs/ccnet/ccnet_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_512x512_20k_voc12aug/ccnet_r50-d8_512x512_20k_voc12aug_20200617_193212-fad81784.pth
-- Name: ccnet_r101-d8_512x512_20k_voc12aug
+- Config: configs/ccnet/ccnet_r101-d8_512x512_20k_voc12aug.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 73.31
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 73.31
+    lr schd: 20000
     memory (GB): 9.5
+  Name: ccnet_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.27
       mIoU(ms+flip): 79.02
-  Config: configs/ccnet/ccnet_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_512x512_20k_voc12aug/ccnet_r101-d8_512x512_20k_voc12aug_20200617_193212-0007b61d.pth
-- Name: ccnet_r50-d8_512x512_40k_voc12aug
+- Config: configs/ccnet/ccnet_r50-d8_512x512_40k_voc12aug.py
   In Collection: ccnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: ccnet_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 75.96
       mIoU(ms+flip): 77.04
-  Config: configs/ccnet/ccnet_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r50-d8_512x512_40k_voc12aug/ccnet_r50-d8_512x512_40k_voc12aug_20200613_232127-c2a15f02.pth
-- Name: ccnet_r101-d8_512x512_40k_voc12aug
+- Config: configs/ccnet/ccnet_r101-d8_512x512_40k_voc12aug.py
   In Collection: ccnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: ccnet_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.87
       mIoU(ms+flip): 78.9
-  Config: configs/ccnet/ccnet_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ccnet/ccnet_r101-d8_512x512_40k_voc12aug/ccnet_r101-d8_512x512_40k_voc12aug_20200613_232127-c30da577.pth

--- a/configs/cgnet/cgnet.yml
+++ b/configs/cgnet/cgnet.yml
@@ -1,50 +1,50 @@
 Collections:
-- Name: cgnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
+  Name: cgnet
 Models:
-- Name: cgnet_680x680_60k_cityscapes
+- Config: configs/cgnet/cgnet_680x680_60k_cityscapes.py
   In Collection: cgnet
   Metadata:
     backbone: M3N21
     crop size: (680,680)
-    lr schd: 60000
     inference time (ms/im):
-    - value: 32.78
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (680,680)
+      value: 32.78
+    lr schd: 60000
     memory (GB): 7.5
+  Name: cgnet_680x680_60k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 65.63
       mIoU(ms+flip): 68.04
-  Config: configs/cgnet/cgnet_680x680_60k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/cgnet/cgnet_680x680_60k_cityscapes/cgnet_680x680_60k_cityscapes_20201101_110253-4c0b2f2d.pth
-- Name: cgnet_512x1024_60k_cityscapes
+- Config: configs/cgnet/cgnet_512x1024_60k_cityscapes.py
   In Collection: cgnet
   Metadata:
     backbone: M3N21
     crop size: (512,1024)
-    lr schd: 60000
     inference time (ms/im):
-    - value: 32.11
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 32.11
+    lr schd: 60000
     memory (GB): 8.3
+  Name: cgnet_512x1024_60k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 68.27
       mIoU(ms+flip): 70.33
-  Config: configs/cgnet/cgnet_512x1024_60k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/cgnet/cgnet_512x1024_60k_cityscapes/cgnet_512x1024_60k_cityscapes_20201101_110254-124ea03b.pth

--- a/configs/danet/danet.yml
+++ b/configs/danet/danet.yml
@@ -1,292 +1,292 @@
 Collections:
-- Name: danet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: danet
 Models:
-- Name: danet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/danet/danet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 375.94
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 375.94
+    lr schd: 40000
     memory (GB): 7.4
+  Name: danet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.74
-  Config: configs/danet/danet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_512x1024_40k_cityscapes/danet_r50-d8_512x1024_40k_cityscapes_20200605_191324-c0dbfa5f.pth
-- Name: danet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/danet/danet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 502.51
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 502.51
+    lr schd: 40000
     memory (GB): 10.9
+  Name: danet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.52
-  Config: configs/danet/danet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_512x1024_40k_cityscapes/danet_r101-d8_512x1024_40k_cityscapes_20200605_200831-c57a7157.pth
-- Name: danet_r50-d8_769x769_40k_cityscapes
+- Config: configs/danet/danet_r50-d8_769x769_40k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 641.03
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 641.03
+    lr schd: 40000
     memory (GB): 8.8
+  Name: danet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.88
       mIoU(ms+flip): 80.62
-  Config: configs/danet/danet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_769x769_40k_cityscapes/danet_r50-d8_769x769_40k_cityscapes_20200530_025703-76681c60.pth
-- Name: danet_r101-d8_769x769_40k_cityscapes
+- Config: configs/danet/danet_r101-d8_769x769_40k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 934.58
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 934.58
+    lr schd: 40000
     memory (GB): 12.8
+  Name: danet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.88
       mIoU(ms+flip): 81.47
-  Config: configs/danet/danet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_769x769_40k_cityscapes/danet_r101-d8_769x769_40k_cityscapes_20200530_025717-dcb7fd4e.pth
-- Name: danet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/danet/danet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: danet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.34
-  Config: configs/danet/danet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_512x1024_80k_cityscapes/danet_r50-d8_512x1024_80k_cityscapes_20200607_133029-2bfa2293.pth
-- Name: danet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/danet/danet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: danet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.41
-  Config: configs/danet/danet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_512x1024_80k_cityscapes/danet_r101-d8_512x1024_80k_cityscapes_20200607_132918-955e6350.pth
-- Name: danet_r50-d8_769x769_80k_cityscapes
+- Config: configs/danet/danet_r50-d8_769x769_80k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: danet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.27
       mIoU(ms+flip): 80.96
-  Config: configs/danet/danet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_769x769_80k_cityscapes/danet_r50-d8_769x769_80k_cityscapes_20200607_132954-495689b4.pth
-- Name: danet_r101-d8_769x769_80k_cityscapes
+- Config: configs/danet/danet_r101-d8_769x769_80k_cityscapes.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: danet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.47
       mIoU(ms+flip): 82.02
-  Config: configs/danet/danet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_769x769_80k_cityscapes/danet_r101-d8_769x769_80k_cityscapes_20200607_132918-f3a929e7.pth
-- Name: danet_r50-d8_512x512_80k_ade20k
+- Config: configs/danet/danet_r50-d8_512x512_80k_ade20k.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 47.17
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.17
+    lr schd: 80000
     memory (GB): 11.5
+  Name: danet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.66
       mIoU(ms+flip): 42.9
-  Config: configs/danet/danet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_512x512_80k_ade20k/danet_r50-d8_512x512_80k_ade20k_20200615_015125-edb18e08.pth
-- Name: danet_r101-d8_512x512_80k_ade20k
+- Config: configs/danet/danet_r101-d8_512x512_80k_ade20k.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 70.52
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 70.52
+    lr schd: 80000
     memory (GB): 15.0
+  Name: danet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.64
       mIoU(ms+flip): 45.19
-  Config: configs/danet/danet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_512x512_80k_ade20k/danet_r101-d8_512x512_80k_ade20k_20200615_015126-d0357c73.pth
-- Name: danet_r50-d8_512x512_160k_ade20k
+- Config: configs/danet/danet_r50-d8_512x512_160k_ade20k.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: danet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.45
       mIoU(ms+flip): 43.25
-  Config: configs/danet/danet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_512x512_160k_ade20k/danet_r50-d8_512x512_160k_ade20k_20200616_082340-9cb35dcd.pth
-- Name: danet_r101-d8_512x512_160k_ade20k
+- Config: configs/danet/danet_r101-d8_512x512_160k_ade20k.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: danet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 44.17
       mIoU(ms+flip): 45.02
-  Config: configs/danet/danet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_512x512_160k_ade20k/danet_r101-d8_512x512_160k_ade20k_20200616_082348-23bf12f9.pth
-- Name: danet_r50-d8_512x512_20k_voc12aug
+- Config: configs/danet/danet_r50-d8_512x512_20k_voc12aug.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 47.76
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.76
+    lr schd: 20000
     memory (GB): 6.5
+  Name: danet_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 74.45
       mIoU(ms+flip): 75.69
-  Config: configs/danet/danet_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_512x512_20k_voc12aug/danet_r50-d8_512x512_20k_voc12aug_20200618_070026-9e9e3ab3.pth
-- Name: danet_r101-d8_512x512_20k_voc12aug
+- Config: configs/danet/danet_r101-d8_512x512_20k_voc12aug.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 72.67
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 72.67
+    lr schd: 20000
     memory (GB): 9.9
+  Name: danet_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.02
       mIoU(ms+flip): 77.23
-  Config: configs/danet/danet_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_512x512_20k_voc12aug/danet_r101-d8_512x512_20k_voc12aug_20200618_070026-d48d23b2.pth
-- Name: danet_r50-d8_512x512_40k_voc12aug
+- Config: configs/danet/danet_r50-d8_512x512_40k_voc12aug.py
   In Collection: danet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: danet_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.37
       mIoU(ms+flip): 77.29
-  Config: configs/danet/danet_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r50-d8_512x512_40k_voc12aug/danet_r50-d8_512x512_40k_voc12aug_20200613_235526-426e3a64.pth
-- Name: danet_r101-d8_512x512_40k_voc12aug
+- Config: configs/danet/danet_r101-d8_512x512_40k_voc12aug.py
   In Collection: danet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: danet_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.51
       mIoU(ms+flip): 77.32
-  Config: configs/danet/danet_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/danet/danet_r101-d8_512x512_40k_voc12aug/danet_r101-d8_512x512_40k_voc12aug_20200613_223031-788e232a.pth

--- a/configs/deeplabv3/deeplabv3.yml
+++ b/configs/deeplabv3/deeplabv3.yml
@@ -1,552 +1,552 @@
 Collections:
-- Name: deeplabv3
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
     - Pascal Context
     - Pascal Context 59
+  Name: deeplabv3
 Models:
-- Name: deeplabv3_r50-d8_512x1024_40k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r50-d8_512x1024_40k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 389.11
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 389.11
+    lr schd: 40000
     memory (GB): 6.1
+  Name: deeplabv3_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.09
       mIoU(ms+flip): 80.45
-  Config: configs/deeplabv3/deeplabv3_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_512x1024_40k_cityscapes/deeplabv3_r50-d8_512x1024_40k_cityscapes_20200605_022449-acadc2f8.pth
-- Name: deeplabv3_r101-d8_512x1024_40k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r101-d8_512x1024_40k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 520.83
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 520.83
+    lr schd: 40000
     memory (GB): 9.6
+  Name: deeplabv3_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.12
       mIoU(ms+flip): 79.61
-  Config: configs/deeplabv3/deeplabv3_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_512x1024_40k_cityscapes/deeplabv3_r101-d8_512x1024_40k_cityscapes_20200605_012241-7fd3f799.pth
-- Name: deeplabv3_r50-d8_769x769_40k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r50-d8_769x769_40k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 900.9
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 900.9
+    lr schd: 40000
     memory (GB): 6.9
+  Name: deeplabv3_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.58
       mIoU(ms+flip): 79.89
-  Config: configs/deeplabv3/deeplabv3_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_769x769_40k_cityscapes/deeplabv3_r50-d8_769x769_40k_cityscapes_20200606_113723-7eda553c.pth
-- Name: deeplabv3_r101-d8_769x769_40k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r101-d8_769x769_40k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 1204.82
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 1204.82
+    lr schd: 40000
     memory (GB): 10.9
+  Name: deeplabv3_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.27
       mIoU(ms+flip): 80.11
-  Config: configs/deeplabv3/deeplabv3_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_769x769_40k_cityscapes/deeplabv3_r101-d8_769x769_40k_cityscapes_20200606_113809-c64f889f.pth
-- Name: deeplabv3_r18-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r18-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-18-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 72.57
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 72.57
+    lr schd: 80000
     memory (GB): 1.7
+  Name: deeplabv3_r18-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.7
       mIoU(ms+flip): 78.27
-  Config: configs/deeplabv3/deeplabv3_r18-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r18-d8_512x1024_80k_cityscapes/deeplabv3_r18-d8_512x1024_80k_cityscapes_20201225_021506-23dffbe2.pth
-- Name: deeplabv3_r50-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r50-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: deeplabv3_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.32
       mIoU(ms+flip): 80.57
-  Config: configs/deeplabv3/deeplabv3_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_512x1024_80k_cityscapes/deeplabv3_r50-d8_512x1024_80k_cityscapes_20200606_113404-b92cfdd4.pth
-- Name: deeplabv3_r101-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r101-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: deeplabv3_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.2
       mIoU(ms+flip): 81.21
-  Config: configs/deeplabv3/deeplabv3_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_512x1024_80k_cityscapes/deeplabv3_r101-d8_512x1024_80k_cityscapes_20200606_113503-9e428899.pth
-- Name: deeplabv3_r18-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r18-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-18-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 180.18
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 180.18
+    lr schd: 80000
     memory (GB): 1.9
+  Name: deeplabv3_r18-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.6
       mIoU(ms+flip): 78.26
-  Config: configs/deeplabv3/deeplabv3_r18-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r18-d8_769x769_80k_cityscapes/deeplabv3_r18-d8_769x769_80k_cityscapes_20201225_021506-6452126a.pth
-- Name: deeplabv3_r50-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r50-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: deeplabv3_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.89
       mIoU(ms+flip): 81.06
-  Config: configs/deeplabv3/deeplabv3_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_769x769_80k_cityscapes/deeplabv3_r50-d8_769x769_80k_cityscapes_20200606_221338-788d6228.pth
-- Name: deeplabv3_r101-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r101-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: deeplabv3_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.67
       mIoU(ms+flip): 80.81
-  Config: configs/deeplabv3/deeplabv3_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_769x769_80k_cityscapes/deeplabv3_r101-d8_769x769_80k_cityscapes_20200607_013353-60e95418.pth
-- Name: deeplabv3_r101-d16-mg124_512x1024_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r101-d16-mg124_512x1024_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D16-MG124
     crop size: (512,1024)
     lr schd: 80000
+  Name: deeplabv3_r101-d16-mg124_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.36
       mIoU(ms+flip): 79.84
-  Config: configs/deeplabv3/deeplabv3_r101-d16-mg124_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d16-mg124_512x1024_80k_cityscapes/deeplabv3_r101-d16-mg124_512x1024_80k_cityscapes_20200908_005644-57bb8425.pth
-- Name: deeplabv3_r18b-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r18b-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-18b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 71.79
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 71.79
+    lr schd: 80000
     memory (GB): 1.6
+  Name: deeplabv3_r18b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.26
       mIoU(ms+flip): 77.88
-  Config: configs/deeplabv3/deeplabv3_r18b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r18b-d8_512x1024_80k_cityscapes/deeplabv3_r18b-d8_512x1024_80k_cityscapes_20201225_094144-46040cef.pth
-- Name: deeplabv3_r50b-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r50b-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 364.96
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 364.96
+    lr schd: 80000
     memory (GB): 6.0
+  Name: deeplabv3_r50b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.63
       mIoU(ms+flip): 80.98
-  Config: configs/deeplabv3/deeplabv3_r50b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50b-d8_512x1024_80k_cityscapes/deeplabv3_r50b-d8_512x1024_80k_cityscapes_20201225_155148-ec368954.pth
-- Name: deeplabv3_r101b-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r101b-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 552.49
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 552.49
+    lr schd: 80000
     memory (GB): 9.5
+  Name: deeplabv3_r101b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.01
       mIoU(ms+flip): 81.21
-  Config: configs/deeplabv3/deeplabv3_r101b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101b-d8_512x1024_80k_cityscapes/deeplabv3_r101b-d8_512x1024_80k_cityscapes_20201226_171821-8fd49503.pth
-- Name: deeplabv3_r18b-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r18b-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-18b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 172.71
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 172.71
+    lr schd: 80000
     memory (GB): 1.8
+  Name: deeplabv3_r18b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.63
       mIoU(ms+flip): 77.51
-  Config: configs/deeplabv3/deeplabv3_r18b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r18b-d8_769x769_80k_cityscapes/deeplabv3_r18b-d8_769x769_80k_cityscapes_20201225_094144-fdc985d9.pth
-- Name: deeplabv3_r50b-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r50b-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 862.07
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 862.07
+    lr schd: 80000
     memory (GB): 6.8
+  Name: deeplabv3_r50b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.8
       mIoU(ms+flip): 80.27
-  Config: configs/deeplabv3/deeplabv3_r50b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50b-d8_769x769_80k_cityscapes/deeplabv3_r50b-d8_769x769_80k_cityscapes_20201225_155404-87fb0cf4.pth
-- Name: deeplabv3_r101b-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3/deeplabv3_r101b-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 1219.51
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 1219.51
+    lr schd: 80000
     memory (GB): 10.7
+  Name: deeplabv3_r101b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.41
       mIoU(ms+flip): 80.73
-  Config: configs/deeplabv3/deeplabv3_r101b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101b-d8_769x769_80k_cityscapes/deeplabv3_r101b-d8_769x769_80k_cityscapes_20201226_190843-9142ee57.pth
-- Name: deeplabv3_r50-d8_512x512_80k_ade20k
+- Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_80k_ade20k.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 67.75
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 67.75
+    lr schd: 80000
     memory (GB): 8.9
+  Name: deeplabv3_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.42
       mIoU(ms+flip): 43.28
-  Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_512x512_80k_ade20k/deeplabv3_r50-d8_512x512_80k_ade20k_20200614_185028-0bb3f844.pth
-- Name: deeplabv3_r101-d8_512x512_80k_ade20k
+- Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_80k_ade20k.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 98.62
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 98.62
+    lr schd: 80000
     memory (GB): 12.4
+  Name: deeplabv3_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 44.08
       mIoU(ms+flip): 45.19
-  Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_512x512_80k_ade20k/deeplabv3_r101-d8_512x512_80k_ade20k_20200615_021256-d89c7fa4.pth
-- Name: deeplabv3_r50-d8_512x512_160k_ade20k
+- Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_160k_ade20k.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: deeplabv3_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.66
       mIoU(ms+flip): 44.09
-  Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_512x512_160k_ade20k/deeplabv3_r50-d8_512x512_160k_ade20k_20200615_123227-5d0ee427.pth
-- Name: deeplabv3_r101-d8_512x512_160k_ade20k
+- Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_160k_ade20k.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: deeplabv3_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.0
       mIoU(ms+flip): 46.66
-  Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_512x512_160k_ade20k/deeplabv3_r101-d8_512x512_160k_ade20k_20200615_105816-b1f72b3b.pth
-- Name: deeplabv3_r50-d8_512x512_20k_voc12aug
+- Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_20k_voc12aug.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 72.05
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 72.05
+    lr schd: 20000
     memory (GB): 6.1
+  Name: deeplabv3_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.17
       mIoU(ms+flip): 77.42
-  Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_512x512_20k_voc12aug/deeplabv3_r50-d8_512x512_20k_voc12aug_20200617_010906-596905ef.pth
-- Name: deeplabv3_r101-d8_512x512_20k_voc12aug
+- Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_20k_voc12aug.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 101.94
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 101.94
+    lr schd: 20000
     memory (GB): 9.6
+  Name: deeplabv3_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 78.7
       mIoU(ms+flip): 79.95
-  Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_512x512_20k_voc12aug/deeplabv3_r101-d8_512x512_20k_voc12aug_20200617_010932-8d13832f.pth
-- Name: deeplabv3_r50-d8_512x512_40k_voc12aug
+- Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_40k_voc12aug.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: deeplabv3_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.68
       mIoU(ms+flip): 78.78
-  Config: configs/deeplabv3/deeplabv3_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r50-d8_512x512_40k_voc12aug/deeplabv3_r50-d8_512x512_40k_voc12aug_20200613_161546-2ae96e7e.pth
-- Name: deeplabv3_r101-d8_512x512_40k_voc12aug
+- Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_40k_voc12aug.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: deeplabv3_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.92
       mIoU(ms+flip): 79.18
-  Config: configs/deeplabv3/deeplabv3_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_512x512_40k_voc12aug/deeplabv3_r101-d8_512x512_40k_voc12aug_20200613_161432-0017d784.pth
-- Name: deeplabv3_r101-d8_480x480_40k_pascal_context
+- Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_40k_pascal_context.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 141.04
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (480,480)
+      value: 141.04
+    lr schd: 40000
     memory (GB): 9.2
+  Name: deeplabv3_r101-d8_480x480_40k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 46.55
       mIoU(ms+flip): 47.81
-  Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_40k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_480x480_40k_pascal_context/deeplabv3_r101-d8_480x480_40k_pascal_context_20200911_204118-1aa27336.pth
-- Name: deeplabv3_r101-d8_480x480_80k_pascal_context
+- Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_80k_pascal_context.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: deeplabv3_r101-d8_480x480_80k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 46.42
       mIoU(ms+flip): 47.53
-  Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_80k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_480x480_80k_pascal_context/deeplabv3_r101-d8_480x480_80k_pascal_context_20200911_170155-2a21fff3.pth
-- Name: deeplabv3_r101-d8_480x480_40k_pascal_context_59
+- Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_40k_pascal_context_59.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 40000
+  Name: deeplabv3_r101-d8_480x480_40k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 52.61
       mIoU(ms+flip): 54.28
-  Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_40k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_480x480_40k_pascal_context_59/deeplabv3_r101-d8_480x480_40k_pascal_context_59_20210416_110332-cb08ea46.pth
-- Name: deeplabv3_r101-d8_480x480_80k_pascal_context_59
+- Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_80k_pascal_context_59.py
   In Collection: deeplabv3
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: deeplabv3_r101-d8_480x480_80k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 52.46
       mIoU(ms+flip): 54.09
-  Config: configs/deeplabv3/deeplabv3_r101-d8_480x480_80k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3/deeplabv3_r101-d8_480x480_80k_pascal_context_59/deeplabv3_r101-d8_480x480_80k_pascal_context_59_20210416_113002-26303993.pth

--- a/configs/deeplabv3plus/deeplabv3plus.yml
+++ b/configs/deeplabv3plus/deeplabv3plus.yml
@@ -1,574 +1,574 @@
 Collections:
-- Name: deeplabv3plus
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - ' Pascal VOC 2012 + Aug'
     - ' Pascal Context'
     - ' Pascal Context 59'
+  Name: deeplabv3plus
 Models:
-- Name: deeplabv3plus_r50-d8_512x1024_40k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_40k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 253.81
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 253.81
+    lr schd: 40000
     memory (GB): 7.5
+  Name: deeplabv3plus_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.61
       mIoU(ms+flip): 81.01
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_40k_cityscapes/deeplabv3plus_r50-d8_512x1024_40k_cityscapes_20200605_094610-d222ffcd.pth
-- Name: deeplabv3plus_r101-d8_512x1024_40k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x1024_40k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 384.62
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 384.62
+    lr schd: 40000
     memory (GB): 11.0
+  Name: deeplabv3plus_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.21
       mIoU(ms+flip): 81.82
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_512x1024_40k_cityscapes/deeplabv3plus_r101-d8_512x1024_40k_cityscapes_20200605_094614-3769eecf.pth
-- Name: deeplabv3plus_r50-d8_769x769_40k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_769x769_40k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 581.4
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 581.4
+    lr schd: 40000
     memory (GB): 8.5
+  Name: deeplabv3plus_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.97
       mIoU(ms+flip): 80.46
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_769x769_40k_cityscapes/deeplabv3plus_r50-d8_769x769_40k_cityscapes_20200606_114143-1dcb0e3c.pth
-- Name: deeplabv3plus_r101-d8_769x769_40k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_769x769_40k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 869.57
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 869.57
+    lr schd: 40000
     memory (GB): 12.5
+  Name: deeplabv3plus_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.46
       mIoU(ms+flip): 80.5
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_769x769_40k_cityscapes/deeplabv3plus_r101-d8_769x769_40k_cityscapes_20200606_114304-ff414b9e.pth
-- Name: deeplabv3plus_r18-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r18-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-18-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 70.08
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 70.08
+    lr schd: 80000
     memory (GB): 2.2
+  Name: deeplabv3plus_r18-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.89
       mIoU(ms+flip): 78.76
-  Config: configs/deeplabv3plus/deeplabv3plus_r18-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r18-d8_512x1024_80k_cityscapes/deeplabv3plus_r18-d8_512x1024_80k_cityscapes_20201226_080942-cff257fe.pth
-- Name: deeplabv3plus_r50-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: deeplabv3plus_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.09
       mIoU(ms+flip): 81.13
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_80k_cityscapes/deeplabv3plus_r50-d8_512x1024_80k_cityscapes_20200606_114049-f9fb496d.pth
-- Name: deeplabv3plus_r101-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: deeplabv3plus_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.97
       mIoU(ms+flip): 82.03
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_512x1024_80k_cityscapes/deeplabv3plus_r101-d8_512x1024_80k_cityscapes_20200606_114143-068fcfe9.pth
-- Name: deeplabv3plus_r18-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r18-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-18-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 174.22
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 174.22
+    lr schd: 80000
     memory (GB): 2.5
+  Name: deeplabv3plus_r18-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.26
       mIoU(ms+flip): 77.91
-  Config: configs/deeplabv3plus/deeplabv3plus_r18-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r18-d8_769x769_80k_cityscapes/deeplabv3plus_r18-d8_769x769_80k_cityscapes_20201226_083346-f326e06a.pth
-- Name: deeplabv3plus_r50-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: deeplabv3plus_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.83
       mIoU(ms+flip): 81.48
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_769x769_80k_cityscapes/deeplabv3plus_r50-d8_769x769_80k_cityscapes_20200606_210233-0e9dfdc4.pth
-- Name: deeplabv3plus_r101-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: deeplabv3plus_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.98
       mIoU(ms+flip): 82.18
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_769x769_80k_cityscapes/deeplabv3plus_r101-d8_769x769_80k_cityscapes_20200607_000405-a7573d20.pth
-- Name: deeplabv3plus_r101-d16-mg124_512x1024_40k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d16-mg124_512x1024_40k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D16-MG124
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 133.69
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 133.69
+    lr schd: 40000
     memory (GB): 5.8
+  Name: deeplabv3plus_r101-d16-mg124_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.09
       mIoU(ms+flip): 80.36
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d16-mg124_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d16-mg124_512x1024_40k_cityscapes/deeplabv3plus_r101-d16-mg124_512x1024_40k_cityscapes_20200908_005644-cf9ce186.pth
-- Name: deeplabv3plus_r101-d16-mg124_512x1024_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d16-mg124_512x1024_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D16-MG124
     crop size: (512,1024)
     lr schd: 80000
     memory (GB): 9.9
+  Name: deeplabv3plus_r101-d16-mg124_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.9
       mIoU(ms+flip): 81.33
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d16-mg124_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d16-mg124_512x1024_80k_cityscapes/deeplabv3plus_r101-d16-mg124_512x1024_80k_cityscapes_20200908_005644-ee6158e0.pth
-- Name: deeplabv3plus_r18b-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r18b-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-18b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 66.89
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 66.89
+    lr schd: 80000
     memory (GB): 2.1
+  Name: deeplabv3plus_r18b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.87
       mIoU(ms+flip): 77.52
-  Config: configs/deeplabv3plus/deeplabv3plus_r18b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r18b-d8_512x1024_80k_cityscapes/deeplabv3plus_r18b-d8_512x1024_80k_cityscapes_20201226_090828-e451abd9.pth
-- Name: deeplabv3plus_r50b-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r50b-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 253.81
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 253.81
+    lr schd: 80000
     memory (GB): 7.4
+  Name: deeplabv3plus_r50b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.28
       mIoU(ms+flip): 81.44
-  Config: configs/deeplabv3plus/deeplabv3plus_r50b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50b-d8_512x1024_80k_cityscapes/deeplabv3plus_r50b-d8_512x1024_80k_cityscapes_20201225_213645-a97e4e43.pth
-- Name: deeplabv3plus_r101b-d8_512x1024_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101b-d8_512x1024_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 384.62
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 384.62
+    lr schd: 80000
     memory (GB): 10.9
+  Name: deeplabv3plus_r101b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.16
       mIoU(ms+flip): 81.41
-  Config: configs/deeplabv3plus/deeplabv3plus_r101b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101b-d8_512x1024_80k_cityscapes/deeplabv3plus_r101b-d8_512x1024_80k_cityscapes_20201226_190843-9c3c93a4.pth
-- Name: deeplabv3plus_r18b-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r18b-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-18b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 167.79
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 167.79
+    lr schd: 80000
     memory (GB): 2.4
+  Name: deeplabv3plus_r18b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.36
       mIoU(ms+flip): 78.24
-  Config: configs/deeplabv3plus/deeplabv3plus_r18b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r18b-d8_769x769_80k_cityscapes/deeplabv3plus_r18b-d8_769x769_80k_cityscapes_20201226_151312-2c868aff.pth
-- Name: deeplabv3plus_r50b-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r50b-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 581.4
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 581.4
+    lr schd: 80000
     memory (GB): 8.4
+  Name: deeplabv3plus_r50b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.41
       mIoU(ms+flip): 80.56
-  Config: configs/deeplabv3plus/deeplabv3plus_r50b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50b-d8_769x769_80k_cityscapes/deeplabv3plus_r50b-d8_769x769_80k_cityscapes_20201225_224655-8b596d1c.pth
-- Name: deeplabv3plus_r101b-d8_769x769_80k_cityscapes
+- Config: configs/deeplabv3plus/deeplabv3plus_r101b-d8_769x769_80k_cityscapes.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 909.09
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 909.09
+    lr schd: 80000
     memory (GB): 12.3
+  Name: deeplabv3plus_r101b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.88
       mIoU(ms+flip): 81.46
-  Config: configs/deeplabv3plus/deeplabv3plus_r101b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101b-d8_769x769_80k_cityscapes/deeplabv3plus_r101b-d8_769x769_80k_cityscapes_20201226_205041-227cdf7c.pth
-- Name: deeplabv3plus_r50-d8_512x512_80k_ade20k
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_80k_ade20k.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 47.6
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.6
+    lr schd: 80000
     memory (GB): 10.6
+  Name: deeplabv3plus_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.72
       mIoU(ms+flip): 43.75
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_512x512_80k_ade20k/deeplabv3plus_r50-d8_512x512_80k_ade20k_20200614_185028-bf1400d8.pth
-- Name: deeplabv3plus_r101-d8_512x512_80k_ade20k
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_80k_ade20k.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 70.62
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 70.62
+    lr schd: 80000
     memory (GB): 14.1
+  Name: deeplabv3plus_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 44.6
       mIoU(ms+flip): 46.06
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_512x512_80k_ade20k/deeplabv3plus_r101-d8_512x512_80k_ade20k_20200615_014139-d5730af7.pth
-- Name: deeplabv3plus_r50-d8_512x512_160k_ade20k
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_160k_ade20k.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: deeplabv3plus_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.95
       mIoU(ms+flip): 44.93
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_512x512_160k_ade20k/deeplabv3plus_r50-d8_512x512_160k_ade20k_20200615_124504-6135c7e0.pth
-- Name: deeplabv3plus_r101-d8_512x512_160k_ade20k
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_160k_ade20k.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: deeplabv3plus_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.47
       mIoU(ms+flip): 46.35
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_512x512_160k_ade20k/deeplabv3plus_r101-d8_512x512_160k_ade20k_20200615_123232-38ed86bb.pth
-- Name: deeplabv3plus_r50-d8_512x512_20k_voc12aug
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_20k_voc12aug.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 47.62
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.62
+    lr schd: 20000
     memory (GB): 7.6
+  Name: deeplabv3plus_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal VOC 2012 + Aug'
     Metrics:
       mIoU: 75.93
       mIoU(ms+flip): 77.5
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_512x512_20k_voc12aug/deeplabv3plus_r50-d8_512x512_20k_voc12aug_20200617_102323-aad58ef1.pth
-- Name: deeplabv3plus_r101-d8_512x512_20k_voc12aug
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_20k_voc12aug.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 72.05
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 72.05
+    lr schd: 20000
     memory (GB): 11.0
+  Name: deeplabv3plus_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal VOC 2012 + Aug'
     Metrics:
       mIoU: 77.22
       mIoU(ms+flip): 78.59
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_512x512_20k_voc12aug/deeplabv3plus_r101-d8_512x512_20k_voc12aug_20200617_102345-c7ff3d56.pth
-- Name: deeplabv3plus_r50-d8_512x512_40k_voc12aug
+- Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_40k_voc12aug.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: deeplabv3plus_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal VOC 2012 + Aug'
     Metrics:
       mIoU: 76.81
       mIoU(ms+flip): 77.57
-  Config: configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r50-d8_512x512_40k_voc12aug/deeplabv3plus_r50-d8_512x512_40k_voc12aug_20200613_161759-e1b43aa9.pth
-- Name: deeplabv3plus_r101-d8_512x512_40k_voc12aug
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_40k_voc12aug.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: deeplabv3plus_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal VOC 2012 + Aug'
     Metrics:
       mIoU: 78.62
       mIoU(ms+flip): 79.53
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_512x512_40k_voc12aug/deeplabv3plus_r101-d8_512x512_40k_voc12aug_20200613_205333-faf03387.pth
-- Name: deeplabv3plus_r101-d8_480x480_40k_pascal_context
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_40k_pascal_context.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 110.01
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (480,480)
+      value: 110.01
+    lr schd: 40000
+  Name: deeplabv3plus_r101-d8_480x480_40k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal Context'
     Metrics:
       mIoU: 47.3
       mIoU(ms+flip): 48.47
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_40k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_480x480_40k_pascal_context/deeplabv3plus_r101-d8_480x480_40k_pascal_context_20200911_165459-d3c8a29e.pth
-- Name: deeplabv3plus_r101-d8_480x480_80k_pascal_context
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_80k_pascal_context.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: deeplabv3plus_r101-d8_480x480_80k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal Context'
     Metrics:
       mIoU: 47.23
       mIoU(ms+flip): 48.26
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_80k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_480x480_80k_pascal_context/deeplabv3plus_r101-d8_480x480_80k_pascal_context_20200911_155322-145d3ee8.pth
-- Name: deeplabv3plus_r101-d8_480x480_40k_pascal_context_59
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_40k_pascal_context_59.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 40000
+  Name: deeplabv3plus_r101-d8_480x480_40k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal Context 59'
     Metrics:
       mIoU: 52.86
       mIoU(ms+flip): 54.54
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_40k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_480x480_40k_pascal_context_59/deeplabv3plus_r101-d8_480x480_40k_pascal_context_59_20210416_111233-ed937f15.pth
-- Name: deeplabv3plus_r101-d8_480x480_80k_pascal_context_59
+- Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_80k_pascal_context_59.py
   In Collection: deeplabv3plus
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: deeplabv3plus_r101-d8_480x480_80k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: ' Pascal Context 59'
     Metrics:
       mIoU: 53.2
       mIoU(ms+flip): 54.67
-  Config: configs/deeplabv3plus/deeplabv3plus_r101-d8_480x480_80k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/deeplabv3plus/deeplabv3plus_r101-d8_480x480_80k_pascal_context_59/deeplabv3plus_r101-d8_480x480_80k_pascal_context_59_20210416_111127-7ca0331d.pth

--- a/configs/dmnet/dmnet.yml
+++ b/configs/dmnet/dmnet.yml
@@ -1,223 +1,223 @@
 Collections:
-- Name: dmnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
+  Name: dmnet
 Models:
-- Name: dmnet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/dmnet/dmnet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 273.22
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 273.22
+    lr schd: 40000
     memory (GB): 7.0
+  Name: dmnet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.78
       mIoU(ms+flip): 79.14
-  Config: configs/dmnet/dmnet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r50-d8_512x1024_40k_cityscapes/dmnet_r50-d8_512x1024_40k_cityscapes_20201215_042326-615373cf.pth
-- Name: dmnet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/dmnet/dmnet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 393.7
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 393.7
+    lr schd: 40000
     memory (GB): 10.6
+  Name: dmnet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.37
       mIoU(ms+flip): 79.72
-  Config: configs/dmnet/dmnet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r101-d8_512x1024_40k_cityscapes/dmnet_r101-d8_512x1024_40k_cityscapes_20201215_043100-8291e976.pth
-- Name: dmnet_r50-d8_769x769_40k_cityscapes
+- Config: configs/dmnet/dmnet_r50-d8_769x769_40k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 636.94
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 636.94
+    lr schd: 40000
     memory (GB): 7.9
+  Name: dmnet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.49
       mIoU(ms+flip): 80.27
-  Config: configs/dmnet/dmnet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r50-d8_769x769_40k_cityscapes/dmnet_r50-d8_769x769_40k_cityscapes_20201215_093706-e7f0e23e.pth
-- Name: dmnet_r101-d8_769x769_40k_cityscapes
+- Config: configs/dmnet/dmnet_r101-d8_769x769_40k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 990.1
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 990.1
+    lr schd: 40000
     memory (GB): 12.0
+  Name: dmnet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.62
       mIoU(ms+flip): 78.94
-  Config: configs/dmnet/dmnet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r101-d8_769x769_40k_cityscapes/dmnet_r101-d8_769x769_40k_cityscapes_20201215_081348-a74261f6.pth
-- Name: dmnet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/dmnet/dmnet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: dmnet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.07
       mIoU(ms+flip): 80.22
-  Config: configs/dmnet/dmnet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r50-d8_512x1024_80k_cityscapes/dmnet_r50-d8_512x1024_80k_cityscapes_20201215_053728-3c8893b9.pth
-- Name: dmnet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/dmnet/dmnet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: dmnet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.64
       mIoU(ms+flip): 80.67
-  Config: configs/dmnet/dmnet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r101-d8_512x1024_80k_cityscapes/dmnet_r101-d8_512x1024_80k_cityscapes_20201215_031718-fa081cb8.pth
-- Name: dmnet_r50-d8_769x769_80k_cityscapes
+- Config: configs/dmnet/dmnet_r50-d8_769x769_80k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: dmnet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.22
       mIoU(ms+flip): 80.55
-  Config: configs/dmnet/dmnet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r50-d8_769x769_80k_cityscapes/dmnet_r50-d8_769x769_80k_cityscapes_20201215_034006-6060840e.pth
-- Name: dmnet_r101-d8_769x769_80k_cityscapes
+- Config: configs/dmnet/dmnet_r101-d8_769x769_80k_cityscapes.py
   In Collection: dmnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: dmnet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.19
       mIoU(ms+flip): 80.65
-  Config: configs/dmnet/dmnet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r101-d8_769x769_80k_cityscapes/dmnet_r101-d8_769x769_80k_cityscapes_20201215_082810-7f0de59a.pth
-- Name: dmnet_r50-d8_512x512_80k_ade20k
+- Config: configs/dmnet/dmnet_r50-d8_512x512_80k_ade20k.py
   In Collection: dmnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 47.73
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.73
+    lr schd: 80000
     memory (GB): 9.4
+  Name: dmnet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.37
       mIoU(ms+flip): 43.62
-  Config: configs/dmnet/dmnet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r50-d8_512x512_80k_ade20k/dmnet_r50-d8_512x512_80k_ade20k_20201215_144744-f89092a6.pth
-- Name: dmnet_r101-d8_512x512_80k_ade20k
+- Config: configs/dmnet/dmnet_r101-d8_512x512_80k_ade20k.py
   In Collection: dmnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 72.05
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 72.05
+    lr schd: 80000
     memory (GB): 13.0
+  Name: dmnet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.34
       mIoU(ms+flip): 46.13
-  Config: configs/dmnet/dmnet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r101-d8_512x512_80k_ade20k/dmnet_r101-d8_512x512_80k_ade20k_20201215_104812-bfa45311.pth
-- Name: dmnet_r50-d8_512x512_160k_ade20k
+- Config: configs/dmnet/dmnet_r50-d8_512x512_160k_ade20k.py
   In Collection: dmnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: dmnet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.15
       mIoU(ms+flip): 44.17
-  Config: configs/dmnet/dmnet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r50-d8_512x512_160k_ade20k/dmnet_r50-d8_512x512_160k_ade20k_20201215_115313-025ab3f9.pth
-- Name: dmnet_r101-d8_512x512_160k_ade20k
+- Config: configs/dmnet/dmnet_r101-d8_512x512_160k_ade20k.py
   In Collection: dmnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: dmnet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.42
       mIoU(ms+flip): 46.76
-  Config: configs/dmnet/dmnet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dmnet/dmnet_r101-d8_512x512_160k_ade20k/dmnet_r101-d8_512x512_160k_ade20k_20201215_111145-a0bc02ef.pth

--- a/configs/dnlnet/dnlnet.yml
+++ b/configs/dnlnet/dnlnet.yml
@@ -1,219 +1,219 @@
 Collections:
-- Name: dnlnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
+  Name: dnlnet
 Models:
-- Name: dnl_r50-d8_512x1024_40k_cityscapes
+- Config: configs/dnlnet/dnl_r50-d8_512x1024_40k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 390.62
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 390.62
+    lr schd: 40000
     memory (GB): 7.3
+  Name: dnl_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.61
-  Config: configs/dnlnet/dnl_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r50-d8_512x1024_40k_cityscapes/dnl_r50-d8_512x1024_40k_cityscapes_20200904_233629-53d4ea93.pth
-- Name: dnl_r101-d8_512x1024_40k_cityscapes
+- Config: configs/dnlnet/dnl_r101-d8_512x1024_40k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 510.2
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 510.2
+    lr schd: 40000
     memory (GB): 10.9
+  Name: dnl_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.31
-  Config: configs/dnlnet/dnl_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r101-d8_512x1024_40k_cityscapes/dnl_r101-d8_512x1024_40k_cityscapes_20200904_233629-9928ffef.pth
-- Name: dnl_r50-d8_769x769_40k_cityscapes
+- Config: configs/dnlnet/dnl_r50-d8_769x769_40k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 666.67
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 666.67
+    lr schd: 40000
     memory (GB): 9.2
+  Name: dnl_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.44
       mIoU(ms+flip): 80.27
-  Config: configs/dnlnet/dnl_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r50-d8_769x769_40k_cityscapes/dnl_r50-d8_769x769_40k_cityscapes_20200820_232206-0f283785.pth
-- Name: dnl_r101-d8_769x769_40k_cityscapes
+- Config: configs/dnlnet/dnl_r101-d8_769x769_40k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 980.39
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 980.39
+    lr schd: 40000
     memory (GB): 12.6
+  Name: dnl_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.39
       mIoU(ms+flip): 77.77
-  Config: configs/dnlnet/dnl_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r101-d8_769x769_40k_cityscapes/dnl_r101-d8_769x769_40k_cityscapes_20200820_171256-76c596df.pth
-- Name: dnl_r50-d8_512x1024_80k_cityscapes
+- Config: configs/dnlnet/dnl_r50-d8_512x1024_80k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: dnl_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.33
-  Config: configs/dnlnet/dnl_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r50-d8_512x1024_80k_cityscapes/dnl_r50-d8_512x1024_80k_cityscapes_20200904_233629-58b2f778.pth
-- Name: dnl_r101-d8_512x1024_80k_cityscapes
+- Config: configs/dnlnet/dnl_r101-d8_512x1024_80k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: dnl_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.41
-  Config: configs/dnlnet/dnl_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r101-d8_512x1024_80k_cityscapes/dnl_r101-d8_512x1024_80k_cityscapes_20200904_233629-758e2dd4.pth
-- Name: dnl_r50-d8_769x769_80k_cityscapes
+- Config: configs/dnlnet/dnl_r50-d8_769x769_80k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: dnl_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.36
       mIoU(ms+flip): 80.7
-  Config: configs/dnlnet/dnl_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r50-d8_769x769_80k_cityscapes/dnl_r50-d8_769x769_80k_cityscapes_20200820_011925-366bc4c7.pth
-- Name: dnl_r101-d8_769x769_80k_cityscapes
+- Config: configs/dnlnet/dnl_r101-d8_769x769_80k_cityscapes.py
   In Collection: dnlnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: dnl_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.41
       mIoU(ms+flip): 80.68
-  Config: configs/dnlnet/dnl_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r101-d8_769x769_80k_cityscapes/dnl_r101-d8_769x769_80k_cityscapes_20200821_051111-95ff84ab.pth
-- Name: dnl_r50-d8_512x512_80k_ade20k
+- Config: configs/dnlnet/dnl_r50-d8_512x512_80k_ade20k.py
   In Collection: dnlnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 48.4
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 48.4
+    lr schd: 80000
     memory (GB): 8.8
+  Name: dnl_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.76
       mIoU(ms+flip): 42.99
-  Config: configs/dnlnet/dnl_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r50-d8_512x512_80k_ade20k/dnl_r50-d8_512x512_80k_ade20k_20200826_183354-1cf6e0c1.pth
-- Name: dnl_r101-d8_512x512_80k_ade20k
+- Config: configs/dnlnet/dnl_r101-d8_512x512_80k_ade20k.py
   In Collection: dnlnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 79.74
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 79.74
+    lr schd: 80000
     memory (GB): 12.8
+  Name: dnl_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.76
       mIoU(ms+flip): 44.91
-  Config: configs/dnlnet/dnl_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r101-d8_512x512_80k_ade20k/dnl_r101-d8_512x512_80k_ade20k_20200826_183354-d820d6ea.pth
-- Name: dnl_r50-d8_512x512_160k_ade20k
+- Config: configs/dnlnet/dnl_r50-d8_512x512_160k_ade20k.py
   In Collection: dnlnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: dnl_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.87
       mIoU(ms+flip): 43.01
-  Config: configs/dnlnet/dnl_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r50-d8_512x512_160k_ade20k/dnl_r50-d8_512x512_160k_ade20k_20200826_183350-37837798.pth
-- Name: dnl_r101-d8_512x512_160k_ade20k
+- Config: configs/dnlnet/dnl_r101-d8_512x512_160k_ade20k.py
   In Collection: dnlnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: dnl_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 44.25
       mIoU(ms+flip): 45.78
-  Config: configs/dnlnet/dnl_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/dnlnet/dnl_r101-d8_512x512_160k_ade20k/dnl_r101-d8_512x512_160k_ade20k_20200826_183350-ed522c61.pth

--- a/configs/emanet/emanet.yml
+++ b/configs/emanet/emanet.yml
@@ -1,94 +1,94 @@
 Collections:
-- Name: emanet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
+  Name: emanet
 Models:
-- Name: emanet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/emanet/emanet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: emanet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 218.34
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 218.34
+    lr schd: 80000
     memory (GB): 5.4
+  Name: emanet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.59
       mIoU(ms+flip): 79.44
-  Config: configs/emanet/emanet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/emanet/emanet_r50-d8_512x1024_80k_cityscapes/emanet_r50-d8_512x1024_80k_cityscapes_20200901_100301-c43fcef1.pth
-- Name: emanet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/emanet/emanet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: emanet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 348.43
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 348.43
+    lr schd: 80000
     memory (GB): 6.2
+  Name: emanet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.1
       mIoU(ms+flip): 81.21
-  Config: configs/emanet/emanet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/emanet/emanet_r101-d8_512x1024_80k_cityscapes/emanet_r101-d8_512x1024_80k_cityscapes_20200901_100301-2d970745.pth
-- Name: emanet_r50-d8_769x769_80k_cityscapes
+- Config: configs/emanet/emanet_r50-d8_769x769_80k_cityscapes.py
   In Collection: emanet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 507.61
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 507.61
+    lr schd: 80000
     memory (GB): 8.9
+  Name: emanet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.33
       mIoU(ms+flip): 80.49
-  Config: configs/emanet/emanet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/emanet/emanet_r50-d8_769x769_80k_cityscapes/emanet_r50-d8_769x769_80k_cityscapes_20200901_100301-16f8de52.pth
-- Name: emanet_r101-d8_769x769_80k_cityscapes
+- Config: configs/emanet/emanet_r101-d8_769x769_80k_cityscapes.py
   In Collection: emanet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 819.67
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 819.67
+    lr schd: 80000
     memory (GB): 10.1
+  Name: emanet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.62
       mIoU(ms+flip): 81.0
-  Config: configs/emanet/emanet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/emanet/emanet_r101-d8_769x769_80k_cityscapes/emanet_r101-d8_769x769_80k_cityscapes_20200901_100301-47a324ce.pth

--- a/configs/encnet/encnet.yml
+++ b/configs/encnet/encnet.yml
@@ -1,223 +1,223 @@
 Collections:
-- Name: encnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
+  Name: encnet
 Models:
-- Name: encnet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/encnet/encnet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 218.34
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 218.34
+    lr schd: 40000
     memory (GB): 8.6
+  Name: encnet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.67
       mIoU(ms+flip): 77.08
-  Config: configs/encnet/encnet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r50-d8_512x1024_40k_cityscapes/encnet_r50-d8_512x1024_40k_cityscapes_20200621_220958-68638a47.pth
-- Name: encnet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/encnet/encnet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 375.94
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 375.94
+    lr schd: 40000
     memory (GB): 12.1
+  Name: encnet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.81
       mIoU(ms+flip): 77.21
-  Config: configs/encnet/encnet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r101-d8_512x1024_40k_cityscapes/encnet_r101-d8_512x1024_40k_cityscapes_20200621_220933-35e0a3e8.pth
-- Name: encnet_r50-d8_769x769_40k_cityscapes
+- Config: configs/encnet/encnet_r50-d8_769x769_40k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 549.45
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 549.45
+    lr schd: 40000
     memory (GB): 9.8
+  Name: encnet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.24
       mIoU(ms+flip): 77.85
-  Config: configs/encnet/encnet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r50-d8_769x769_40k_cityscapes/encnet_r50-d8_769x769_40k_cityscapes_20200621_220958-3bcd2884.pth
-- Name: encnet_r101-d8_769x769_40k_cityscapes
+- Config: configs/encnet/encnet_r101-d8_769x769_40k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 793.65
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 793.65
+    lr schd: 40000
     memory (GB): 13.7
+  Name: encnet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 74.25
       mIoU(ms+flip): 76.25
-  Config: configs/encnet/encnet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r101-d8_769x769_40k_cityscapes/encnet_r101-d8_769x769_40k_cityscapes_20200621_220933-2fafed55.pth
-- Name: encnet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/encnet/encnet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: encnet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.94
       mIoU(ms+flip): 79.13
-  Config: configs/encnet/encnet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r50-d8_512x1024_80k_cityscapes/encnet_r50-d8_512x1024_80k_cityscapes_20200622_003554-fc5c5624.pth
-- Name: encnet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/encnet/encnet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: encnet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.55
       mIoU(ms+flip): 79.47
-  Config: configs/encnet/encnet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r101-d8_512x1024_80k_cityscapes/encnet_r101-d8_512x1024_80k_cityscapes_20200622_003555-1de64bec.pth
-- Name: encnet_r50-d8_769x769_80k_cityscapes
+- Config: configs/encnet/encnet_r50-d8_769x769_80k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: encnet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.44
       mIoU(ms+flip): 78.72
-  Config: configs/encnet/encnet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r50-d8_769x769_80k_cityscapes/encnet_r50-d8_769x769_80k_cityscapes_20200622_003554-55096dcb.pth
-- Name: encnet_r101-d8_769x769_80k_cityscapes
+- Config: configs/encnet/encnet_r101-d8_769x769_80k_cityscapes.py
   In Collection: encnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: encnet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.1
       mIoU(ms+flip): 76.97
-  Config: configs/encnet/encnet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r101-d8_769x769_80k_cityscapes/encnet_r101-d8_769x769_80k_cityscapes_20200622_003555-470ef79d.pth
-- Name: encnet_r50-d8_512x512_80k_ade20k
+- Config: configs/encnet/encnet_r50-d8_512x512_80k_ade20k.py
   In Collection: encnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 43.84
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 43.84
+    lr schd: 80000
     memory (GB): 10.1
+  Name: encnet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 39.53
       mIoU(ms+flip): 41.17
-  Config: configs/encnet/encnet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r50-d8_512x512_80k_ade20k/encnet_r50-d8_512x512_80k_ade20k_20200622_042412-44b46b04.pth
-- Name: encnet_r101-d8_512x512_80k_ade20k
+- Config: configs/encnet/encnet_r101-d8_512x512_80k_ade20k.py
   In Collection: encnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 67.25
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 67.25
+    lr schd: 80000
     memory (GB): 13.6
+  Name: encnet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.11
       mIoU(ms+flip): 43.61
-  Config: configs/encnet/encnet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r101-d8_512x512_80k_ade20k/encnet_r101-d8_512x512_80k_ade20k_20200622_101128-dd35e237.pth
-- Name: encnet_r50-d8_512x512_160k_ade20k
+- Config: configs/encnet/encnet_r50-d8_512x512_160k_ade20k.py
   In Collection: encnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: encnet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 40.1
       mIoU(ms+flip): 41.71
-  Config: configs/encnet/encnet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r50-d8_512x512_160k_ade20k/encnet_r50-d8_512x512_160k_ade20k_20200622_101059-b2db95e0.pth
-- Name: encnet_r101-d8_512x512_160k_ade20k
+- Config: configs/encnet/encnet_r101-d8_512x512_160k_ade20k.py
   In Collection: encnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: encnet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.61
       mIoU(ms+flip): 44.01
-  Config: configs/encnet/encnet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/encnet/encnet_r101-d8_512x512_160k_ade20k/encnet_r101-d8_512x512_160k_ade20k_20200622_073348-7989641f.pth

--- a/configs/fastscnn/fastscnn.yml
+++ b/configs/fastscnn/fastscnn.yml
@@ -1,28 +1,28 @@
 Collections:
-- Name: fastscnn
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
+  Name: fastscnn
 Models:
-- Name: fast_scnn_lr0.12_8x4_160k_cityscapes
+- Config: configs/fastscnn/fast_scnn_lr0.12_8x4_160k_cityscapes.py
   In Collection: fastscnn
   Metadata:
     backbone: Fast-SCNN
     crop size: (512,1024)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 17.71
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 17.71
+    lr schd: 160000
     memory (GB): 3.3
+  Name: fast_scnn_lr0.12_8x4_160k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 70.96
       mIoU(ms+flip): 72.65
-  Config: configs/fastscnn/fast_scnn_lr0.12_8x4_160k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fast_scnn/fast_scnn_8x4_160k_lr0.12_cityscapes-0cec9937.pth

--- a/configs/fcn/fcn.yml
+++ b/configs/fcn/fcn.yml
@@ -1,797 +1,797 @@
 Collections:
-- Name: fcn
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
     - Pascal Context
     - Pascal Context 59
+  Name: fcn
 Models:
-- Name: fcn_r50-d8_512x1024_40k_cityscapes
+- Config: configs/fcn/fcn_r50-d8_512x1024_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 239.81
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 239.81
+    lr schd: 40000
     memory (GB): 5.7
+  Name: fcn_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 72.25
       mIoU(ms+flip): 73.36
-  Config: configs/fcn/fcn_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_512x1024_40k_cityscapes/fcn_r50-d8_512x1024_40k_cityscapes_20200604_192608-efe53f0d.pth
-- Name: fcn_r101-d8_512x1024_40k_cityscapes
+- Config: configs/fcn/fcn_r101-d8_512x1024_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 375.94
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 375.94
+    lr schd: 40000
     memory (GB): 9.2
+  Name: fcn_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.45
       mIoU(ms+flip): 76.58
-  Config: configs/fcn/fcn_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_512x1024_40k_cityscapes/fcn_r101-d8_512x1024_40k_cityscapes_20200604_181852-a883d3a1.pth
-- Name: fcn_r50-d8_769x769_40k_cityscapes
+- Config: configs/fcn/fcn_r50-d8_769x769_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 555.56
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 555.56
+    lr schd: 40000
     memory (GB): 6.5
+  Name: fcn_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 71.47
       mIoU(ms+flip): 72.54
-  Config: configs/fcn/fcn_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_769x769_40k_cityscapes/fcn_r50-d8_769x769_40k_cityscapes_20200606_113104-977b5d02.pth
-- Name: fcn_r101-d8_769x769_40k_cityscapes
+- Config: configs/fcn/fcn_r101-d8_769x769_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 840.34
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 840.34
+    lr schd: 40000
     memory (GB): 10.4
+  Name: fcn_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 73.93
       mIoU(ms+flip): 75.14
-  Config: configs/fcn/fcn_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_769x769_40k_cityscapes/fcn_r101-d8_769x769_40k_cityscapes_20200606_113208-7d4ab69c.pth
-- Name: fcn_r18-d8_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_r18-d8_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-18-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 68.26
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 68.26
+    lr schd: 80000
     memory (GB): 1.7
+  Name: fcn_r18-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 71.11
       mIoU(ms+flip): 72.91
-  Config: configs/fcn/fcn_r18-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r18-d8_512x1024_80k_cityscapes/fcn_r18-d8_512x1024_80k_cityscapes_20201225_021327-6c50f8b4.pth
-- Name: fcn_r50-d8_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_r50-d8_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: fcn_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 73.61
       mIoU(ms+flip): 74.24
-  Config: configs/fcn/fcn_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_512x1024_80k_cityscapes/fcn_r50-d8_512x1024_80k_cityscapes_20200606_113019-03aa804d.pth
-- Name: fcn_r101-d8_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_r101-d8_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: fcn_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.13
       mIoU(ms+flip): 75.94
-  Config: configs/fcn/fcn_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_512x1024_80k_cityscapes/fcn_r101-d8_512x1024_80k_cityscapes_20200606_113038-3fb937eb.pth
-- Name: fcn_r18-d8_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_r18-d8_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-18-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 156.25
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 156.25
+    lr schd: 80000
     memory (GB): 1.9
+  Name: fcn_r18-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 70.8
       mIoU(ms+flip): 73.16
-  Config: configs/fcn/fcn_r18-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r18-d8_769x769_80k_cityscapes/fcn_r18-d8_769x769_80k_cityscapes_20201225_021451-9739d1b8.pth
-- Name: fcn_r50-d8_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_r50-d8_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: fcn_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 72.64
       mIoU(ms+flip): 73.32
-  Config: configs/fcn/fcn_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_769x769_80k_cityscapes/fcn_r50-d8_769x769_80k_cityscapes_20200606_195749-f5caeabc.pth
-- Name: fcn_r101-d8_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_r101-d8_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: fcn_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.52
       mIoU(ms+flip): 76.61
-  Config: configs/fcn/fcn_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_769x769_80k_cityscapes/fcn_r101-d8_769x769_80k_cityscapes_20200606_214354-45cbac68.pth
-- Name: fcn_r18b-d8_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_r18b-d8_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-18b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 59.74
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 59.74
+    lr schd: 80000
     memory (GB): 1.6
+  Name: fcn_r18b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 70.24
       mIoU(ms+flip): 72.77
-  Config: configs/fcn/fcn_r18b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r18b-d8_512x1024_80k_cityscapes/fcn_r18b-d8_512x1024_80k_cityscapes_20201225_230143-92c0f445.pth
-- Name: fcn_r50b-d8_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_r50b-d8_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 238.1
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 238.1
+    lr schd: 80000
     memory (GB): 5.6
+  Name: fcn_r50b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.65
       mIoU(ms+flip): 77.59
-  Config: configs/fcn/fcn_r50b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50b-d8_512x1024_80k_cityscapes/fcn_r50b-d8_512x1024_80k_cityscapes_20201225_094221-82957416.pth
-- Name: fcn_r101b-d8_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_r101b-d8_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 366.3
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 366.3
+    lr schd: 80000
     memory (GB): 9.1
+  Name: fcn_r101b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.37
       mIoU(ms+flip): 78.77
-  Config: configs/fcn/fcn_r101b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101b-d8_512x1024_80k_cityscapes/fcn_r101b-d8_512x1024_80k_cityscapes_20201226_160213-4543858f.pth
-- Name: fcn_r18b-d8_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_r18b-d8_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-18b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 149.25
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 149.25
+    lr schd: 80000
     memory (GB): 1.7
+  Name: fcn_r18b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 69.66
       mIoU(ms+flip): 72.07
-  Config: configs/fcn/fcn_r18b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r18b-d8_769x769_80k_cityscapes/fcn_r18b-d8_769x769_80k_cityscapes_20201226_004430-32d504e5.pth
-- Name: fcn_r50b-d8_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_r50b-d8_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 549.45
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 549.45
+    lr schd: 80000
     memory (GB): 6.3
+  Name: fcn_r50b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 73.83
       mIoU(ms+flip): 76.6
-  Config: configs/fcn/fcn_r50b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50b-d8_769x769_80k_cityscapes/fcn_r50b-d8_769x769_80k_cityscapes_20201225_094223-94552d38.pth
-- Name: fcn_r101b-d8_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_r101b-d8_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 869.57
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 869.57
+    lr schd: 80000
     memory (GB): 10.3
+  Name: fcn_r101b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.02
       mIoU(ms+flip): 78.67
-  Config: configs/fcn/fcn_r101b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101b-d8_769x769_80k_cityscapes/fcn_r101b-d8_769x769_80k_cityscapes_20201226_170012-82be37e2.pth
-- Name: fcn_d6_r50-d16_512x1024_40k_cityscapes
+- Config: configs/fcn/fcn_d6_r50-d16_512x1024_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D16
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 97.85
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 97.85
+    lr schd: 40000
     memory (GB): 3.4
+  Name: fcn_d6_r50-d16_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.06
       mIoU(ms+flip): 78.85
-  Config: configs/fcn/fcn_d6_r50-d16_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r50-d16_512x1024_40k_cityscapes/fcn_d6_r50-d16_512x1024_40k_cityscapes-98d5d1bc.pth
-- Name: fcn_d6_r50-d16_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r50-d16_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D16
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 96.62
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 96.62
+    lr schd: 80000
+  Name: fcn_d6_r50-d16_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.27
       mIoU(ms+flip): 78.88
-  Config: configs/fcn/fcn_d6_r50-d16_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r50-d16_512x1024_80k_cityscapes/fcn_d6_r50-d16_512x1024_40k_cityscapes-98d5d1bc.pth
-- Name: fcn_d6_r50-d16_769x769_40k_cityscapes
+- Config: configs/fcn/fcn_d6_r50-d16_769x769_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D16
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 239.81
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 239.81
+    lr schd: 40000
     memory (GB): 3.7
+  Name: fcn_d6_r50-d16_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.82
       mIoU(ms+flip): 78.22
-  Config: configs/fcn/fcn_d6_r50-d16_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r50-d16_769x769_40k_cityscapes/fcn_d6_r50-d16_769x769_40k_cityscapes-1aab18ed.pth
-- Name: fcn_d6_r50-d16_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r50-d16_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D16
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 240.96
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 240.96
+    lr schd: 80000
+  Name: fcn_d6_r50-d16_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.04
       mIoU(ms+flip): 78.4
-  Config: configs/fcn/fcn_d6_r50-d16_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r50-d16_769x769_80k_cityscapes/fcn_d6_r50-d16_769x769_80k_cityscapes-109d88eb.pth
-- Name: fcn_d6_r101-d16_512x1024_40k_cityscapes
+- Config: configs/fcn/fcn_d6_r101-d16_512x1024_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D16
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 124.38
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 124.38
+    lr schd: 40000
     memory (GB): 4.5
+  Name: fcn_d6_r101-d16_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.36
       mIoU(ms+flip): 79.18
-  Config: configs/fcn/fcn_d6_r101-d16_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r101-d16_512x1024_40k_cityscapes/fcn_d6_r101-d16_512x1024_40k_cityscapes-9cf2b450.pth
-- Name: fcn_d6_r101-d16_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r101-d16_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D16
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 121.07
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 121.07
+    lr schd: 80000
+  Name: fcn_d6_r101-d16_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.46
       mIoU(ms+flip): 80.42
-  Config: configs/fcn/fcn_d6_r101-d16_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r101-d16_512x1024_80k_cityscapes/fcn_d6_r101-d16_512x1024_80k_cityscapes-cb336445.pth
-- Name: fcn_d6_r101-d16_769x769_40k_cityscapes
+- Config: configs/fcn/fcn_d6_r101-d16_769x769_40k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D16
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 320.51
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 320.51
+    lr schd: 40000
     memory (GB): 5.0
+  Name: fcn_d6_r101-d16_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.28
       mIoU(ms+flip): 78.95
-  Config: configs/fcn/fcn_d6_r101-d16_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r101-d16_769x769_40k_cityscapes/fcn_d6_r101-d16_769x769_40k_cityscapes-60b114e9.pth
-- Name: fcn_d6_r101-d16_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r101-d16_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D16
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 311.53
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 311.53
+    lr schd: 80000
+  Name: fcn_d6_r101-d16_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.06
       mIoU(ms+flip): 79.58
-  Config: configs/fcn/fcn_d6_r101-d16_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r101-d16_769x769_80k_cityscapes/fcn_d6_r101-d16_769x769_80k_cityscapes-e33adc4f.pth
-- Name: fcn_d6_r50b-d16_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r50b-d16_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50b-D16
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 98.43
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 98.43
+    lr schd: 80000
     memory (GB): 3.2
+  Name: fcn_d6_r50b-d16_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.99
       mIoU(ms+flip): 79.03
-  Config: configs/fcn/fcn_d6_r50b-d16_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r50b_d16_512x1024_80k_cityscapes/fcn_d6_r50b_d16_512x1024_80k_cityscapes-6a0b62e9.pth
-- Name: fcn_d6_r50b-d16_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r50b-d16_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-50b-D16
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 239.81
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 239.81
+    lr schd: 80000
     memory (GB): 3.6
+  Name: fcn_d6_r50b-d16_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.86
       mIoU(ms+flip): 78.52
-  Config: configs/fcn/fcn_d6_r50b-d16_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r50b_d16_769x769_80k_cityscapes/fcn_d6_r50b_d16_769x769_80k_cityscapes-d665f231.pth
-- Name: fcn_d6_r101b-d16_512x1024_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r101b-d16_512x1024_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101b-D16
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 118.2
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 118.2
+    lr schd: 80000
     memory (GB): 4.3
+  Name: fcn_d6_r101b-d16_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.72
       mIoU(ms+flip): 79.53
-  Config: configs/fcn/fcn_d6_r101b-d16_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r101b_d16_512x1024_80k_cityscapes/fcn_d6_r101b_d16_512x1024_80k_cityscapes-3f2eb5b4.pth
-- Name: fcn_d6_r101b-d16_769x769_80k_cityscapes
+- Config: configs/fcn/fcn_d6_r101b-d16_769x769_80k_cityscapes.py
   In Collection: fcn
   Metadata:
     backbone: R-101b-D16
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 301.2
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 301.2
+    lr schd: 80000
     memory (GB): 4.8
+  Name: fcn_d6_r101b-d16_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.34
       mIoU(ms+flip): 78.91
-  Config: configs/fcn/fcn_d6_r101b-d16_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_d6_r101b_d16_769x769_80k_cityscapes/fcn_d6_r101b_d16_769x769_80k_cityscapes-c4d8bfbc.pth
-- Name: fcn_r50-d8_512x512_80k_ade20k
+- Config: configs/fcn/fcn_r50-d8_512x512_80k_ade20k.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 42.57
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.57
+    lr schd: 80000
     memory (GB): 8.5
+  Name: fcn_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 35.94
       mIoU(ms+flip): 37.94
-  Config: configs/fcn/fcn_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_512x512_80k_ade20k/fcn_r50-d8_512x512_80k_ade20k_20200614_144016-f8ac5082.pth
-- Name: fcn_r101-d8_512x512_80k_ade20k
+- Config: configs/fcn/fcn_r101-d8_512x512_80k_ade20k.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 67.66
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 67.66
+    lr schd: 80000
     memory (GB): 12.0
+  Name: fcn_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 39.61
       mIoU(ms+flip): 40.83
-  Config: configs/fcn/fcn_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_512x512_80k_ade20k/fcn_r101-d8_512x512_80k_ade20k_20200615_014143-bc1809f7.pth
-- Name: fcn_r50-d8_512x512_160k_ade20k
+- Config: configs/fcn/fcn_r50-d8_512x512_160k_ade20k.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: fcn_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 36.1
       mIoU(ms+flip): 38.08
-  Config: configs/fcn/fcn_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_512x512_160k_ade20k/fcn_r50-d8_512x512_160k_ade20k_20200615_100713-4edbc3b4.pth
-- Name: fcn_r101-d8_512x512_160k_ade20k
+- Config: configs/fcn/fcn_r101-d8_512x512_160k_ade20k.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: fcn_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 39.91
       mIoU(ms+flip): 41.4
-  Config: configs/fcn/fcn_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_512x512_160k_ade20k/fcn_r101-d8_512x512_160k_ade20k_20200615_105816-fd192bd5.pth
-- Name: fcn_r50-d8_512x512_20k_voc12aug
+- Config: configs/fcn/fcn_r50-d8_512x512_20k_voc12aug.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 42.96
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.96
+    lr schd: 20000
     memory (GB): 5.7
+  Name: fcn_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 67.08
       mIoU(ms+flip): 69.94
-  Config: configs/fcn/fcn_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_512x512_20k_voc12aug/fcn_r50-d8_512x512_20k_voc12aug_20200617_010715-52dc5306.pth
-- Name: fcn_r101-d8_512x512_20k_voc12aug
+- Config: configs/fcn/fcn_r101-d8_512x512_20k_voc12aug.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 67.52
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 67.52
+    lr schd: 20000
     memory (GB): 9.2
+  Name: fcn_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 71.16
       mIoU(ms+flip): 73.57
-  Config: configs/fcn/fcn_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_512x512_20k_voc12aug/fcn_r101-d8_512x512_20k_voc12aug_20200617_010842-0bb4e798.pth
-- Name: fcn_r50-d8_512x512_40k_voc12aug
+- Config: configs/fcn/fcn_r50-d8_512x512_40k_voc12aug.py
   In Collection: fcn
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: fcn_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 66.97
       mIoU(ms+flip): 69.04
-  Config: configs/fcn/fcn_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r50-d8_512x512_40k_voc12aug/fcn_r50-d8_512x512_40k_voc12aug_20200613_161222-5e2dbf40.pth
-- Name: fcn_r101-d8_512x512_40k_voc12aug
+- Config: configs/fcn/fcn_r101-d8_512x512_40k_voc12aug.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: fcn_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 69.91
       mIoU(ms+flip): 72.38
-  Config: configs/fcn/fcn_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_512x512_40k_voc12aug/fcn_r101-d8_512x512_40k_voc12aug_20200613_161240-4c8bcefd.pth
-- Name: fcn_r101-d8_480x480_40k_pascal_context
+- Config: configs/fcn/fcn_r101-d8_480x480_40k_pascal_context.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 100.7
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (480,480)
+      value: 100.7
+    lr schd: 40000
+  Name: fcn_r101-d8_480x480_40k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 44.43
       mIoU(ms+flip): 45.63
-  Config: configs/fcn/fcn_r101-d8_480x480_40k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_480x480_40k_pascal_context/fcn_r101-d8_480x480_40k_pascal_context-20210421_154757-b5e97937.pth
-- Name: fcn_r101-d8_480x480_80k_pascal_context
+- Config: configs/fcn/fcn_r101-d8_480x480_80k_pascal_context.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: fcn_r101-d8_480x480_80k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 44.13
       mIoU(ms+flip): 45.26
-  Config: configs/fcn/fcn_r101-d8_480x480_80k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_480x480_80k_pascal_context/fcn_r101-d8_480x480_80k_pascal_context-20210421_163310-4711813f.pth
-- Name: fcn_r101-d8_480x480_40k_pascal_context_59
+- Config: configs/fcn/fcn_r101-d8_480x480_40k_pascal_context_59.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 40000
+  Name: fcn_r101-d8_480x480_40k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 48.42
       mIoU(ms+flip): 50.4
-  Config: configs/fcn/fcn_r101-d8_480x480_40k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_480x480_40k_pascal_context_59/fcn_r101-d8_480x480_40k_pascal_context_59_20210415_230724-8cf83682.pth
-- Name: fcn_r101-d8_480x480_80k_pascal_context_59
+- Config: configs/fcn/fcn_r101-d8_480x480_80k_pascal_context_59.py
   In Collection: fcn
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: fcn_r101-d8_480x480_80k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 49.35
       mIoU(ms+flip): 51.38
-  Config: configs/fcn/fcn_r101-d8_480x480_80k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fcn/fcn_r101-d8_480x480_80k_pascal_context_59/fcn_r101-d8_480x480_80k_pascal_context_59_20210416_110804-9a6f2c94.pth

--- a/configs/fp16/fp16.yml
+++ b/configs/fp16/fp16.yml
@@ -1,90 +1,90 @@
 Collections:
-- Name: fp16
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
+  Name: fp16
 Models:
-- Name: fcn_r101-d8_512x1024_80k_fp16_cityscapes
+- Config: configs/fp16/fcn_r101-d8_512x1024_80k_fp16_cityscapes.py
   In Collection: fp16
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 115.74
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 115.74
+    lr schd: 80000
     memory (GB): 5.37
+  Name: fcn_r101-d8_512x1024_80k_fp16_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.8
-  Config: configs/fp16/fcn_r101-d8_512x1024_80k_fp16_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fp16/fcn_r101-d8_512x1024_80k_fp16_cityscapes/fcn_r101-d8_512x1024_80k_fp16_cityscapes-50245227.pth
-- Name: pspnet_r101-d8_512x1024_80k_fp16_cityscapes
+- Config: configs/fp16/pspnet_r101-d8_512x1024_80k_fp16_cityscapes.py
   In Collection: fp16
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 114.03
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 114.03
+    lr schd: 80000
     memory (GB): 5.34
+  Name: pspnet_r101-d8_512x1024_80k_fp16_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.46
-  Config: configs/fp16/pspnet_r101-d8_512x1024_80k_fp16_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fp16/pspnet_r101-d8_512x1024_80k_fp16_cityscapes/pspnet_r101-d8_512x1024_80k_fp16_cityscapes-ade37931.pth
-- Name: deeplabv3_r101-d8_512x1024_80k_fp16_cityscapes
+- Config: configs/fp16/deeplabv3_r101-d8_512x1024_80k_fp16_cityscapes.py
   In Collection: fp16
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 259.07
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 259.07
+    lr schd: 80000
     memory (GB): 5.75
+  Name: deeplabv3_r101-d8_512x1024_80k_fp16_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.48
-  Config: configs/fp16/deeplabv3_r101-d8_512x1024_80k_fp16_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fp16/deeplabv3_r101-d8_512x1024_80k_fp16_cityscapes/deeplabv3_r101-d8_512x1024_80k_fp16_cityscapes-bc86dc84.pth
-- Name: deeplabv3plus_r101-d8_512x1024_80k_fp16_cityscapes
+- Config: configs/fp16/deeplabv3plus_r101-d8_512x1024_80k_fp16_cityscapes.py
   In Collection: fp16
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 127.06
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 127.06
+    lr schd: 80000
     memory (GB): 6.35
+  Name: deeplabv3plus_r101-d8_512x1024_80k_fp16_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.46
-  Config: configs/fp16/deeplabv3plus_r101-d8_512x1024_80k_fp16_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/fp16/deeplabv3plus_r101-d8_512x1024_80k_fp16_cityscapes/deeplabv3plus_r101-d8_512x1024_80k_fp16_cityscapes-cc58bc8d.pth

--- a/configs/gcnet/gcnet.yml
+++ b/configs/gcnet/gcnet.yml
@@ -1,296 +1,296 @@
 Collections:
-- Name: gcnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: gcnet
 Models:
-- Name: gcnet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/gcnet/gcnet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 254.45
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 254.45
+    lr schd: 40000
     memory (GB): 5.8
+  Name: gcnet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.69
       mIoU(ms+flip): 78.56
-  Config: configs/gcnet/gcnet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_512x1024_40k_cityscapes/gcnet_r50-d8_512x1024_40k_cityscapes_20200618_074436-4b0fd17b.pth
-- Name: gcnet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/gcnet/gcnet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 383.14
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 383.14
+    lr schd: 40000
     memory (GB): 9.2
+  Name: gcnet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.28
       mIoU(ms+flip): 79.34
-  Config: configs/gcnet/gcnet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_512x1024_40k_cityscapes/gcnet_r101-d8_512x1024_40k_cityscapes_20200618_074436-5e62567f.pth
-- Name: gcnet_r50-d8_769x769_40k_cityscapes
+- Config: configs/gcnet/gcnet_r50-d8_769x769_40k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 598.8
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 598.8
+    lr schd: 40000
     memory (GB): 6.5
+  Name: gcnet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.12
       mIoU(ms+flip): 80.09
-  Config: configs/gcnet/gcnet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_769x769_40k_cityscapes/gcnet_r50-d8_769x769_40k_cityscapes_20200618_182814-a26f4471.pth
-- Name: gcnet_r101-d8_769x769_40k_cityscapes
+- Config: configs/gcnet/gcnet_r101-d8_769x769_40k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 884.96
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 884.96
+    lr schd: 40000
     memory (GB): 10.5
+  Name: gcnet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.95
       mIoU(ms+flip): 80.71
-  Config: configs/gcnet/gcnet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_769x769_40k_cityscapes/gcnet_r101-d8_769x769_40k_cityscapes_20200619_092550-ca4f0a84.pth
-- Name: gcnet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/gcnet/gcnet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: gcnet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.48
       mIoU(ms+flip): 80.01
-  Config: configs/gcnet/gcnet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_512x1024_80k_cityscapes/gcnet_r50-d8_512x1024_80k_cityscapes_20200618_074450-ef8f069b.pth
-- Name: gcnet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/gcnet/gcnet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: gcnet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.03
       mIoU(ms+flip): 79.84
-  Config: configs/gcnet/gcnet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_512x1024_80k_cityscapes/gcnet_r101-d8_512x1024_80k_cityscapes_20200618_074450-778ebf69.pth
-- Name: gcnet_r50-d8_769x769_80k_cityscapes
+- Config: configs/gcnet/gcnet_r50-d8_769x769_80k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: gcnet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.68
       mIoU(ms+flip): 80.66
-  Config: configs/gcnet/gcnet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_769x769_80k_cityscapes/gcnet_r50-d8_769x769_80k_cityscapes_20200619_092516-4839565b.pth
-- Name: gcnet_r101-d8_769x769_80k_cityscapes
+- Config: configs/gcnet/gcnet_r101-d8_769x769_80k_cityscapes.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: gcnet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.18
       mIoU(ms+flip): 80.71
-  Config: configs/gcnet/gcnet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_769x769_80k_cityscapes/gcnet_r101-d8_769x769_80k_cityscapes_20200619_092628-8e043423.pth
-- Name: gcnet_r50-d8_512x512_80k_ade20k
+- Config: configs/gcnet/gcnet_r50-d8_512x512_80k_ade20k.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 42.77
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.77
+    lr schd: 80000
     memory (GB): 8.5
+  Name: gcnet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.47
       mIoU(ms+flip): 42.85
-  Config: configs/gcnet/gcnet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_512x512_80k_ade20k/gcnet_r50-d8_512x512_80k_ade20k_20200614_185146-91a6da41.pth
-- Name: gcnet_r101-d8_512x512_80k_ade20k
+- Config: configs/gcnet/gcnet_r101-d8_512x512_80k_ade20k.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 65.79
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 65.79
+    lr schd: 80000
     memory (GB): 12.0
+  Name: gcnet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.82
       mIoU(ms+flip): 44.54
-  Config: configs/gcnet/gcnet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_512x512_80k_ade20k/gcnet_r101-d8_512x512_80k_ade20k_20200615_020811-c3fcb6dd.pth
-- Name: gcnet_r50-d8_512x512_160k_ade20k
+- Config: configs/gcnet/gcnet_r50-d8_512x512_160k_ade20k.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: gcnet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.37
       mIoU(ms+flip): 43.52
-  Config: configs/gcnet/gcnet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_512x512_160k_ade20k/gcnet_r50-d8_512x512_160k_ade20k_20200615_224122-d95f3e1f.pth
-- Name: gcnet_r101-d8_512x512_160k_ade20k
+- Config: configs/gcnet/gcnet_r101-d8_512x512_160k_ade20k.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: gcnet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.69
       mIoU(ms+flip): 45.21
-  Config: configs/gcnet/gcnet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_512x512_160k_ade20k/gcnet_r101-d8_512x512_160k_ade20k_20200615_225406-615528d7.pth
-- Name: gcnet_r50-d8_512x512_20k_voc12aug
+- Config: configs/gcnet/gcnet_r50-d8_512x512_20k_voc12aug.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 42.83
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.83
+    lr schd: 20000
     memory (GB): 5.8
+  Name: gcnet_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.42
       mIoU(ms+flip): 77.51
-  Config: configs/gcnet/gcnet_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_512x512_20k_voc12aug/gcnet_r50-d8_512x512_20k_voc12aug_20200617_165701-3cbfdab1.pth
-- Name: gcnet_r101-d8_512x512_20k_voc12aug
+- Config: configs/gcnet/gcnet_r101-d8_512x512_20k_voc12aug.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 67.57
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 67.57
+    lr schd: 20000
     memory (GB): 9.2
+  Name: gcnet_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.41
       mIoU(ms+flip): 78.56
-  Config: configs/gcnet/gcnet_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_512x512_20k_voc12aug/gcnet_r101-d8_512x512_20k_voc12aug_20200617_165713-6c720aa9.pth
-- Name: gcnet_r50-d8_512x512_40k_voc12aug
+- Config: configs/gcnet/gcnet_r50-d8_512x512_40k_voc12aug.py
   In Collection: gcnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: gcnet_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.24
       mIoU(ms+flip): 77.63
-  Config: configs/gcnet/gcnet_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r50-d8_512x512_40k_voc12aug/gcnet_r50-d8_512x512_40k_voc12aug_20200613_195105-9797336d.pth
-- Name: gcnet_r101-d8_512x512_40k_voc12aug
+- Config: configs/gcnet/gcnet_r101-d8_512x512_40k_voc12aug.py
   In Collection: gcnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: gcnet_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.84
       mIoU(ms+flip): 78.59
-  Config: configs/gcnet/gcnet_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/gcnet/gcnet_r101-d8_512x512_40k_voc12aug/gcnet_r101-d8_512x512_40k_voc12aug_20200613_185806-1e38208d.pth

--- a/configs/hrnet/hrnet.yml
+++ b/configs/hrnet/hrnet.yml
@@ -1,440 +1,440 @@
 Collections:
-- Name: hrnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
     - Pascal Context
     - Pascal Context 59
+  Name: hrnet
 Models:
-- Name: fcn_hr18s_512x1024_40k_cityscapes
+- Config: configs/hrnet/fcn_hr18s_512x1024_40k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 42.12
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 42.12
+    lr schd: 40000
     memory (GB): 1.7
+  Name: fcn_hr18s_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 73.86
       mIoU(ms+flip): 75.91
-  Config: configs/hrnet/fcn_hr18s_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18s_512x1024_40k_cityscapes/fcn_hr18s_512x1024_40k_cityscapes_20200601_014216-93db27d0.pth
-- Name: fcn_hr18_512x1024_40k_cityscapes
+- Config: configs/hrnet/fcn_hr18_512x1024_40k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 77.1
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 77.1
+    lr schd: 40000
     memory (GB): 2.9
+  Name: fcn_hr18_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.19
       mIoU(ms+flip): 78.92
-  Config: configs/hrnet/fcn_hr18_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18_512x1024_40k_cityscapes/fcn_hr18_512x1024_40k_cityscapes_20200601_014216-f196fb4e.pth
-- Name: fcn_hr48_512x1024_40k_cityscapes
+- Config: configs/hrnet/fcn_hr48_512x1024_40k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 155.76
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 155.76
+    lr schd: 40000
     memory (GB): 6.2
+  Name: fcn_hr48_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.48
       mIoU(ms+flip): 79.69
-  Config: configs/hrnet/fcn_hr48_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_512x1024_40k_cityscapes/fcn_hr48_512x1024_40k_cityscapes_20200601_014240-a989b146.pth
-- Name: fcn_hr18s_512x1024_80k_cityscapes
+- Config: configs/hrnet/fcn_hr18s_512x1024_80k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,1024)
     lr schd: 80000
+  Name: fcn_hr18s_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.31
       mIoU(ms+flip): 77.48
-  Config: configs/hrnet/fcn_hr18s_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18s_512x1024_80k_cityscapes/fcn_hr18s_512x1024_80k_cityscapes_20200601_202700-1462b75d.pth
-- Name: fcn_hr18_512x1024_80k_cityscapes
+- Config: configs/hrnet/fcn_hr18_512x1024_80k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,1024)
     lr schd: 80000
+  Name: fcn_hr18_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.65
       mIoU(ms+flip): 80.35
-  Config: configs/hrnet/fcn_hr18_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18_512x1024_80k_cityscapes/fcn_hr18_512x1024_80k_cityscapes_20200601_223255-4e7b345e.pth
-- Name: fcn_hr48_512x1024_80k_cityscapes
+- Config: configs/hrnet/fcn_hr48_512x1024_80k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,1024)
     lr schd: 80000
+  Name: fcn_hr48_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.93
       mIoU(ms+flip): 80.72
-  Config: configs/hrnet/fcn_hr48_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_512x1024_80k_cityscapes/fcn_hr48_512x1024_80k_cityscapes_20200601_202606-58ea95d6.pth
-- Name: fcn_hr18s_512x1024_160k_cityscapes
+- Config: configs/hrnet/fcn_hr18s_512x1024_160k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,1024)
     lr schd: 160000
+  Name: fcn_hr18s_512x1024_160k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.31
       mIoU(ms+flip): 78.31
-  Config: configs/hrnet/fcn_hr18s_512x1024_160k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18s_512x1024_160k_cityscapes/fcn_hr18s_512x1024_160k_cityscapes_20200602_190901-4a0797ea.pth
-- Name: fcn_hr18_512x1024_160k_cityscapes
+- Config: configs/hrnet/fcn_hr18_512x1024_160k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,1024)
     lr schd: 160000
+  Name: fcn_hr18_512x1024_160k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.8
       mIoU(ms+flip): 80.74
-  Config: configs/hrnet/fcn_hr18_512x1024_160k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18_512x1024_160k_cityscapes/fcn_hr18_512x1024_160k_cityscapes_20200602_190822-221e4a4f.pth
-- Name: fcn_hr48_512x1024_160k_cityscapes
+- Config: configs/hrnet/fcn_hr48_512x1024_160k_cityscapes.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,1024)
     lr schd: 160000
+  Name: fcn_hr48_512x1024_160k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.65
       mIoU(ms+flip): 81.92
-  Config: configs/hrnet/fcn_hr48_512x1024_160k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_512x1024_160k_cityscapes/fcn_hr48_512x1024_160k_cityscapes_20200602_190946-59b7973e.pth
-- Name: fcn_hr18s_512x512_80k_ade20k
+- Config: configs/hrnet/fcn_hr18s_512x512_80k_ade20k.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 25.87
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 25.87
+    lr schd: 80000
     memory (GB): 3.8
+  Name: fcn_hr18s_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 31.38
       mIoU(ms+flip): 32.45
-  Config: configs/hrnet/fcn_hr18s_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18s_512x512_80k_ade20k/fcn_hr18s_512x512_80k_ade20k_20200614_144345-77fc814a.pth
-- Name: fcn_hr18_512x512_80k_ade20k
+- Config: configs/hrnet/fcn_hr18_512x512_80k_ade20k.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 44.31
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 44.31
+    lr schd: 80000
     memory (GB): 4.9
+  Name: fcn_hr18_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 35.51
       mIoU(ms+flip): 36.8
-  Config: configs/hrnet/fcn_hr18_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18_512x512_80k_ade20k/fcn_hr18_512x512_80k_ade20k_20200614_185145-66f20cb7.pth
-- Name: fcn_hr48_512x512_80k_ade20k
+- Config: configs/hrnet/fcn_hr48_512x512_80k_ade20k.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 47.1
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.1
+    lr schd: 80000
     memory (GB): 8.2
+  Name: fcn_hr48_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.9
       mIoU(ms+flip): 43.27
-  Config: configs/hrnet/fcn_hr48_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_512x512_80k_ade20k/fcn_hr48_512x512_80k_ade20k_20200614_193946-7ba5258d.pth
-- Name: fcn_hr18s_512x512_160k_ade20k
+- Config: configs/hrnet/fcn_hr18s_512x512_160k_ade20k.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
     lr schd: 160000
+  Name: fcn_hr18s_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 33.0
       mIoU(ms+flip): 34.55
-  Config: configs/hrnet/fcn_hr18s_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18s_512x512_160k_ade20k/fcn_hr18s_512x512_160k_ade20k_20200614_214413-870f65ac.pth
-- Name: fcn_hr18_512x512_160k_ade20k
+- Config: configs/hrnet/fcn_hr18_512x512_160k_ade20k.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
     lr schd: 160000
+  Name: fcn_hr18_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 36.79
       mIoU(ms+flip): 38.58
-  Config: configs/hrnet/fcn_hr18_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18_512x512_160k_ade20k/fcn_hr18_512x512_160k_ade20k_20200614_214426-ca961836.pth
-- Name: fcn_hr48_512x512_160k_ade20k
+- Config: configs/hrnet/fcn_hr48_512x512_160k_ade20k.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
     lr schd: 160000
+  Name: fcn_hr48_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.02
       mIoU(ms+flip): 43.86
-  Config: configs/hrnet/fcn_hr48_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_512x512_160k_ade20k/fcn_hr48_512x512_160k_ade20k_20200614_214407-a52fc02c.pth
-- Name: fcn_hr18s_512x512_20k_voc12aug
+- Config: configs/hrnet/fcn_hr18s_512x512_20k_voc12aug.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 23.06
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 23.06
+    lr schd: 20000
     memory (GB): 1.8
+  Name: fcn_hr18s_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 65.2
       mIoU(ms+flip): 68.55
-  Config: configs/hrnet/fcn_hr18s_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18s_512x512_20k_voc12aug/fcn_hr18s_512x512_20k_voc12aug_20200617_224503-56e36088.pth
-- Name: fcn_hr18_512x512_20k_voc12aug
+- Config: configs/hrnet/fcn_hr18_512x512_20k_voc12aug.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 42.59
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.59
+    lr schd: 20000
     memory (GB): 2.9
+  Name: fcn_hr18_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 72.3
       mIoU(ms+flip): 74.71
-  Config: configs/hrnet/fcn_hr18_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18_512x512_20k_voc12aug/fcn_hr18_512x512_20k_voc12aug_20200617_224503-488d45f7.pth
-- Name: fcn_hr48_512x512_20k_voc12aug
+- Config: configs/hrnet/fcn_hr48_512x512_20k_voc12aug.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 45.35
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 45.35
+    lr schd: 20000
     memory (GB): 6.2
+  Name: fcn_hr48_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 75.87
       mIoU(ms+flip): 78.58
-  Config: configs/hrnet/fcn_hr48_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_512x512_20k_voc12aug/fcn_hr48_512x512_20k_voc12aug_20200617_224419-89de05cd.pth
-- Name: fcn_hr18s_512x512_40k_voc12aug
+- Config: configs/hrnet/fcn_hr18s_512x512_40k_voc12aug.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
     lr schd: 40000
+  Name: fcn_hr18s_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 66.61
       mIoU(ms+flip): 70.0
-  Config: configs/hrnet/fcn_hr18s_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18s_512x512_40k_voc12aug/fcn_hr18s_512x512_40k_voc12aug_20200614_000648-4f8d6e7f.pth
-- Name: fcn_hr18_512x512_40k_voc12aug
+- Config: configs/hrnet/fcn_hr18_512x512_40k_voc12aug.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
     lr schd: 40000
+  Name: fcn_hr18_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 72.9
       mIoU(ms+flip): 75.59
-  Config: configs/hrnet/fcn_hr18_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr18_512x512_40k_voc12aug/fcn_hr18_512x512_40k_voc12aug_20200613_224401-1b4b76cd.pth
-- Name: fcn_hr48_512x512_40k_voc12aug
+- Config: configs/hrnet/fcn_hr48_512x512_40k_voc12aug.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
     lr schd: 40000
+  Name: fcn_hr48_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.24
       mIoU(ms+flip): 78.49
-  Config: configs/hrnet/fcn_hr48_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_512x512_40k_voc12aug/fcn_hr48_512x512_40k_voc12aug_20200613_222111-1b0f18bc.pth
-- Name: fcn_hr48_480x480_40k_pascal_context
+- Config: configs/hrnet/fcn_hr48_480x480_40k_pascal_context.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (480,480)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 112.87
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (480,480)
+      value: 112.87
+    lr schd: 40000
     memory (GB): 6.1
+  Name: fcn_hr48_480x480_40k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 45.14
       mIoU(ms+flip): 47.42
-  Config: configs/hrnet/fcn_hr48_480x480_40k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_480x480_40k_pascal_context/fcn_hr48_480x480_40k_pascal_context_20200911_164852-667d00b0.pth
-- Name: fcn_hr48_480x480_80k_pascal_context
+- Config: configs/hrnet/fcn_hr48_480x480_80k_pascal_context.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (480,480)
     lr schd: 80000
+  Name: fcn_hr48_480x480_80k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 45.84
       mIoU(ms+flip): 47.84
-  Config: configs/hrnet/fcn_hr48_480x480_80k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_480x480_80k_pascal_context/fcn_hr48_480x480_80k_pascal_context_20200911_155322-847a6711.pth
-- Name: fcn_hr48_480x480_40k_pascal_context_59
+- Config: configs/hrnet/fcn_hr48_480x480_40k_pascal_context_59.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (480,480)
     lr schd: 40000
+  Name: fcn_hr48_480x480_40k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 50.33
       mIoU(ms+flip): 52.83
-  Config: configs/hrnet/fcn_hr48_480x480_40k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_480x480_40k_pascal_context_59/fcn_hr48_480x480_40k_pascal_context_59_20210410_122738-b808b8b2.pth
-- Name: fcn_hr48_480x480_80k_pascal_context_59
+- Config: configs/hrnet/fcn_hr48_480x480_80k_pascal_context_59.py
   In Collection: hrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (480,480)
     lr schd: 80000
+  Name: fcn_hr48_480x480_80k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 51.12
       mIoU(ms+flip): 53.56
-  Config: configs/hrnet/fcn_hr48_480x480_80k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/hrnet/fcn_hr48_480x480_80k_pascal_context_59/fcn_hr48_480x480_80k_pascal_context_59_20210411_003240-3ae7081e.pth

--- a/configs/mobilenet_v2/mobilenet_v2.yml
+++ b/configs/mobilenet_v2/mobilenet_v2.yml
@@ -1,175 +1,175 @@
 Collections:
-- Name: mobilenet_v2
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20k
+  Name: mobilenet_v2
 Models:
-- Name: fcn_m-v2-d8_512x1024_80k_cityscapes
+- Config: configs/mobilenet_v2/fcn_m-v2-d8_512x1024_80k_cityscapes.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 70.42
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 70.42
+    lr schd: 80000
     memory (GB): 3.4
+  Name: fcn_m-v2-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 61.54
-  Config: configs/mobilenet_v2/fcn_m-v2-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/fcn_m-v2-d8_512x1024_80k_cityscapes/fcn_m-v2-d8_512x1024_80k_cityscapes_20200825_124817-d24c28c1.pth
-- Name: pspnet_m-v2-d8_512x1024_80k_cityscapes
+- Config: configs/mobilenet_v2/pspnet_m-v2-d8_512x1024_80k_cityscapes.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 89.29
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 89.29
+    lr schd: 80000
     memory (GB): 3.6
+  Name: pspnet_m-v2-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 70.23
-  Config: configs/mobilenet_v2/pspnet_m-v2-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/pspnet_m-v2-d8_512x1024_80k_cityscapes/pspnet_m-v2-d8_512x1024_80k_cityscapes_20200825_124817-19e81d51.pth
-- Name: deeplabv3_m-v2-d8_512x1024_80k_cityscapes
+- Config: configs/mobilenet_v2/deeplabv3_m-v2-d8_512x1024_80k_cityscapes.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 119.05
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 119.05
+    lr schd: 80000
     memory (GB): 3.9
+  Name: deeplabv3_m-v2-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 73.84
-  Config: configs/mobilenet_v2/deeplabv3_m-v2-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/deeplabv3_m-v2-d8_512x1024_80k_cityscapes/deeplabv3_m-v2-d8_512x1024_80k_cityscapes_20200825_124836-bef03590.pth
-- Name: deeplabv3plus_m-v2-d8_512x1024_80k_cityscapes
+- Config: configs/mobilenet_v2/deeplabv3plus_m-v2-d8_512x1024_80k_cityscapes.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 119.05
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 119.05
+    lr schd: 80000
     memory (GB): 5.1
+  Name: deeplabv3plus_m-v2-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.2
-  Config: configs/mobilenet_v2/deeplabv3plus_m-v2-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/deeplabv3plus_m-v2-d8_512x1024_80k_cityscapes/deeplabv3plus_m-v2-d8_512x1024_80k_cityscapes_20200825_124836-d256dd4b.pth
-- Name: fcn_m-v2-d8_512x512_160k_ade20k
+- Config: configs/mobilenet_v2/fcn_m-v2-d8_512x512_160k_ade20k.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 15.53
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 15.53
+    lr schd: 160000
     memory (GB): 6.5
+  Name: fcn_m-v2-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 19.71
-  Config: configs/mobilenet_v2/fcn_m-v2-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/fcn_m-v2-d8_512x512_160k_ade20k/fcn_m-v2-d8_512x512_160k_ade20k_20200825_214953-c40e1095.pth
-- Name: pspnet_m-v2-d8_512x512_160k_ade20k
+- Config: configs/mobilenet_v2/pspnet_m-v2-d8_512x512_160k_ade20k.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 17.33
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 17.33
+    lr schd: 160000
     memory (GB): 6.5
+  Name: pspnet_m-v2-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 29.68
-  Config: configs/mobilenet_v2/pspnet_m-v2-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/pspnet_m-v2-d8_512x512_160k_ade20k/pspnet_m-v2-d8_512x512_160k_ade20k_20200825_214953-f5942f7a.pth
-- Name: deeplabv3_m-v2-d8_512x512_160k_ade20k
+- Config: configs/mobilenet_v2/deeplabv3_m-v2-d8_512x512_160k_ade20k.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 25.06
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 25.06
+    lr schd: 160000
     memory (GB): 6.8
+  Name: deeplabv3_m-v2-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 34.08
-  Config: configs/mobilenet_v2/deeplabv3_m-v2-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/deeplabv3_m-v2-d8_512x512_160k_ade20k/deeplabv3_m-v2-d8_512x512_160k_ade20k_20200825_223255-63986343.pth
-- Name: deeplabv3plus_m-v2-d8_512x512_160k_ade20k
+- Config: configs/mobilenet_v2/deeplabv3plus_m-v2-d8_512x512_160k_ade20k.py
   In Collection: mobilenet_v2
   Metadata:
     backbone: M-V2-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 23.2
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 23.2
+    lr schd: 160000
     memory (GB): 8.2
+  Name: deeplabv3plus_m-v2-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 34.02
-  Config: configs/mobilenet_v2/deeplabv3plus_m-v2-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v2/deeplabv3plus_m-v2-d8_512x512_160k_ade20k/deeplabv3plus_m-v2-d8_512x512_160k_ade20k_20200825_223255-465a01d4.pth

--- a/configs/mobilenet_v3/mobilenet_v3.yml
+++ b/configs/mobilenet_v3/mobilenet_v3.yml
@@ -1,94 +1,94 @@
 Collections:
-- Name: mobilenet_v3
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
+  Name: mobilenet_v3
 Models:
-- Name: lraspp_m-v3-d8_512x1024_320k_cityscapes
+- Config: configs/mobilenet_v3/lraspp_m-v3-d8_512x1024_320k_cityscapes.py
   In Collection: mobilenet_v3
   Metadata:
     backbone: M-V3-D8
     crop size: (512,1024)
-    lr schd: 320000
     inference time (ms/im):
-    - value: 65.7
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 65.7
+    lr schd: 320000
     memory (GB): 8.9
+  Name: lraspp_m-v3-d8_512x1024_320k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 69.54
       mIoU(ms+flip): 70.89
-  Config: configs/mobilenet_v3/lraspp_m-v3-d8_512x1024_320k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v3/lraspp_m-v3-d8_512x1024_320k_cityscapes/lraspp_m-v3-d8_512x1024_320k_cityscapes_20201224_220337-cfe8fb07.pth
-- Name: lraspp_m-v3-d8_scratch_512x1024_320k_cityscapes
+- Config: configs/mobilenet_v3/lraspp_m-v3-d8_scratch_512x1024_320k_cityscapes.py
   In Collection: mobilenet_v3
   Metadata:
     backbone: M-V3-D8 (scratch)
     crop size: (512,1024)
-    lr schd: 320000
     inference time (ms/im):
-    - value: 67.7
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 67.7
+    lr schd: 320000
     memory (GB): 8.9
+  Name: lraspp_m-v3-d8_scratch_512x1024_320k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 67.87
       mIoU(ms+flip): 69.78
-  Config: configs/mobilenet_v3/lraspp_m-v3-d8_scratch_512x1024_320k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v3/lraspp_m-v3-d8_scratch_512x1024_320k_cityscapes/lraspp_m-v3-d8_scratch_512x1024_320k_cityscapes_20201224_220337-9f29cd72.pth
-- Name: lraspp_m-v3s-d8_512x1024_320k_cityscapes
+- Config: configs/mobilenet_v3/lraspp_m-v3s-d8_512x1024_320k_cityscapes.py
   In Collection: mobilenet_v3
   Metadata:
     backbone: M-V3s-D8
     crop size: (512,1024)
-    lr schd: 320000
     inference time (ms/im):
-    - value: 42.3
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 42.3
+    lr schd: 320000
     memory (GB): 5.3
+  Name: lraspp_m-v3s-d8_512x1024_320k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 64.11
       mIoU(ms+flip): 66.42
-  Config: configs/mobilenet_v3/lraspp_m-v3s-d8_512x1024_320k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v3/lraspp_m-v3s-d8_512x1024_320k_cityscapes/lraspp_m-v3s-d8_512x1024_320k_cityscapes_20201224_223935-61565b34.pth
-- Name: lraspp_m-v3s-d8_scratch_512x1024_320k_cityscapes
+- Config: configs/mobilenet_v3/lraspp_m-v3s-d8_scratch_512x1024_320k_cityscapes.py
   In Collection: mobilenet_v3
   Metadata:
     backbone: M-V3s-D8 (scratch)
     crop size: (512,1024)
-    lr schd: 320000
     inference time (ms/im):
-    - value: 40.82
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 40.82
+    lr schd: 320000
     memory (GB): 5.3
+  Name: lraspp_m-v3s-d8_scratch_512x1024_320k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 62.74
       mIoU(ms+flip): 65.01
-  Config: configs/mobilenet_v3/lraspp_m-v3s-d8_scratch_512x1024_320k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/mobilenet_v3/lraspp_m-v3s-d8_scratch_512x1024_320k_cityscapes/lraspp_m-v3s-d8_scratch_512x1024_320k_cityscapes_20201224_223935-03daeabb.pth

--- a/configs/nonlocal_net/nonlocal_net.yml
+++ b/configs/nonlocal_net/nonlocal_net.yml
@@ -1,292 +1,292 @@
 Collections:
-- Name: nonlocal_net
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: nonlocal_net
 Models:
-- Name: nonlocal_r50-d8_512x1024_40k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r50-d8_512x1024_40k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 367.65
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 367.65
+    lr schd: 40000
     memory (GB): 7.4
+  Name: nonlocal_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.24
-  Config: configs/nonlocal_net/nonlocal_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_512x1024_40k_cityscapes/nonlocal_r50-d8_512x1024_40k_cityscapes_20200605_210748-c75e81e3.pth
-- Name: nonlocal_r101-d8_512x1024_40k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r101-d8_512x1024_40k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 512.82
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 512.82
+    lr schd: 40000
     memory (GB): 10.9
+  Name: nonlocal_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.66
-  Config: configs/nonlocal_net/nonlocal_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_512x1024_40k_cityscapes/nonlocal_r101-d8_512x1024_40k_cityscapes_20200605_210748-d63729fa.pth
-- Name: nonlocal_r50-d8_769x769_40k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r50-d8_769x769_40k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 657.89
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 657.89
+    lr schd: 40000
     memory (GB): 8.9
+  Name: nonlocal_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.33
       mIoU(ms+flip): 79.92
-  Config: configs/nonlocal_net/nonlocal_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_769x769_40k_cityscapes/nonlocal_r50-d8_769x769_40k_cityscapes_20200530_045243-82ef6749.pth
-- Name: nonlocal_r101-d8_769x769_40k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r101-d8_769x769_40k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 952.38
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 952.38
+    lr schd: 40000
     memory (GB): 12.8
+  Name: nonlocal_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.57
       mIoU(ms+flip): 80.29
-  Config: configs/nonlocal_net/nonlocal_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_769x769_40k_cityscapes/nonlocal_r101-d8_769x769_40k_cityscapes_20200530_045348-8fe9a9dc.pth
-- Name: nonlocal_r50-d8_512x1024_80k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r50-d8_512x1024_80k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: nonlocal_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.01
-  Config: configs/nonlocal_net/nonlocal_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_512x1024_80k_cityscapes/nonlocal_r50-d8_512x1024_80k_cityscapes_20200607_193518-d6839fae.pth
-- Name: nonlocal_r101-d8_512x1024_80k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r101-d8_512x1024_80k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: nonlocal_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.93
-  Config: configs/nonlocal_net/nonlocal_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_512x1024_80k_cityscapes/nonlocal_r101-d8_512x1024_80k_cityscapes_20200607_183411-32700183.pth
-- Name: nonlocal_r50-d8_769x769_80k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r50-d8_769x769_80k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: nonlocal_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.05
       mIoU(ms+flip): 80.68
-  Config: configs/nonlocal_net/nonlocal_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_769x769_80k_cityscapes/nonlocal_r50-d8_769x769_80k_cityscapes_20200607_193506-1f9792f6.pth
-- Name: nonlocal_r101-d8_769x769_80k_cityscapes
+- Config: configs/nonlocal_net/nonlocal_r101-d8_769x769_80k_cityscapes.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: nonlocal_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.4
       mIoU(ms+flip): 80.85
-  Config: configs/nonlocal_net/nonlocal_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_769x769_80k_cityscapes/nonlocal_r101-d8_769x769_80k_cityscapes_20200607_183428-0e1fa4f9.pth
-- Name: nonlocal_r50-d8_512x512_80k_ade20k
+- Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_80k_ade20k.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 46.79
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 46.79
+    lr schd: 80000
     memory (GB): 9.1
+  Name: nonlocal_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 40.75
       mIoU(ms+flip): 42.05
-  Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_512x512_80k_ade20k/nonlocal_r50-d8_512x512_80k_ade20k_20200615_015801-5ae0aa33.pth
-- Name: nonlocal_r101-d8_512x512_80k_ade20k
+- Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_80k_ade20k.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 71.58
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 71.58
+    lr schd: 80000
     memory (GB): 12.6
+  Name: nonlocal_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.9
       mIoU(ms+flip): 44.27
-  Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_512x512_80k_ade20k/nonlocal_r101-d8_512x512_80k_ade20k_20200615_015758-24105919.pth
-- Name: nonlocal_r50-d8_512x512_160k_ade20k
+- Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_160k_ade20k.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: nonlocal_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.03
       mIoU(ms+flip): 43.04
-  Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_512x512_160k_ade20k/nonlocal_r50-d8_512x512_160k_ade20k_20200616_005410-baef45e3.pth
-- Name: nonlocal_r101-d8_512x512_160k_ade20k
+- Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_160k_ade20k.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: nonlocal_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.36
       mIoU(ms+flip): 44.83
-  Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_512x512_160k_ade20k/nonlocal_r101-d8_512x512_160k_ade20k_20200616_003422-affd0f8d.pth
-- Name: nonlocal_r50-d8_512x512_20k_voc12aug
+- Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_20k_voc12aug.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 47.15
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.15
+    lr schd: 20000
     memory (GB): 6.4
+  Name: nonlocal_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.2
       mIoU(ms+flip): 77.12
-  Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_512x512_20k_voc12aug/nonlocal_r50-d8_512x512_20k_voc12aug_20200617_222613-07f2a57c.pth
-- Name: nonlocal_r101-d8_512x512_20k_voc12aug
+- Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_20k_voc12aug.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 71.38
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 71.38
+    lr schd: 20000
     memory (GB): 9.8
+  Name: nonlocal_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 78.15
       mIoU(ms+flip): 78.86
-  Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_512x512_20k_voc12aug/nonlocal_r101-d8_512x512_20k_voc12aug_20200617_222615-948c68ab.pth
-- Name: nonlocal_r50-d8_512x512_40k_voc12aug
+- Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_40k_voc12aug.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: nonlocal_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.65
       mIoU(ms+flip): 77.47
-  Config: configs/nonlocal_net/nonlocal_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r50-d8_512x512_40k_voc12aug/nonlocal_r50-d8_512x512_40k_voc12aug_20200614_000028-0139d4a9.pth
-- Name: nonlocal_r101-d8_512x512_40k_voc12aug
+- Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_40k_voc12aug.py
   In Collection: nonlocal_net
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: nonlocal_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 78.27
       mIoU(ms+flip): 79.12
-  Config: configs/nonlocal_net/nonlocal_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/nonlocal_net/nonlocal_r101-d8_512x512_40k_voc12aug/nonlocal_r101-d8_512x512_40k_voc12aug_20200614_000028-7e5ff470.pth

--- a/configs/ocrnet/ocrnet.yml
+++ b/configs/ocrnet/ocrnet.yml
@@ -1,431 +1,431 @@
 Collections:
-- Name: ocrnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ' HRNet backbone'
     - ' ResNet backbone'
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: ocrnet
 Models:
-- Name: ocrnet_hr18s_512x1024_40k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr18s_512x1024_40k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 95.69
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 95.69
+    lr schd: 40000
     memory (GB): 3.5
+  Name: ocrnet_hr18s_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 74.3
       mIoU(ms+flip): 75.95
-  Config: configs/ocrnet/ocrnet_hr18s_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18s_512x1024_40k_cityscapes/ocrnet_hr18s_512x1024_40k_cityscapes_20200601_033304-fa2436c2.pth
-- Name: ocrnet_hr18_512x1024_40k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr18_512x1024_40k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 133.33
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 133.33
+    lr schd: 40000
     memory (GB): 4.7
+  Name: ocrnet_hr18_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 77.72
       mIoU(ms+flip): 79.49
-  Config: configs/ocrnet/ocrnet_hr18_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18_512x1024_40k_cityscapes/ocrnet_hr18_512x1024_40k_cityscapes_20200601_033320-401c5bdd.pth
-- Name: ocrnet_hr48_512x1024_40k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr48_512x1024_40k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 236.97
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 236.97
+    lr schd: 40000
     memory (GB): 8.0
+  Name: ocrnet_hr48_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 80.58
       mIoU(ms+flip): 81.79
-  Config: configs/ocrnet/ocrnet_hr48_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr48_512x1024_40k_cityscapes/ocrnet_hr48_512x1024_40k_cityscapes_20200601_033336-55b32491.pth
-- Name: ocrnet_hr18s_512x1024_80k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr18s_512x1024_80k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,1024)
     lr schd: 80000
+  Name: ocrnet_hr18s_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 77.16
       mIoU(ms+flip): 78.66
-  Config: configs/ocrnet/ocrnet_hr18s_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18s_512x1024_80k_cityscapes/ocrnet_hr18s_512x1024_80k_cityscapes_20200601_222735-55979e63.pth
-- Name: ocrnet_hr18_512x1024_80k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr18_512x1024_80k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,1024)
     lr schd: 80000
+  Name: ocrnet_hr18_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 78.57
       mIoU(ms+flip): 80.46
-  Config: configs/ocrnet/ocrnet_hr18_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18_512x1024_80k_cityscapes/ocrnet_hr18_512x1024_80k_cityscapes_20200614_230521-c2e1dd4a.pth
-- Name: ocrnet_hr48_512x1024_80k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr48_512x1024_80k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,1024)
     lr schd: 80000
+  Name: ocrnet_hr48_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 80.7
       mIoU(ms+flip): 81.87
-  Config: configs/ocrnet/ocrnet_hr48_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr48_512x1024_80k_cityscapes/ocrnet_hr48_512x1024_80k_cityscapes_20200601_222752-9076bcdf.pth
-- Name: ocrnet_hr18s_512x1024_160k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr18s_512x1024_160k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,1024)
     lr schd: 160000
+  Name: ocrnet_hr18s_512x1024_160k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 78.45
       mIoU(ms+flip): 79.97
-  Config: configs/ocrnet/ocrnet_hr18s_512x1024_160k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18s_512x1024_160k_cityscapes/ocrnet_hr18s_512x1024_160k_cityscapes_20200602_191005-f4a7af28.pth
-- Name: ocrnet_hr18_512x1024_160k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr18_512x1024_160k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,1024)
     lr schd: 160000
+  Name: ocrnet_hr18_512x1024_160k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 79.47
       mIoU(ms+flip): 80.91
-  Config: configs/ocrnet/ocrnet_hr18_512x1024_160k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18_512x1024_160k_cityscapes/ocrnet_hr18_512x1024_160k_cityscapes_20200602_191001-b9172d0c.pth
-- Name: ocrnet_hr48_512x1024_160k_cityscapes
+- Config: configs/ocrnet/ocrnet_hr48_512x1024_160k_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,1024)
     lr schd: 160000
+  Name: ocrnet_hr48_512x1024_160k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' HRNet backbone'
     Metrics:
       mIoU: 81.35
       mIoU(ms+flip): 82.7
-  Config: configs/ocrnet/ocrnet_hr48_512x1024_160k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr48_512x1024_160k_cityscapes/ocrnet_hr48_512x1024_160k_cityscapes_20200602_191037-dfbf1b0c.pth
-- Name: ocrnet_r101-d8_512x1024_40k_b8_cityscapes
+- Config: configs/ocrnet/ocrnet_r101-d8_512x1024_40k_b8_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 40000
+  Name: ocrnet_r101-d8_512x1024_40k_b8_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' ResNet backbone'
     Metrics:
       mIoU: 80.09
-  Config: configs/ocrnet/ocrnet_r101-d8_512x1024_40k_b8_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_r101-d8_512x1024_40k_b8_cityscapes/ocrnet_r101-d8_512x1024_40k_b8_cityscapes-02ac0f13.pth
-- Name: ocrnet_r101-d8_512x1024_40k_b16_cityscapes
+- Config: configs/ocrnet/ocrnet_r101-d8_512x1024_40k_b16_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 331.13
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 331.13
+    lr schd: 40000
     memory (GB): 8.8
+  Name: ocrnet_r101-d8_512x1024_40k_b16_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' ResNet backbone'
     Metrics:
       mIoU: 80.3
-  Config: configs/ocrnet/ocrnet_r101-d8_512x1024_40k_b16_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_r101-d8_512x1024_40k_b16_cityscapes/ocrnet_r101-d8_512x1024_40k_b16_cityscapes-db500f80.pth
-- Name: ocrnet_r101-d8_512x1024_80k_b16_cityscapes
+- Config: configs/ocrnet/ocrnet_r101-d8_512x1024_80k_b16_cityscapes.py
   In Collection: ocrnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 331.13
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 331.13
+    lr schd: 80000
     memory (GB): 8.8
+  Name: ocrnet_r101-d8_512x1024_80k_b16_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: ' ResNet backbone'
     Metrics:
       mIoU: 80.81
-  Config: configs/ocrnet/ocrnet_r101-d8_512x1024_80k_b16_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_r101-d8_512x1024_80k_b16_cityscapes/ocrnet_r101-d8_512x1024_80k_b16_cityscapes-78688424.pth
-- Name: ocrnet_hr18s_512x512_80k_ade20k
+- Config: configs/ocrnet/ocrnet_hr18s_512x512_80k_ade20k.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 34.51
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 34.51
+    lr schd: 80000
     memory (GB): 6.7
+  Name: ocrnet_hr18s_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 35.06
       mIoU(ms+flip): 35.8
-  Config: configs/ocrnet/ocrnet_hr18s_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18s_512x512_80k_ade20k/ocrnet_hr18s_512x512_80k_ade20k_20200615_055600-e80b62af.pth
-- Name: ocrnet_hr18_512x512_80k_ade20k
+- Config: configs/ocrnet/ocrnet_hr18_512x512_80k_ade20k.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 52.83
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 52.83
+    lr schd: 80000
     memory (GB): 7.9
+  Name: ocrnet_hr18_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 37.79
       mIoU(ms+flip): 39.16
-  Config: configs/ocrnet/ocrnet_hr18_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18_512x512_80k_ade20k/ocrnet_hr18_512x512_80k_ade20k_20200615_053157-d173d83b.pth
-- Name: ocrnet_hr48_512x512_80k_ade20k
+- Config: configs/ocrnet/ocrnet_hr48_512x512_80k_ade20k.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 58.86
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 58.86
+    lr schd: 80000
     memory (GB): 11.2
+  Name: ocrnet_hr48_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.0
       mIoU(ms+flip): 44.3
-  Config: configs/ocrnet/ocrnet_hr48_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr48_512x512_80k_ade20k/ocrnet_hr48_512x512_80k_ade20k_20200615_021518-d168c2d1.pth
-- Name: ocrnet_hr18s_512x512_160k_ade20k
+- Config: configs/ocrnet/ocrnet_hr18s_512x512_160k_ade20k.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
     lr schd: 160000
+  Name: ocrnet_hr18s_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 37.19
       mIoU(ms+flip): 38.4
-  Config: configs/ocrnet/ocrnet_hr18s_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18s_512x512_160k_ade20k/ocrnet_hr18s_512x512_160k_ade20k_20200615_184505-8e913058.pth
-- Name: ocrnet_hr18_512x512_160k_ade20k
+- Config: configs/ocrnet/ocrnet_hr18_512x512_160k_ade20k.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
     lr schd: 160000
+  Name: ocrnet_hr18_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 39.32
       mIoU(ms+flip): 40.8
-  Config: configs/ocrnet/ocrnet_hr18_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18_512x512_160k_ade20k/ocrnet_hr18_512x512_160k_ade20k_20200615_200940-d8fcd9d1.pth
-- Name: ocrnet_hr48_512x512_160k_ade20k
+- Config: configs/ocrnet/ocrnet_hr48_512x512_160k_ade20k.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
     lr schd: 160000
+  Name: ocrnet_hr48_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.25
       mIoU(ms+flip): 44.88
-  Config: configs/ocrnet/ocrnet_hr48_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr48_512x512_160k_ade20k/ocrnet_hr48_512x512_160k_ade20k_20200615_184705-a073726d.pth
-- Name: ocrnet_hr18s_512x512_20k_voc12aug
+- Config: configs/ocrnet/ocrnet_hr18s_512x512_20k_voc12aug.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 31.7
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 31.7
+    lr schd: 20000
     memory (GB): 3.5
+  Name: ocrnet_hr18s_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 71.7
       mIoU(ms+flip): 73.84
-  Config: configs/ocrnet/ocrnet_hr18s_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18s_512x512_20k_voc12aug/ocrnet_hr18s_512x512_20k_voc12aug_20200617_233913-02b04fcb.pth
-- Name: ocrnet_hr18_512x512_20k_voc12aug
+- Config: configs/ocrnet/ocrnet_hr18_512x512_20k_voc12aug.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 50.23
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 50.23
+    lr schd: 20000
     memory (GB): 4.7
+  Name: ocrnet_hr18_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 74.75
       mIoU(ms+flip): 77.11
-  Config: configs/ocrnet/ocrnet_hr18_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18_512x512_20k_voc12aug/ocrnet_hr18_512x512_20k_voc12aug_20200617_233932-8954cbb7.pth
-- Name: ocrnet_hr48_512x512_20k_voc12aug
+- Config: configs/ocrnet/ocrnet_hr48_512x512_20k_voc12aug.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 56.09
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 56.09
+    lr schd: 20000
     memory (GB): 8.1
+  Name: ocrnet_hr48_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.72
       mIoU(ms+flip): 79.87
-  Config: configs/ocrnet/ocrnet_hr48_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr48_512x512_20k_voc12aug/ocrnet_hr48_512x512_20k_voc12aug_20200617_233932-9e82080a.pth
-- Name: ocrnet_hr18s_512x512_40k_voc12aug
+- Config: configs/ocrnet/ocrnet_hr18s_512x512_40k_voc12aug.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18-Small
     crop size: (512,512)
     lr schd: 40000
+  Name: ocrnet_hr18s_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 72.76
       mIoU(ms+flip): 74.6
-  Config: configs/ocrnet/ocrnet_hr18s_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18s_512x512_40k_voc12aug/ocrnet_hr18s_512x512_40k_voc12aug_20200614_002025-42b587ac.pth
-- Name: ocrnet_hr18_512x512_40k_voc12aug
+- Config: configs/ocrnet/ocrnet_hr18_512x512_40k_voc12aug.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W18
     crop size: (512,512)
     lr schd: 40000
+  Name: ocrnet_hr18_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 74.98
       mIoU(ms+flip): 77.4
-  Config: configs/ocrnet/ocrnet_hr18_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr18_512x512_40k_voc12aug/ocrnet_hr18_512x512_40k_voc12aug_20200614_015958-714302be.pth
-- Name: ocrnet_hr48_512x512_40k_voc12aug
+- Config: configs/ocrnet/ocrnet_hr48_512x512_40k_voc12aug.py
   In Collection: ocrnet
   Metadata:
     backbone: HRNetV2p-W48
     crop size: (512,512)
     lr schd: 40000
+  Name: ocrnet_hr48_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.14
       mIoU(ms+flip): 79.71
-  Config: configs/ocrnet/ocrnet_hr48_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/ocrnet/ocrnet_hr48_512x512_40k_voc12aug/ocrnet_hr48_512x512_40k_voc12aug_20200614_015958-255bc5ce.pth

--- a/configs/point_rend/point_rend.yml
+++ b/configs/point_rend/point_rend.yml
@@ -1,95 +1,95 @@
 Collections:
-- Name: point_rend
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
+  Name: point_rend
 Models:
-- Name: pointrend_r50_512x1024_80k_cityscapes
+- Config: configs/point_rend/pointrend_r50_512x1024_80k_cityscapes.py
   In Collection: point_rend
   Metadata:
     backbone: R-50
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 117.92
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 117.92
+    lr schd: 80000
     memory (GB): 3.1
+  Name: pointrend_r50_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 76.47
       mIoU(ms+flip): 78.13
-  Config: configs/point_rend/pointrend_r50_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/point_rend/pointrend_r50_512x1024_80k_cityscapes/pointrend_r50_512x1024_80k_cityscapes_20200711_015821-bb1ff523.pth
-- Name: pointrend_r101_512x1024_80k_cityscapes
+- Config: configs/point_rend/pointrend_r101_512x1024_80k_cityscapes.py
   In Collection: point_rend
   Metadata:
     backbone: R-101
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 142.86
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 142.86
+    lr schd: 80000
     memory (GB): 4.2
+  Name: pointrend_r101_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.3
       mIoU(ms+flip): 79.97
-  Config: configs/point_rend/pointrend_r101_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/point_rend/pointrend_r101_512x1024_80k_cityscapes/pointrend_r101_512x1024_80k_cityscapes_20200711_170850-d0ca84be.pth
-- Name: pointrend_r50_512x512_160k_ade20k
+- Config: configs/point_rend/pointrend_r50_512x512_160k_ade20k.py
   In Collection: point_rend
   Metadata:
     backbone: R-50
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 57.77
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 57.77
+    lr schd: 160000
     memory (GB): 5.1
+  Name: pointrend_r50_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 37.64
       mIoU(ms+flip): 39.17
-  Config: configs/point_rend/pointrend_r50_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/point_rend/pointrend_r50_512x512_160k_ade20k/pointrend_r50_512x512_160k_ade20k_20200807_232644-ac3febf2.pth
-- Name: pointrend_r101_512x512_160k_ade20k
+- Config: configs/point_rend/pointrend_r101_512x512_160k_ade20k.py
   In Collection: point_rend
   Metadata:
     backbone: R-101
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 64.52
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 64.52
+    lr schd: 160000
     memory (GB): 6.1
+  Name: pointrend_r101_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 40.02
       mIoU(ms+flip): 41.6
-  Config: configs/point_rend/pointrend_r101_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/point_rend/pointrend_r101_512x512_160k_ade20k/pointrend_r101_512x512_160k_ade20k_20200808_030852-8834902a.pth

--- a/configs/psanet/psanet.yml
+++ b/configs/psanet/psanet.yml
@@ -1,296 +1,296 @@
 Collections:
-- Name: psanet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: psanet
 Models:
-- Name: psanet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/psanet/psanet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 315.46
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 315.46
+    lr schd: 40000
     memory (GB): 7.0
+  Name: psanet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.63
       mIoU(ms+flip): 79.04
-  Config: configs/psanet/psanet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_512x1024_40k_cityscapes/psanet_r50-d8_512x1024_40k_cityscapes_20200606_103117-99fac37c.pth
-- Name: psanet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/psanet/psanet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 454.55
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 454.55
+    lr schd: 40000
     memory (GB): 10.5
+  Name: psanet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.14
       mIoU(ms+flip): 80.19
-  Config: configs/psanet/psanet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_512x1024_40k_cityscapes/psanet_r101-d8_512x1024_40k_cityscapes_20200606_001418-27b9cfa7.pth
-- Name: psanet_r50-d8_769x769_40k_cityscapes
+- Config: configs/psanet/psanet_r50-d8_769x769_40k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 714.29
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 714.29
+    lr schd: 40000
     memory (GB): 7.9
+  Name: psanet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.99
       mIoU(ms+flip): 79.64
-  Config: configs/psanet/psanet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_769x769_40k_cityscapes/psanet_r50-d8_769x769_40k_cityscapes_20200530_033717-d5365506.pth
-- Name: psanet_r101-d8_769x769_40k_cityscapes
+- Config: configs/psanet/psanet_r101-d8_769x769_40k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 1020.41
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 1020.41
+    lr schd: 40000
     memory (GB): 11.9
+  Name: psanet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.43
       mIoU(ms+flip): 80.26
-  Config: configs/psanet/psanet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_769x769_40k_cityscapes/psanet_r101-d8_769x769_40k_cityscapes_20200530_035107-997da1e6.pth
-- Name: psanet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/psanet/psanet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: psanet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.24
       mIoU(ms+flip): 78.69
-  Config: configs/psanet/psanet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_512x1024_80k_cityscapes/psanet_r50-d8_512x1024_80k_cityscapes_20200606_161842-ab60a24f.pth
-- Name: psanet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/psanet/psanet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: psanet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.31
       mIoU(ms+flip): 80.53
-  Config: configs/psanet/psanet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_512x1024_80k_cityscapes/psanet_r101-d8_512x1024_80k_cityscapes_20200606_161823-0f73a169.pth
-- Name: psanet_r50-d8_769x769_80k_cityscapes
+- Config: configs/psanet/psanet_r50-d8_769x769_80k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: psanet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.31
       mIoU(ms+flip): 80.91
-  Config: configs/psanet/psanet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_769x769_80k_cityscapes/psanet_r50-d8_769x769_80k_cityscapes_20200606_225134-fe42f49e.pth
-- Name: psanet_r101-d8_769x769_80k_cityscapes
+- Config: configs/psanet/psanet_r101-d8_769x769_80k_cityscapes.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: psanet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.69
       mIoU(ms+flip): 80.89
-  Config: configs/psanet/psanet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_769x769_80k_cityscapes/psanet_r101-d8_769x769_80k_cityscapes_20200606_214550-7665827b.pth
-- Name: psanet_r50-d8_512x512_80k_ade20k
+- Config: configs/psanet/psanet_r50-d8_512x512_80k_ade20k.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 52.88
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 52.88
+    lr schd: 80000
     memory (GB): 9.0
+  Name: psanet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.14
       mIoU(ms+flip): 41.91
-  Config: configs/psanet/psanet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_512x512_80k_ade20k/psanet_r50-d8_512x512_80k_ade20k_20200614_144141-835e4b97.pth
-- Name: psanet_r101-d8_512x512_80k_ade20k
+- Config: configs/psanet/psanet_r101-d8_512x512_80k_ade20k.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 76.16
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 76.16
+    lr schd: 80000
     memory (GB): 12.5
+  Name: psanet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.8
       mIoU(ms+flip): 44.75
-  Config: configs/psanet/psanet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_512x512_80k_ade20k/psanet_r101-d8_512x512_80k_ade20k_20200614_185117-1fab60d4.pth
-- Name: psanet_r50-d8_512x512_160k_ade20k
+- Config: configs/psanet/psanet_r50-d8_512x512_160k_ade20k.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: psanet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.67
       mIoU(ms+flip): 42.95
-  Config: configs/psanet/psanet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_512x512_160k_ade20k/psanet_r50-d8_512x512_160k_ade20k_20200615_161258-148077dd.pth
-- Name: psanet_r101-d8_512x512_160k_ade20k
+- Config: configs/psanet/psanet_r101-d8_512x512_160k_ade20k.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: psanet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.74
       mIoU(ms+flip): 45.38
-  Config: configs/psanet/psanet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_512x512_160k_ade20k/psanet_r101-d8_512x512_160k_ade20k_20200615_161537-dbfa564c.pth
-- Name: psanet_r50-d8_512x512_20k_voc12aug
+- Config: configs/psanet/psanet_r50-d8_512x512_20k_voc12aug.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 54.82
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 54.82
+    lr schd: 20000
     memory (GB): 6.9
+  Name: psanet_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.39
       mIoU(ms+flip): 77.34
-  Config: configs/psanet/psanet_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_512x512_20k_voc12aug/psanet_r50-d8_512x512_20k_voc12aug_20200617_102413-2f1bbaa1.pth
-- Name: psanet_r101-d8_512x512_20k_voc12aug
+- Config: configs/psanet/psanet_r101-d8_512x512_20k_voc12aug.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 79.18
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 79.18
+    lr schd: 20000
     memory (GB): 10.4
+  Name: psanet_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.91
       mIoU(ms+flip): 79.3
-  Config: configs/psanet/psanet_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_512x512_20k_voc12aug/psanet_r101-d8_512x512_20k_voc12aug_20200617_110624-946fef11.pth
-- Name: psanet_r50-d8_512x512_40k_voc12aug
+- Config: configs/psanet/psanet_r50-d8_512x512_40k_voc12aug.py
   In Collection: psanet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: psanet_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.3
       mIoU(ms+flip): 77.35
-  Config: configs/psanet/psanet_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r50-d8_512x512_40k_voc12aug/psanet_r50-d8_512x512_40k_voc12aug_20200613_161946-f596afb5.pth
-- Name: psanet_r101-d8_512x512_40k_voc12aug
+- Config: configs/psanet/psanet_r101-d8_512x512_40k_voc12aug.py
   In Collection: psanet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: psanet_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.73
       mIoU(ms+flip): 79.05
-  Config: configs/psanet/psanet_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/psanet/psanet_r101-d8_512x512_40k_voc12aug/psanet_r101-d8_512x512_40k_voc12aug_20200613_161946-1f560f9e.pth

--- a/configs/pspnet/pspnet.yml
+++ b/configs/pspnet/pspnet.yml
@@ -1,538 +1,538 @@
 Collections:
-- Name: pspnet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
     - Pascal Context
     - Pascal Context 59
+  Name: pspnet
 Models:
-- Name: pspnet_r50-d8_512x1024_40k_cityscapes
+- Config: configs/pspnet/pspnet_r50-d8_512x1024_40k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 245.7
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 245.7
+    lr schd: 40000
     memory (GB): 6.1
+  Name: pspnet_r50-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.85
       mIoU(ms+flip): 79.18
-  Config: configs/pspnet/pspnet_r50-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x1024_40k_cityscapes/pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth
-- Name: pspnet_r101-d8_512x1024_40k_cityscapes
+- Config: configs/pspnet/pspnet_r101-d8_512x1024_40k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 373.13
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 373.13
+    lr schd: 40000
     memory (GB): 9.6
+  Name: pspnet_r101-d8_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.34
       mIoU(ms+flip): 79.74
-  Config: configs/pspnet/pspnet_r101-d8_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_512x1024_40k_cityscapes/pspnet_r101-d8_512x1024_40k_cityscapes_20200604_232751-467e7cf4.pth
-- Name: pspnet_r50-d8_769x769_40k_cityscapes
+- Config: configs/pspnet/pspnet_r50-d8_769x769_40k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 568.18
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 568.18
+    lr schd: 40000
     memory (GB): 6.9
+  Name: pspnet_r50-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.26
       mIoU(ms+flip): 79.88
-  Config: configs/pspnet/pspnet_r50-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_769x769_40k_cityscapes/pspnet_r50-d8_769x769_40k_cityscapes_20200606_112725-86638686.pth
-- Name: pspnet_r101-d8_769x769_40k_cityscapes
+- Config: configs/pspnet/pspnet_r101-d8_769x769_40k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 869.57
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 869.57
+    lr schd: 40000
     memory (GB): 10.9
+  Name: pspnet_r101-d8_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.08
       mIoU(ms+flip): 80.28
-  Config: configs/pspnet/pspnet_r101-d8_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_769x769_40k_cityscapes/pspnet_r101-d8_769x769_40k_cityscapes_20200606_112753-61c6f5be.pth
-- Name: pspnet_r18-d8_512x1024_80k_cityscapes
+- Config: configs/pspnet/pspnet_r18-d8_512x1024_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-18-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 63.65
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 63.65
+    lr schd: 80000
     memory (GB): 1.7
+  Name: pspnet_r18-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 74.87
       mIoU(ms+flip): 76.04
-  Config: configs/pspnet/pspnet_r18-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r18-d8_512x1024_80k_cityscapes/pspnet_r18-d8_512x1024_80k_cityscapes_20201225_021458-09ffa746.pth
-- Name: pspnet_r50-d8_512x1024_80k_cityscapes
+- Config: configs/pspnet/pspnet_r50-d8_512x1024_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: pspnet_r50-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.55
       mIoU(ms+flip): 79.79
-  Config: configs/pspnet/pspnet_r50-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x1024_80k_cityscapes/pspnet_r50-d8_512x1024_80k_cityscapes_20200606_112131-2376f12b.pth
-- Name: pspnet_r101-d8_512x1024_80k_cityscapes
+- Config: configs/pspnet/pspnet_r101-d8_512x1024_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,1024)
     lr schd: 80000
+  Name: pspnet_r101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.76
       mIoU(ms+flip): 81.01
-  Config: configs/pspnet/pspnet_r101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_512x1024_80k_cityscapes/pspnet_r101-d8_512x1024_80k_cityscapes_20200606_112211-e1e1100f.pth
-- Name: pspnet_r18-d8_769x769_80k_cityscapes
+- Config: configs/pspnet/pspnet_r18-d8_769x769_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-18-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 161.29
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 161.29
+    lr schd: 80000
     memory (GB): 1.9
+  Name: pspnet_r18-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.9
       mIoU(ms+flip): 77.86
-  Config: configs/pspnet/pspnet_r18-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r18-d8_769x769_80k_cityscapes/pspnet_r18-d8_769x769_80k_cityscapes_20201225_021458-3deefc62.pth
-- Name: pspnet_r50-d8_769x769_80k_cityscapes
+- Config: configs/pspnet/pspnet_r50-d8_769x769_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: pspnet_r50-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.59
       mIoU(ms+flip): 80.69
-  Config: configs/pspnet/pspnet_r50-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_769x769_80k_cityscapes/pspnet_r50-d8_769x769_80k_cityscapes_20200606_210121-5ccf03dd.pth
-- Name: pspnet_r101-d8_769x769_80k_cityscapes
+- Config: configs/pspnet/pspnet_r101-d8_769x769_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (769,769)
     lr schd: 80000
+  Name: pspnet_r101-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.77
       mIoU(ms+flip): 81.06
-  Config: configs/pspnet/pspnet_r101-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_769x769_80k_cityscapes/pspnet_r101-d8_769x769_80k_cityscapes_20200606_225055-dba412fa.pth
-- Name: pspnet_r18b-d8_512x1024_80k_cityscapes
+- Config: configs/pspnet/pspnet_r18b-d8_512x1024_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-18b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 61.43
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 61.43
+    lr schd: 80000
     memory (GB): 1.5
+  Name: pspnet_r18b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 74.23
       mIoU(ms+flip): 75.79
-  Config: configs/pspnet/pspnet_r18b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r18b-d8_512x1024_80k_cityscapes/pspnet_r18b-d8_512x1024_80k_cityscapes_20201226_063116-26928a60.pth
-- Name: pspnet_r50b-d8_512x1024_80k_cityscapes
+- Config: configs/pspnet/pspnet_r50b-d8_512x1024_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-50b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 232.56
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 232.56
+    lr schd: 80000
     memory (GB): 6.0
+  Name: pspnet_r50b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.22
       mIoU(ms+flip): 79.46
-  Config: configs/pspnet/pspnet_r50b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50b-d8_512x1024_80k_cityscapes/pspnet_r50b-d8_512x1024_80k_cityscapes_20201225_094315-6344287a.pth
-- Name: pspnet_r101b-d8_512x1024_80k_cityscapes
+- Config: configs/pspnet/pspnet_r101b-d8_512x1024_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-101b-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 362.32
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 362.32
+    lr schd: 80000
     memory (GB): 9.5
+  Name: pspnet_r101b-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.69
       mIoU(ms+flip): 80.79
-  Config: configs/pspnet/pspnet_r101b-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101b-d8_512x1024_80k_cityscapes/pspnet_r101b-d8_512x1024_80k_cityscapes_20201226_170012-3a4d38ab.pth
-- Name: pspnet_r18b-d8_769x769_80k_cityscapes
+- Config: configs/pspnet/pspnet_r18b-d8_769x769_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-18b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 156.01
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 156.01
+    lr schd: 80000
     memory (GB): 1.7
+  Name: pspnet_r18b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 74.92
       mIoU(ms+flip): 76.9
-  Config: configs/pspnet/pspnet_r18b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r18b-d8_769x769_80k_cityscapes/pspnet_r18b-d8_769x769_80k_cityscapes_20201226_080942-bf98d186.pth
-- Name: pspnet_r50b-d8_769x769_80k_cityscapes
+- Config: configs/pspnet/pspnet_r50b-d8_769x769_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-50b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 531.91
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 531.91
+    lr schd: 80000
     memory (GB): 6.8
+  Name: pspnet_r50b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.5
       mIoU(ms+flip): 79.96
-  Config: configs/pspnet/pspnet_r50b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50b-d8_769x769_80k_cityscapes/pspnet_r50b-d8_769x769_80k_cityscapes_20201225_094316-4c643cf6.pth
-- Name: pspnet_r101b-d8_769x769_80k_cityscapes
+- Config: configs/pspnet/pspnet_r101b-d8_769x769_80k_cityscapes.py
   In Collection: pspnet
   Metadata:
     backbone: R-101b-D8
     crop size: (769,769)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 854.7
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 854.7
+    lr schd: 80000
     memory (GB): 10.8
+  Name: pspnet_r101b-d8_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.87
       mIoU(ms+flip): 80.04
-  Config: configs/pspnet/pspnet_r101b-d8_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101b-d8_769x769_80k_cityscapes/pspnet_r101b-d8_769x769_80k_cityscapes_20201226_171823-f0e7c293.pth
-- Name: pspnet_r50-d8_512x512_80k_ade20k
+- Config: configs/pspnet/pspnet_r50-d8_512x512_80k_ade20k.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 42.5
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.5
+    lr schd: 80000
     memory (GB): 8.5
+  Name: pspnet_r50-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 41.13
       mIoU(ms+flip): 41.94
-  Config: configs/pspnet/pspnet_r50-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x512_80k_ade20k/pspnet_r50-d8_512x512_80k_ade20k_20200615_014128-15a8b914.pth
-- Name: pspnet_r101-d8_512x512_80k_ade20k
+- Config: configs/pspnet/pspnet_r101-d8_512x512_80k_ade20k.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 65.36
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 65.36
+    lr schd: 80000
     memory (GB): 12.0
+  Name: pspnet_r101-d8_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.57
       mIoU(ms+flip): 44.35
-  Config: configs/pspnet/pspnet_r101-d8_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_512x512_80k_ade20k/pspnet_r101-d8_512x512_80k_ade20k_20200614_031423-b6e782f0.pth
-- Name: pspnet_r50-d8_512x512_160k_ade20k
+- Config: configs/pspnet/pspnet_r50-d8_512x512_160k_ade20k.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: pspnet_r50-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.48
       mIoU(ms+flip): 43.44
-  Config: configs/pspnet/pspnet_r50-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x512_160k_ade20k/pspnet_r50-d8_512x512_160k_ade20k_20200615_184358-1890b0bd.pth
-- Name: pspnet_r101-d8_512x512_160k_ade20k
+- Config: configs/pspnet/pspnet_r101-d8_512x512_160k_ade20k.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 160000
+  Name: pspnet_r101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 44.39
       mIoU(ms+flip): 45.35
-  Config: configs/pspnet/pspnet_r101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_512x512_160k_ade20k/pspnet_r101-d8_512x512_160k_ade20k_20200615_100650-967c316f.pth
-- Name: pspnet_r50-d8_512x512_20k_voc12aug
+- Config: configs/pspnet/pspnet_r50-d8_512x512_20k_voc12aug.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 42.39
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.39
+    lr schd: 20000
     memory (GB): 6.1
+  Name: pspnet_r50-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 76.78
       mIoU(ms+flip): 77.61
-  Config: configs/pspnet/pspnet_r50-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x512_20k_voc12aug/pspnet_r50-d8_512x512_20k_voc12aug_20200617_101958-ed5dfbd9.pth
-- Name: pspnet_r101-d8_512x512_20k_voc12aug
+- Config: configs/pspnet/pspnet_r101-d8_512x512_20k_voc12aug.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 66.58
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 66.58
+    lr schd: 20000
     memory (GB): 9.6
+  Name: pspnet_r101-d8_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 78.47
       mIoU(ms+flip): 79.25
-  Config: configs/pspnet/pspnet_r101-d8_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_512x512_20k_voc12aug/pspnet_r101-d8_512x512_20k_voc12aug_20200617_102003-4aef3c9a.pth
-- Name: pspnet_r50-d8_512x512_40k_voc12aug
+- Config: configs/pspnet/pspnet_r50-d8_512x512_40k_voc12aug.py
   In Collection: pspnet
   Metadata:
     backbone: R-50-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: pspnet_r50-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.29
       mIoU(ms+flip): 78.48
-  Config: configs/pspnet/pspnet_r50-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x512_40k_voc12aug/pspnet_r50-d8_512x512_40k_voc12aug_20200613_161222-ae9c1b8c.pth
-- Name: pspnet_r101-d8_512x512_40k_voc12aug
+- Config: configs/pspnet/pspnet_r101-d8_512x512_40k_voc12aug.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (512,512)
     lr schd: 40000
+  Name: pspnet_r101-d8_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 78.52
       mIoU(ms+flip): 79.57
-  Config: configs/pspnet/pspnet_r101-d8_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_512x512_40k_voc12aug/pspnet_r101-d8_512x512_40k_voc12aug_20200613_161222-bc933b18.pth
-- Name: pspnet_r101-d8_480x480_40k_pascal_context
+- Config: configs/pspnet/pspnet_r101-d8_480x480_40k_pascal_context.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 103.31
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (480,480)
+      value: 103.31
+    lr schd: 40000
     memory (GB): 8.8
+  Name: pspnet_r101-d8_480x480_40k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 46.6
       mIoU(ms+flip): 47.78
-  Config: configs/pspnet/pspnet_r101-d8_480x480_40k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_480x480_40k_pascal_context/pspnet_r101-d8_480x480_40k_pascal_context_20200911_211210-bf0f5d7c.pth
-- Name: pspnet_r101-d8_480x480_80k_pascal_context
+- Config: configs/pspnet/pspnet_r101-d8_480x480_80k_pascal_context.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: pspnet_r101-d8_480x480_80k_pascal_context
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context
     Metrics:
       mIoU: 46.03
       mIoU(ms+flip): 47.15
-  Config: configs/pspnet/pspnet_r101-d8_480x480_80k_pascal_context.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_480x480_80k_pascal_context/pspnet_r101-d8_480x480_80k_pascal_context_20200911_190530-c86d6233.pth
-- Name: pspnet_r101-d8_480x480_40k_pascal_context_59
+- Config: configs/pspnet/pspnet_r101-d8_480x480_40k_pascal_context_59.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 40000
+  Name: pspnet_r101-d8_480x480_40k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 52.02
       mIoU(ms+flip): 53.54
-  Config: configs/pspnet/pspnet_r101-d8_480x480_40k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_480x480_40k_pascal_context_59/pspnet_r101-d8_480x480_40k_pascal_context_59_20210416_114524-86d44cd4.pth
-- Name: pspnet_r101-d8_480x480_80k_pascal_context_59
+- Config: configs/pspnet/pspnet_r101-d8_480x480_80k_pascal_context_59.py
   In Collection: pspnet
   Metadata:
     backbone: R-101-D8
     crop size: (480,480)
     lr schd: 80000
+  Name: pspnet_r101-d8_480x480_80k_pascal_context_59
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal Context 59
     Metrics:
       mIoU: 52.47
       mIoU(ms+flip): 53.99
-  Config: configs/pspnet/pspnet_r101-d8_480x480_80k_pascal_context_59.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r101-d8_480x480_80k_pascal_context_59/pspnet_r101-d8_480x480_80k_pascal_context_59_20210416_114418-fa6caaa2.pth

--- a/configs/resnest/resnest.yml
+++ b/configs/resnest/resnest.yml
@@ -1,183 +1,183 @@
 Collections:
-- Name: resnest
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20k
+  Name: resnest
 Models:
-- Name: fcn_s101-d8_512x1024_80k_cityscapes
+- Config: configs/resnest/fcn_s101-d8_512x1024_80k_cityscapes.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 418.41
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 418.41
+    lr schd: 80000
     memory (GB): 11.4
+  Name: fcn_s101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.56
       mIoU(ms+flip): 78.98
-  Config: configs/resnest/fcn_s101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/fcn_s101-d8_512x1024_80k_cityscapes/fcn_s101-d8_512x1024_80k_cityscapes_20200807_140631-f8d155b3.pth
-- Name: pspnet_s101-d8_512x1024_80k_cityscapes
+- Config: configs/resnest/pspnet_s101-d8_512x1024_80k_cityscapes.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 396.83
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 396.83
+    lr schd: 80000
     memory (GB): 11.8
+  Name: pspnet_s101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.57
       mIoU(ms+flip): 79.19
-  Config: configs/resnest/pspnet_s101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/pspnet_s101-d8_512x1024_80k_cityscapes/pspnet_s101-d8_512x1024_80k_cityscapes_20200807_140631-c75f3b99.pth
-- Name: deeplabv3_s101-d8_512x1024_80k_cityscapes
+- Config: configs/resnest/deeplabv3_s101-d8_512x1024_80k_cityscapes.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 531.91
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 531.91
+    lr schd: 80000
     memory (GB): 11.9
+  Name: deeplabv3_s101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.67
       mIoU(ms+flip): 80.51
-  Config: configs/resnest/deeplabv3_s101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/deeplabv3_s101-d8_512x1024_80k_cityscapes/deeplabv3_s101-d8_512x1024_80k_cityscapes_20200807_144429-b73c4270.pth
-- Name: deeplabv3plus_s101-d8_512x1024_80k_cityscapes
+- Config: configs/resnest/deeplabv3plus_s101-d8_512x1024_80k_cityscapes.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 423.73
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 423.73
+    lr schd: 80000
     memory (GB): 13.2
+  Name: deeplabv3plus_s101-d8_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.62
       mIoU(ms+flip): 80.27
-  Config: configs/resnest/deeplabv3plus_s101-d8_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/deeplabv3plus_s101-d8_512x1024_80k_cityscapes/deeplabv3plus_s101-d8_512x1024_80k_cityscapes_20200807_144429-1239eb43.pth
-- Name: fcn_s101-d8_512x512_160k_ade20k
+- Config: configs/resnest/fcn_s101-d8_512x512_160k_ade20k.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 77.76
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 77.76
+    lr schd: 160000
     memory (GB): 14.2
+  Name: fcn_s101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 45.62
       mIoU(ms+flip): 46.16
-  Config: configs/resnest/fcn_s101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/fcn_s101-d8_512x512_160k_ade20k/fcn_s101-d8_512x512_160k_ade20k_20200807_145416-d3160329.pth
-- Name: pspnet_s101-d8_512x512_160k_ade20k
+- Config: configs/resnest/pspnet_s101-d8_512x512_160k_ade20k.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 76.8
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 76.8
+    lr schd: 160000
     memory (GB): 14.2
+  Name: pspnet_s101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 45.44
       mIoU(ms+flip): 46.28
-  Config: configs/resnest/pspnet_s101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/pspnet_s101-d8_512x512_160k_ade20k/pspnet_s101-d8_512x512_160k_ade20k_20200807_145416-a6daa92a.pth
-- Name: deeplabv3_s101-d8_512x512_160k_ade20k
+- Config: configs/resnest/deeplabv3_s101-d8_512x512_160k_ade20k.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 107.76
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 107.76
+    lr schd: 160000
     memory (GB): 14.6
+  Name: deeplabv3_s101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 45.71
       mIoU(ms+flip): 46.59
-  Config: configs/resnest/deeplabv3_s101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/deeplabv3_s101-d8_512x512_160k_ade20k/deeplabv3_s101-d8_512x512_160k_ade20k_20200807_144503-17ecabe5.pth
-- Name: deeplabv3plus_s101-d8_512x512_160k_ade20k
+- Config: configs/resnest/deeplabv3plus_s101-d8_512x512_160k_ade20k.py
   In Collection: resnest
   Metadata:
     backbone: S-101-D8
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 83.61
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 83.61
+    lr schd: 160000
     memory (GB): 16.2
+  Name: deeplabv3plus_s101-d8_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20k
     Metrics:
       mIoU: 46.47
       mIoU(ms+flip): 47.27
-  Config: configs/resnest/deeplabv3plus_s101-d8_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/resnest/deeplabv3plus_s101-d8_512x512_160k_ade20k/deeplabv3plus_s101-d8_512x512_160k_ade20k_20200807_144503-27b26226.pth

--- a/configs/sem_fpn/sem_fpn.yml
+++ b/configs/sem_fpn/sem_fpn.yml
@@ -1,95 +1,95 @@
 Collections:
-- Name: sem_fpn
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
+  Name: sem_fpn
 Models:
-- Name: fpn_r50_512x1024_80k_cityscapes
+- Config: configs/sem_fpn/fpn_r50_512x1024_80k_cityscapes.py
   In Collection: sem_fpn
   Metadata:
     backbone: R-50
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 73.86
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 73.86
+    lr schd: 80000
     memory (GB): 2.8
+  Name: fpn_r50_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 74.52
       mIoU(ms+flip): 76.08
-  Config: configs/sem_fpn/fpn_r50_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/sem_fpn/fpn_r50_512x1024_80k_cityscapes/fpn_r50_512x1024_80k_cityscapes_20200717_021437-94018a0d.pth
-- Name: fpn_r101_512x1024_80k_cityscapes
+- Config: configs/sem_fpn/fpn_r101_512x1024_80k_cityscapes.py
   In Collection: sem_fpn
   Metadata:
     backbone: R-101
     crop size: (512,1024)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 97.18
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 97.18
+    lr schd: 80000
     memory (GB): 3.9
+  Name: fpn_r101_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 75.8
       mIoU(ms+flip): 77.4
-  Config: configs/sem_fpn/fpn_r101_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/sem_fpn/fpn_r101_512x1024_80k_cityscapes/fpn_r101_512x1024_80k_cityscapes_20200717_012416-c5800d4c.pth
-- Name: fpn_r50_512x512_160k_ade20k
+- Config: configs/sem_fpn/fpn_r50_512x512_160k_ade20k.py
   In Collection: sem_fpn
   Metadata:
     backbone: R-50
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 17.93
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 17.93
+    lr schd: 160000
     memory (GB): 4.9
+  Name: fpn_r50_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 37.49
       mIoU(ms+flip): 39.09
-  Config: configs/sem_fpn/fpn_r50_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/sem_fpn/fpn_r50_512x512_160k_ade20k/fpn_r50_512x512_160k_ade20k_20200718_131734-5b5a6ab9.pth
-- Name: fpn_r101_512x512_160k_ade20k
+- Config: configs/sem_fpn/fpn_r101_512x512_160k_ade20k.py
   In Collection: sem_fpn
   Metadata:
     backbone: R-101
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 24.64
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 24.64
+    lr schd: 160000
     memory (GB): 5.9
+  Name: fpn_r101_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 39.35
       mIoU(ms+flip): 40.72
-  Config: configs/sem_fpn/fpn_r101_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/sem_fpn/fpn_r101_512x512_160k_ade20k/fpn_r101_512x512_160k_ade20k_20200718_131734-306b5004.pth

--- a/configs/setr/setr.yml
+++ b/configs/setr/setr.yml
@@ -1,87 +1,87 @@
 Collections:
-- Name: setr
-  Metadata:
+- Metadata:
     Training Data:
     - ADE20K
+  Name: setr
 Models:
-- Name: setr_naive_512x512_160k_b16_ade20k
+- Config: configs/setr/setr_naive_512x512_160k_b16_ade20k.py
   In Collection: setr
   Metadata:
     backbone: ViT-L
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 211.86
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 211.86
+    lr schd: 160000
     memory (GB): 18.4
+  Name: setr_naive_512x512_160k_b16_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 48.28
       mIoU(ms+flip): 49.56
-  Config: configs/setr/setr_naive_512x512_160k_b16_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/setr/setr_naive_512x512_160k_b16_ade20k/setr_naive_512x512_160k_b16_ade20k_20210619_191258-061f24f5.pth
-- Name: setr_pup_512x512_160k_b16_ade20k
+- Config: configs/setr/setr_pup_512x512_160k_b16_ade20k.py
   In Collection: setr
   Metadata:
     backbone: ViT-L
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 222.22
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 222.22
+    lr schd: 160000
     memory (GB): 19.54
+  Name: setr_pup_512x512_160k_b16_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 48.24
       mIoU(ms+flip): 49.99
-  Config: configs/setr/setr_pup_512x512_160k_b16_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/setr/setr_pup_512x512_160k_b16_ade20k/setr_pup_512x512_160k_b16_ade20k_20210619_191343-7e0ce826.pth
-- Name: setr_mla_512x512_160k_b8_ade20k
+- Config: configs/setr/setr_mla_512x512_160k_b8_ade20k.py
   In Collection: setr
   Metadata:
     backbone: ViT-L
     crop size: (512,512)
     lr schd: 160000
     memory (GB): 10.96
+  Name: setr_mla_512x512_160k_b8_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 47.34
       mIoU(ms+flip): 49.05
-  Config: configs/setr/setr_mla_512x512_160k_b8_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/setr/setr_mla_512x512_160k_b8_ade20k/setr_mla_512x512_160k_b8_ade20k_20210619_191118-c6d21df0.pth
-- Name: setr_mla_512x512_160k_b16_ade20k
+- Config: configs/setr/setr_mla_512x512_160k_b16_ade20k.py
   In Collection: setr
   Metadata:
     backbone: ViT-L
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 190.48
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 190.48
+    lr schd: 160000
     memory (GB): 17.3
+  Name: setr_mla_512x512_160k_b16_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 47.54
       mIoU(ms+flip): 49.37
-  Config: configs/setr/setr_mla_512x512_160k_b16_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/setr/setr_mla_512x512_160k_b16_ade20k/setr_mla_512x512_160k_b16_ade20k_20210619_191057-f9741de7.pth

--- a/configs/swin/swin.yml
+++ b/configs/swin/swin.yml
@@ -1,122 +1,122 @@
 Collections:
-- Name: swin
-  Metadata:
+- Metadata:
     Training Data:
     - ADE20K
+  Name: swin
 Models:
-- Name: upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K
+- Config: configs/swin/upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K.py
   In Collection: swin
   Metadata:
     backbone: Swin-T
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 47.48
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 47.48
+    lr schd: 160000
     memory (GB): 5.02
+  Name: upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 44.41
       mIoU(ms+flip): 45.79
-  Config: configs/swin/upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/swin/upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K/upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K_20210531_112542-e380ad3e.pth
-- Name: upernet_swin_small_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K
+- Config: configs/swin/upernet_swin_small_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K.py
   In Collection: swin
   Metadata:
     backbone: Swin-S
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 67.93
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 67.93
+    lr schd: 160000
     memory (GB): 6.17
+  Name: upernet_swin_small_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 47.72
       mIoU(ms+flip): 49.24
-  Config: configs/swin/upernet_swin_small_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/swin/upernet_swin_small_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K/upernet_swin_small_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K_20210526_192015-ee2fff1c.pth
-- Name: upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K
+- Config: configs/swin/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K.py
   In Collection: swin
   Metadata:
     backbone: Swin-B
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 79.05
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 79.05
+    lr schd: 160000
     memory (GB): 7.61
+  Name: upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 47.99
       mIoU(ms+flip): 49.57
-  Config: configs/swin/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/swin/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K_20210526_192340-593b0e13.pth
-- Name: upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_22K
+- Config: configs/swin/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_22K.py
   In Collection: swin
   Metadata:
     backbone: Swin-B
     crop size: (512,512)
     lr schd: 160000
+  Name: upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_22K
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 50.31
       mIoU(ms+flip): 51.9
-  Config: configs/swin/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_22K.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/swin/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_22K/upernet_swin_base_patch4_window7_512x512_160k_ade20k_pretrain_224x224_22K_20210526_211650-762e2178.pth
-- Name: upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_1K
+- Config: configs/swin/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_1K.py
   In Collection: swin
   Metadata:
     backbone: Swin-B
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 82.64
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 82.64
+    lr schd: 160000
     memory (GB): 8.52
+  Name: upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_1K
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 48.35
       mIoU(ms+flip): 49.65
-  Config: configs/swin/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_1K.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/swin/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_1K/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_1K_20210531_132020-05b22ea4.pth
-- Name: upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_22K
+- Config: configs/swin/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_22K.py
   In Collection: swin
   Metadata:
     backbone: Swin-B
     crop size: (512,512)
     lr schd: 160000
+  Name: upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_22K
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 50.76
       mIoU(ms+flip): 52.4
-  Config: configs/swin/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_22K.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/swin/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_22K/upernet_swin_base_patch4_window12_512x512_160k_ade20k_pretrain_384x384_22K_20210531_125459-429057bf.pth

--- a/configs/unet/unet.yml
+++ b/configs/unet/unet.yml
@@ -1,177 +1,177 @@
 Collections:
-- Name: unet
-  Metadata:
+- Metadata:
     Training Data:
     - DRIVE
     - STARE
     - CHASE_DB1
     - HRF
+  Name: unet
 Models:
-- Name: fcn_unet_s5-d16_64x64_40k_drive
+- Config: configs/unet/fcn_unet_s5-d16_64x64_40k_drive.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (64,64)
     lr schd: 40000
     memory (GB): 0.68
+  Name: fcn_unet_s5-d16_64x64_40k_drive
   Results:
-    Task: Semantic Segmentation
     Dataset: DRIVE
     Metrics:
       mIoU: 78.67
-  Config: configs/unet/fcn_unet_s5-d16_64x64_40k_drive.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/unet_s5-d16_64x64_40k_drive/unet_s5-d16_64x64_40k_drive_20201223_191051-5daf6d3b.pth
-- Name: pspnet_unet_s5-d16_64x64_40k_drive
+- Config: configs/unet/pspnet_unet_s5-d16_64x64_40k_drive.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (64,64)
     lr schd: 40000
     memory (GB): 0.599
+  Name: pspnet_unet_s5-d16_64x64_40k_drive
   Results:
-    Task: Semantic Segmentation
     Dataset: DRIVE
     Metrics:
       mIoU: 78.62
-  Config: configs/unet/pspnet_unet_s5-d16_64x64_40k_drive.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_64x64_40k_drive/pspnet_unet_s5-d16_64x64_40k_drive_20201227_181818-aac73387.pth
-- Name: deeplabv3_unet_s5-d16_64x64_40k_drive
+- Config: configs/unet/deeplabv3_unet_s5-d16_64x64_40k_drive.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (64,64)
     lr schd: 40000
     memory (GB): 0.596
+  Name: deeplabv3_unet_s5-d16_64x64_40k_drive
   Results:
-    Task: Semantic Segmentation
     Dataset: DRIVE
     Metrics:
       mIoU: 78.69
-  Config: configs/unet/deeplabv3_unet_s5-d16_64x64_40k_drive.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_64x64_40k_drive/deeplabv3_unet_s5-d16_64x64_40k_drive_20201226_094047-0671ff20.pth
-- Name: fcn_unet_s5-d16_128x128_40k_stare
+- Config: configs/unet/fcn_unet_s5-d16_128x128_40k_stare.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
     memory (GB): 0.968
+  Name: fcn_unet_s5-d16_128x128_40k_stare
   Results:
-    Task: Semantic Segmentation
     Dataset: STARE
     Metrics:
       mIoU: 81.02
-  Config: configs/unet/fcn_unet_s5-d16_128x128_40k_stare.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/unet_s5-d16_128x128_40k_stare/unet_s5-d16_128x128_40k_stare_20201223_191051-7d77e78b.pth
-- Name: pspnet_unet_s5-d16_128x128_40k_stare
+- Config: configs/unet/pspnet_unet_s5-d16_128x128_40k_stare.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
     memory (GB): 0.982
+  Name: pspnet_unet_s5-d16_128x128_40k_stare
   Results:
-    Task: Semantic Segmentation
     Dataset: STARE
     Metrics:
       mIoU: 81.22
-  Config: configs/unet/pspnet_unet_s5-d16_128x128_40k_stare.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_128x128_40k_stare/pspnet_unet_s5-d16_128x128_40k_stare_20201227_181818-3c2923c4.pth
-- Name: deeplabv3_unet_s5-d16_128x128_40k_stare
+- Config: configs/unet/deeplabv3_unet_s5-d16_128x128_40k_stare.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
     memory (GB): 0.999
+  Name: deeplabv3_unet_s5-d16_128x128_40k_stare
   Results:
-    Task: Semantic Segmentation
     Dataset: STARE
     Metrics:
       mIoU: 80.93
-  Config: configs/unet/deeplabv3_unet_s5-d16_128x128_40k_stare.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_128x128_40k_stare/deeplabv3_unet_s5-d16_128x128_40k_stare_20201226_094047-93dcb93c.pth
-- Name: fcn_unet_s5-d16_128x128_40k_chase_db1
+- Config: configs/unet/fcn_unet_s5-d16_128x128_40k_chase_db1.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
     memory (GB): 0.968
+  Name: fcn_unet_s5-d16_128x128_40k_chase_db1
   Results:
-    Task: Semantic Segmentation
     Dataset: CHASE_DB1
     Metrics:
       mIoU: 80.24
-  Config: configs/unet/fcn_unet_s5-d16_128x128_40k_chase_db1.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/unet_s5-d16_128x128_40k_chase_db1/unet_s5-d16_128x128_40k_chase_db1_20201223_191051-11543527.pth
-- Name: pspnet_unet_s5-d16_128x128_40k_chase_db1
+- Config: configs/unet/pspnet_unet_s5-d16_128x128_40k_chase_db1.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
     memory (GB): 0.982
+  Name: pspnet_unet_s5-d16_128x128_40k_chase_db1
   Results:
-    Task: Semantic Segmentation
     Dataset: CHASE_DB1
     Metrics:
       mIoU: 80.36
-  Config: configs/unet/pspnet_unet_s5-d16_128x128_40k_chase_db1.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_128x128_40k_chase_db1/pspnet_unet_s5-d16_128x128_40k_chase_db1_20201227_181818-68d4e609.pth
-- Name: deeplabv3_unet_s5-d16_128x128_40k_chase_db1
+- Config: configs/unet/deeplabv3_unet_s5-d16_128x128_40k_chase_db1.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
     memory (GB): 0.999
+  Name: deeplabv3_unet_s5-d16_128x128_40k_chase_db1
   Results:
-    Task: Semantic Segmentation
     Dataset: CHASE_DB1
     Metrics:
       mIoU: 80.47
-  Config: configs/unet/deeplabv3_unet_s5-d16_128x128_40k_chase_db1.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_128x128_40k_chase_db1/deeplabv3_unet_s5-d16_128x128_40k_chase_db1_20201226_094047-4c5aefa3.pth
-- Name: fcn_unet_s5-d16_256x256_40k_hrf
+- Config: configs/unet/fcn_unet_s5-d16_256x256_40k_hrf.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (256,256)
     lr schd: 40000
     memory (GB): 2.525
+  Name: fcn_unet_s5-d16_256x256_40k_hrf
   Results:
-    Task: Semantic Segmentation
     Dataset: HRF
     Metrics:
       mIoU: 79.45
-  Config: configs/unet/fcn_unet_s5-d16_256x256_40k_hrf.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/unet_s5-d16_256x256_40k_hrf/unet_s5-d16_256x256_40k_hrf_20201223_173724-d89cf1ed.pth
-- Name: pspnet_unet_s5-d16_256x256_40k_hrf
+- Config: configs/unet/pspnet_unet_s5-d16_256x256_40k_hrf.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (256,256)
     lr schd: 40000
     memory (GB): 2.588
+  Name: pspnet_unet_s5-d16_256x256_40k_hrf
   Results:
-    Task: Semantic Segmentation
     Dataset: HRF
     Metrics:
       mIoU: 80.07
-  Config: configs/unet/pspnet_unet_s5-d16_256x256_40k_hrf.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_256x256_40k_hrf/pspnet_unet_s5-d16_256x256_40k_hrf_20201227_181818-fdb7e29b.pth
-- Name: deeplabv3_unet_s5-d16_256x256_40k_hrf
+- Config: configs/unet/deeplabv3_unet_s5-d16_256x256_40k_hrf.py
   In Collection: unet
   Metadata:
     backbone: UNet-S5-D16
     crop size: (256,256)
     lr schd: 40000
     memory (GB): 2.604
+  Name: deeplabv3_unet_s5-d16_256x256_40k_hrf
   Results:
-    Task: Semantic Segmentation
     Dataset: HRF
     Metrics:
       mIoU: 80.21
-  Config: configs/unet/deeplabv3_unet_s5-d16_256x256_40k_hrf.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_256x256_40k_hrf/deeplabv3_unet_s5-d16_256x256_40k_hrf_20201226_094047-3a1fdf85.pth

--- a/configs/upernet/upernet.yml
+++ b/configs/upernet/upernet.yml
@@ -1,296 +1,296 @@
 Collections:
-- Name: upernet
-  Metadata:
+- Metadata:
     Training Data:
     - Cityscapes
     - ADE20K
     - Pascal VOC 2012 + Aug
+  Name: upernet
 Models:
-- Name: upernet_r50_512x1024_40k_cityscapes
+- Config: configs/upernet/upernet_r50_512x1024_40k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 235.29
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 235.29
+    lr schd: 40000
     memory (GB): 6.4
+  Name: upernet_r50_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.1
       mIoU(ms+flip): 78.37
-  Config: configs/upernet/upernet_r50_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_512x1024_40k_cityscapes/upernet_r50_512x1024_40k_cityscapes_20200605_094827-aa54cb54.pth
-- Name: upernet_r101_512x1024_40k_cityscapes
+- Config: configs/upernet/upernet_r101_512x1024_40k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (512,1024)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 263.85
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,1024)
+      value: 263.85
+    lr schd: 40000
     memory (GB): 7.4
+  Name: upernet_r101_512x1024_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.69
       mIoU(ms+flip): 80.11
-  Config: configs/upernet/upernet_r101_512x1024_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_512x1024_40k_cityscapes/upernet_r101_512x1024_40k_cityscapes_20200605_094933-ebce3b10.pth
-- Name: upernet_r50_769x769_40k_cityscapes
+- Config: configs/upernet/upernet_r50_769x769_40k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 568.18
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 568.18
+    lr schd: 40000
     memory (GB): 7.2
+  Name: upernet_r50_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 77.98
       mIoU(ms+flip): 79.7
-  Config: configs/upernet/upernet_r50_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_769x769_40k_cityscapes/upernet_r50_769x769_40k_cityscapes_20200530_033048-92d21539.pth
-- Name: upernet_r101_769x769_40k_cityscapes
+- Config: configs/upernet/upernet_r101_769x769_40k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (769,769)
-    lr schd: 40000
     inference time (ms/im):
-    - value: 641.03
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (769,769)
+      value: 641.03
+    lr schd: 40000
     memory (GB): 8.4
+  Name: upernet_r101_769x769_40k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.03
       mIoU(ms+flip): 80.77
-  Config: configs/upernet/upernet_r101_769x769_40k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_769x769_40k_cityscapes/upernet_r101_769x769_40k_cityscapes_20200530_040819-83c95d01.pth
-- Name: upernet_r50_512x1024_80k_cityscapes
+- Config: configs/upernet/upernet_r50_512x1024_80k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (512,1024)
     lr schd: 80000
+  Name: upernet_r50_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 78.19
       mIoU(ms+flip): 79.19
-  Config: configs/upernet/upernet_r50_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_512x1024_80k_cityscapes/upernet_r50_512x1024_80k_cityscapes_20200607_052207-848beca8.pth
-- Name: upernet_r101_512x1024_80k_cityscapes
+- Config: configs/upernet/upernet_r101_512x1024_80k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (512,1024)
     lr schd: 80000
+  Name: upernet_r101_512x1024_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.4
       mIoU(ms+flip): 80.46
-  Config: configs/upernet/upernet_r101_512x1024_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_512x1024_80k_cityscapes/upernet_r101_512x1024_80k_cityscapes_20200607_002403-f05f2345.pth
-- Name: upernet_r50_769x769_80k_cityscapes
+- Config: configs/upernet/upernet_r50_769x769_80k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (769,769)
     lr schd: 80000
+  Name: upernet_r50_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 79.39
       mIoU(ms+flip): 80.92
-  Config: configs/upernet/upernet_r50_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_769x769_80k_cityscapes/upernet_r50_769x769_80k_cityscapes_20200607_005107-82ae7d15.pth
-- Name: upernet_r101_769x769_80k_cityscapes
+- Config: configs/upernet/upernet_r101_769x769_80k_cityscapes.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (769,769)
     lr schd: 80000
+  Name: upernet_r101_769x769_80k_cityscapes
   Results:
-    Task: Semantic Segmentation
     Dataset: Cityscapes
     Metrics:
       mIoU: 80.1
       mIoU(ms+flip): 81.49
-  Config: configs/upernet/upernet_r101_769x769_80k_cityscapes.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_769x769_80k_cityscapes/upernet_r101_769x769_80k_cityscapes_20200607_001014-082fc334.pth
-- Name: upernet_r50_512x512_80k_ade20k
+- Config: configs/upernet/upernet_r50_512x512_80k_ade20k.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 42.74
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 42.74
+    lr schd: 80000
     memory (GB): 8.1
+  Name: upernet_r50_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 40.7
       mIoU(ms+flip): 41.81
-  Config: configs/upernet/upernet_r50_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_512x512_80k_ade20k/upernet_r50_512x512_80k_ade20k_20200614_144127-ecc8377b.pth
-- Name: upernet_r101_512x512_80k_ade20k
+- Config: configs/upernet/upernet_r101_512x512_80k_ade20k.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 49.16
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 49.16
+    lr schd: 80000
     memory (GB): 9.1
+  Name: upernet_r101_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.91
       mIoU(ms+flip): 43.96
-  Config: configs/upernet/upernet_r101_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_512x512_80k_ade20k/upernet_r101_512x512_80k_ade20k_20200614_185117-32e4db94.pth
-- Name: upernet_r50_512x512_160k_ade20k
+- Config: configs/upernet/upernet_r50_512x512_160k_ade20k.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (512,512)
     lr schd: 160000
+  Name: upernet_r50_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.05
       mIoU(ms+flip): 42.78
-  Config: configs/upernet/upernet_r50_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_512x512_160k_ade20k/upernet_r50_512x512_160k_ade20k_20200615_184328-8534de8d.pth
-- Name: upernet_r101_512x512_160k_ade20k
+- Config: configs/upernet/upernet_r101_512x512_160k_ade20k.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (512,512)
     lr schd: 160000
+  Name: upernet_r101_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.82
       mIoU(ms+flip): 44.85
-  Config: configs/upernet/upernet_r101_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_512x512_160k_ade20k/upernet_r101_512x512_160k_ade20k_20200615_161951-91b32684.pth
-- Name: upernet_r50_512x512_20k_voc12aug
+- Config: configs/upernet/upernet_r50_512x512_20k_voc12aug.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 43.16
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 43.16
+    lr schd: 20000
     memory (GB): 6.4
+  Name: upernet_r50_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 74.82
       mIoU(ms+flip): 76.35
-  Config: configs/upernet/upernet_r50_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_512x512_20k_voc12aug/upernet_r50_512x512_20k_voc12aug_20200617_165330-5b5890a7.pth
-- Name: upernet_r101_512x512_20k_voc12aug
+- Config: configs/upernet/upernet_r101_512x512_20k_voc12aug.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (512,512)
-    lr schd: 20000
     inference time (ms/im):
-    - value: 50.05
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 50.05
+    lr schd: 20000
     memory (GB): 7.5
+  Name: upernet_r101_512x512_20k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.1
       mIoU(ms+flip): 78.29
-  Config: configs/upernet/upernet_r101_512x512_20k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_512x512_20k_voc12aug/upernet_r101_512x512_20k_voc12aug_20200617_165629-f14e7f27.pth
-- Name: upernet_r50_512x512_40k_voc12aug
+- Config: configs/upernet/upernet_r50_512x512_40k_voc12aug.py
   In Collection: upernet
   Metadata:
     backbone: R-50
     crop size: (512,512)
     lr schd: 40000
+  Name: upernet_r50_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 75.92
       mIoU(ms+flip): 77.44
-  Config: configs/upernet/upernet_r50_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r50_512x512_40k_voc12aug/upernet_r50_512x512_40k_voc12aug_20200613_162257-ca9bcc6b.pth
-- Name: upernet_r101_512x512_40k_voc12aug
+- Config: configs/upernet/upernet_r101_512x512_40k_voc12aug.py
   In Collection: upernet
   Metadata:
     backbone: R-101
     crop size: (512,512)
     lr schd: 40000
+  Name: upernet_r101_512x512_40k_voc12aug
   Results:
-    Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
     Metrics:
       mIoU: 77.43
       mIoU(ms+flip): 78.56
-  Config: configs/upernet/upernet_r101_512x512_40k_voc12aug.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/upernet/upernet_r101_512x512_40k_voc12aug/upernet_r101_512x512_40k_voc12aug_20200613_163549-e26476ac.pth

--- a/configs/vit/vit.yml
+++ b/configs/vit/vit.yml
@@ -1,248 +1,248 @@
 Collections:
-- Name: vit
-  Metadata:
+- Metadata:
     Training Data:
     - ADE20K
+  Name: vit
 Models:
-- Name: upernet_vit-b16_mln_512x512_80k_ade20k
+- Config: configs/vit/upernet_vit-b16_mln_512x512_80k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: ViT-B + MLN
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 144.09
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 144.09
+    lr schd: 80000
     memory (GB): 9.2
+  Name: upernet_vit-b16_mln_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 47.71
       mIoU(ms+flip): 49.51
-  Config: configs/vit/upernet_vit-b16_mln_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_vit-b16_mln_512x512_80k_ade20k/upernet_vit-b16_mln_512x512_80k_ade20k-0403cee1.pth
-- Name: upernet_vit-b16_mln_512x512_160k_ade20k
+- Config: configs/vit/upernet_vit-b16_mln_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: ViT-B + MLN
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 131.93
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 131.93
+    lr schd: 160000
     memory (GB): 9.2
+  Name: upernet_vit-b16_mln_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 46.75
       mIoU(ms+flip): 48.46
-  Config: configs/vit/upernet_vit-b16_mln_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_vit-b16_mln_512x512_160k_ade20k/upernet_vit-b16_mln_512x512_160k_ade20k-852fa768.pth
-- Name: upernet_vit-b16_ln_mln_512x512_160k_ade20k
+- Config: configs/vit/upernet_vit-b16_ln_mln_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: ViT-B + LN + MLN
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 146.63
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 146.63
+    lr schd: 160000
     memory (GB): 9.21
+  Name: upernet_vit-b16_ln_mln_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 47.73
       mIoU(ms+flip): 49.95
-  Config: configs/vit/upernet_vit-b16_ln_mln_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_vit-b16_ln_mln_512x512_160k_ade20k/upernet_vit-b16_ln_mln_512x512_160k_ade20k-f444c077.pth
-- Name: upernet_deit-s16_512x512_80k_ade20k
+- Config: configs/vit/upernet_deit-s16_512x512_80k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-S
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 33.5
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 33.5
+    lr schd: 80000
     memory (GB): 4.68
+  Name: upernet_deit-s16_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.96
       mIoU(ms+flip): 43.79
-  Config: configs/vit/upernet_deit-s16_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-s16_512x512_80k_ade20k/upernet_deit-s16_512x512_80k_ade20k-afc93ec2.pth
-- Name: upernet_deit-s16_512x512_160k_ade20k
+- Config: configs/vit/upernet_deit-s16_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-S
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 34.26
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 34.26
+    lr schd: 160000
     memory (GB): 4.68
+  Name: upernet_deit-s16_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 42.87
       mIoU(ms+flip): 43.79
-  Config: configs/vit/upernet_deit-s16_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-s16_512x512_160k_ade20k/upernet_deit-s16_512x512_160k_ade20k-5110d916.pth
-- Name: upernet_deit-s16_mln_512x512_160k_ade20k
+- Config: configs/vit/upernet_deit-s16_mln_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-S + MLN
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 89.45
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 89.45
+    lr schd: 160000
     memory (GB): 5.69
+  Name: upernet_deit-s16_mln_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.82
       mIoU(ms+flip): 45.07
-  Config: configs/vit/upernet_deit-s16_mln_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-s16_mln_512x512_160k_ade20k/upernet_deit-s16_mln_512x512_160k_ade20k-fb9a5dfb.pth
-- Name: upernet_deit-s16_ln_mln_512x512_160k_ade20k
+- Config: configs/vit/upernet_deit-s16_ln_mln_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-S + LN + MLN
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 80.71
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 80.71
+    lr schd: 160000
     memory (GB): 5.69
+  Name: upernet_deit-s16_ln_mln_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 43.52
       mIoU(ms+flip): 45.01
-  Config: configs/vit/upernet_deit-s16_ln_mln_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-s16_ln_mln_512x512_160k_ade20k/upernet_deit-s16_ln_mln_512x512_160k_ade20k-c0cd652f.pth
-- Name: upernet_deit-b16_512x512_80k_ade20k
+- Config: configs/vit/upernet_deit-b16_512x512_80k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-B
     crop size: (512,512)
-    lr schd: 80000
     inference time (ms/im):
-    - value: 103.2
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 103.2
+    lr schd: 80000
     memory (GB): 7.75
+  Name: upernet_deit-b16_512x512_80k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.24
       mIoU(ms+flip): 46.73
-  Config: configs/vit/upernet_deit-b16_512x512_80k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-b16_512x512_80k_ade20k/upernet_deit-b16_512x512_80k_ade20k-1e090789.pth
-- Name: upernet_deit-b16_512x512_160k_ade20k
+- Config: configs/vit/upernet_deit-b16_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-B
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 96.25
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 96.25
+    lr schd: 160000
     memory (GB): 7.75
+  Name: upernet_deit-b16_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.36
       mIoU(ms+flip): 47.16
-  Config: configs/vit/upernet_deit-b16_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-b16_512x512_160k_ade20k/upernet_deit-b16_512x512_160k_ade20k-828705d7.pth
-- Name: upernet_deit-b16_mln_512x512_160k_ade20k
+- Config: configs/vit/upernet_deit-b16_mln_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-B + MLN
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 128.53
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 128.53
+    lr schd: 160000
     memory (GB): 9.21
+  Name: upernet_deit-b16_mln_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.46
       mIoU(ms+flip): 47.16
-  Config: configs/vit/upernet_deit-b16_mln_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-b16_mln_512x512_160k_ade20k/upernet_deit-b16_mln_512x512_160k_ade20k-4e1450f3.pth
-- Name: upernet_deit-b16_ln_mln_512x512_160k_ade20k
+- Config: configs/vit/upernet_deit-b16_ln_mln_512x512_160k_ade20k.py
   In Collection: vit
   Metadata:
     backbone: DeiT-B + LN + MLN
     crop size: (512,512)
-    lr schd: 160000
     inference time (ms/im):
-    - value: 129.03
-      hardware: V100
-      backend: PyTorch
+    - backend: PyTorch
       batch size: 1
+      hardware: V100
       mode: FP32
       resolution: (512,512)
+      value: 129.03
+    lr schd: 160000
     memory (GB): 9.21
+  Name: upernet_deit-b16_ln_mln_512x512_160k_ade20k
   Results:
-    Task: Semantic Segmentation
     Dataset: ADE20K
     Metrics:
       mIoU: 45.37
       mIoU(ms+flip): 47.23
-  Config: configs/vit/upernet_deit-b16_ln_mln_512x512_160k_ade20k.py
+    Task: Semantic Segmentation
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/vit/upernet_deit-b16_ln_mln_512x512_160k_ade20k/upernet_deit-b16_ln_mln_512x512_160k_ade20k-8a959c14.pth


### PR DESCRIPTION
## Motivation

The pre-commit hook update_model_index is observed to exit with code 1 (indicating files modified) randomly without actually modifying the metafiles. We found that this is caused by file I/O conflict when this pre-commit hook is running in a multi-threading manner.

## Modification

- Add `require_serial=true` in `.pre-commit-config.yaml` to prevent multi-threading that causes file I/O conflict
- Modify `update_model_index` in `md2yml.py` to prevent redundant file I/O
- Set `sort_keys=True` and update model `.yml` files

Related PR https://github.com/open-mmlab/mmpose/pull/866

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
No.
