### PR TITLE
[Fix] Inherit UPSAMPLE_LAYERS registry from MMCV

### DIFF
--- a/mmseg/models/backbones/unet.py
+++ b/mmseg/models/backbones/unet.py
@@ -2,13 +2,12 @@ import warnings
 
 import torch.nn as nn
 import torch.utils.checkpoint as cp
-from mmcv.cnn import (UPSAMPLE_LAYERS, ConvModule, build_activation_layer,
-                      build_norm_layer)
+from mmcv.cnn import ConvModule, build_activation_layer, build_norm_layer
 from mmcv.runner import BaseModule
 from mmcv.utils.parrots_wrapper import _BatchNorm
 
 from mmseg.ops import Upsample
-from ..builder import BACKBONES
+from ..builder import BACKBONES, UPSAMPLE_LAYERS
 from ..utils import UpConvBlock
 
 
@@ -223,6 +222,7 @@ class InterpConv(nn.Module):
 @BACKBONES.register_module()
 class UNet(BaseModule):
     """UNet backbone.
+
     U-Net: Convolutional Networks for Biomedical Image Segmentation.
     https://arxiv.org/pdf/1505.04597.pdf
 
@@ -276,7 +276,6 @@ class UNet(BaseModule):
         The input image size should be divisible by the whole downsample rate
         of the encoder. More detail of the whole downsample rate can be found
         in UNet._check_input_divisible.
-
     """
 
     def __init__(self,

--- a/mmseg/models/builder.py
+++ b/mmseg/models/builder.py
@@ -1,11 +1,14 @@
 import warnings
 
+import torch.nn as nn
 from mmcv.cnn import MODELS as MMCV_MODELS
 from mmcv.cnn.bricks.registry import ATTENTION as MMCV_ATTENTION
+from mmcv.cnn.bricks.registry import UPSAMPLE_LAYERS as MMCV_UPSAMPLE_LAYERS
 from mmcv.utils import Registry
 
 MODELS = Registry('models', parent=MMCV_MODELS)
 ATTENTION = Registry('attention', parent=MMCV_ATTENTION)
+UPSAMPLE_LAYERS = Registry('upsample layer', parent=MMCV_UPSAMPLE_LAYERS)
 
 BACKBONES = MODELS
 NECKS = MODELS
@@ -46,3 +49,40 @@ def build_segmentor(cfg, train_cfg=None, test_cfg=None):
         'test_cfg specified in both outer field and model field '
     return SEGMENTORS.build(
         cfg, default_args=dict(train_cfg=train_cfg, test_cfg=test_cfg))
+
+
+def build_upsample_layer(cfg, *args, **kwargs):
+    """Build upsample layer.
+
+    Args:
+        cfg (dict): The upsample layer config, which should contain:
+
+            - type (str): Layer type.
+            - scale_factor (int): Upsample ratio, which is not applicable to
+                `DeconvModule`, `InterpConv`.
+            - layer args: Args needed to instantiate a upsample layer.
+        args (argument list): Arguments passed to the ``__init__``
+            method of the corresponding conv layer.
+        kwargs (keyword arguments): Keyword arguments passed to the
+            ``__init__`` method of the corresponding conv layer.
+
+    Returns:
+        nn.Module: Created upsample layer.
+    """
+    if not isinstance(cfg, dict):
+        raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
+    if 'type' not in cfg:
+        raise KeyError(
+            f'the cfg dict must contain the key "type", but got {cfg}')
+    cfg_ = cfg.copy()
+
+    layer_type = cfg_.pop('type')
+    if layer_type not in UPSAMPLE_LAYERS:
+        raise KeyError(f'Unrecognized upsample type {layer_type}')
+    else:
+        upsample = UPSAMPLE_LAYERS.get(layer_type)
+
+    if upsample is nn.Upsample:
+        cfg_['mode'] = layer_type
+    layer = upsample(*args, **kwargs, **cfg_)
+    return layer

--- a/mmseg/models/utils/up_conv_block.py
+++ b/mmseg/models/utils/up_conv_block.py
@@ -1,6 +1,8 @@
 import torch
 import torch.nn as nn
-from mmcv.cnn import ConvModule, build_upsample_layer
+from mmcv.cnn import ConvModule
+
+from ..builder import build_upsample_layer
 
 
 class UpConvBlock(nn.Module):


### PR DESCRIPTION
## Motivation

Register `UPSAMPLE_LAYERS` registry from the parent `UPSAMPLE_LAYERS` registry of `MMCV` to avoid conflict with other repositories.

## Modification

Using mmseg `UPSAMPLE_LAYERS` registry to register `upsample` modules.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
No
