### PR TITLE
[Fix] Fix docstring link problem in readthedocs

### DIFF
--- a/mmseg/datasets/pipelines/formating.py
+++ b/mmseg/datasets/pipelines/formating.py
@@ -248,10 +248,10 @@ class Collect(object):
     Args:
         keys (Sequence[str]): Keys of results to be collected in ``data``.
         meta_keys (Sequence[str], optional): Meta keys to be converted to
-            `mmcv.DataContainer` and collected in `data[img_metas]`.
-            Default: `('filename', 'ori_filename', 'ori_shape', 'img_shape',
-            'pad_shape', 'scale_factor', 'flip', 'flip_direction',
-            'img_norm_cfg')`
+            ``mmcv.DataContainer`` and collected in ``data[img_metas]``.
+            Default: `(``filename``, ``ori_filename``, ``ori_shape``,
+            ``img_shape``, ``pad_shape``, ``scale_factor``, ``flip``,
+            ``flip_direction``, ``img_norm_cfg``)`
     """
 
     def __init__(self,

--- a/mmseg/datasets/pipelines/formating.py
+++ b/mmseg/datasets/pipelines/formating.py
@@ -249,9 +249,9 @@ class Collect(object):
         keys (Sequence[str]): Keys of results to be collected in ``data``.
         meta_keys (Sequence[str], optional): Meta keys to be converted to
             ``mmcv.DataContainer`` and collected in ``data[img_metas]``.
-            Default: `(``filename``, ``ori_filename``, ``ori_shape``,
+            Default: (``filename``, ``ori_filename``, ``ori_shape``,
             ``img_shape``, ``pad_shape``, ``scale_factor``, ``flip``,
-            ``flip_direction``, ``img_norm_cfg``)`
+            ``flip_direction``, ``img_norm_cfg``)
     """
 
     def __init__(self,

--- a/mmseg/datasets/pipelines/formating.py
+++ b/mmseg/datasets/pipelines/formating.py
@@ -248,10 +248,10 @@ class Collect(object):
     Args:
         keys (Sequence[str]): Keys of results to be collected in ``data``.
         meta_keys (Sequence[str], optional): Meta keys to be converted to
-            ``mmcv.DataContainer`` and collected in ``data[img_metas]``.
-            Default: ``('filename', 'ori_filename', 'ori_shape', 'img_shape',
+            `mmcv.DataContainer` and collected in `data[img_metas]`.
+            Default: `('filename', 'ori_filename', 'ori_shape', 'img_shape',
             'pad_shape', 'scale_factor', 'flip', 'flip_direction',
-            'img_norm_cfg')``
+            'img_norm_cfg')`
     """
 
     def __init__(self,

--- a/mmseg/models/backbones/cgnet.py
+++ b/mmseg/models/backbones/cgnet.py
@@ -187,8 +187,8 @@ class InputInjection(nn.Module):
 class CGNet(BaseModule):
     """CGNet backbone.
 
-    A Light-weight Context Guided Network for Semantic Segmentation
-    arXiv: https://arxiv.org/abs/1811.08201
+    This backbone is the implementation of `A Light-weight Context Guided
+    Network for Semantic Segmentation <https://arxiv.org/abs/1811.08201>`_.
 
     Args:
         in_channels (int): Number of input image channels. Normally 3.

--- a/mmseg/models/backbones/fast_scnn.py
+++ b/mmseg/models/backbones/fast_scnn.py
@@ -272,6 +272,9 @@ class FeatureFusionModule(nn.Module):
 class FastSCNN(BaseModule):
     """Fast-SCNN Backbone.
 
+    This backbone is the implementation of `Fast-SCNN: Fast Semantic
+    Segmentation Network <https://arxiv.org/abs/1902.04502>`_.
+
     Args:
         in_channels (int): Number of input image channels. Default: 3.
         downsample_dw_channels (tuple[int]): Number of output channels after

--- a/mmseg/models/backbones/hrnet.py
+++ b/mmseg/models/backbones/hrnet.py
@@ -218,8 +218,8 @@ class HRModule(BaseModule):
 class HRNet(BaseModule):
     """HRNet backbone.
 
-    `High-Resolution Representations for Labeling Pixels and Regions
-    arXiv: <https://arxiv.org/abs/1904.04514>`_.
+    This backbone is the implementation of `High-Resolution Representations
+    for Labeling Pixels and Regions <https://arxiv.org/abs/1904.04514>`_.
 
     Args:
         extra (dict): Detailed configuration for each stage of HRNet.

--- a/mmseg/models/backbones/mit.py
+++ b/mmseg/models/backbones/mit.py
@@ -246,9 +246,9 @@ class TransformerEncoderLayer(BaseModule):
 class MixVisionTransformer(BaseModule):
     """The backbone of Segformer.
 
-    A PyTorch implement of : `SegFormer: Simple and Efficient Design for
-    Semantic Segmentation with Transformers` -
-        https://arxiv.org/pdf/2105.15203.pdf
+    This backbone is the implementation of `SegFormer: Simple and
+    Efficient Design for Semantic Segmentation with
+    Transformers <https://arxiv.org/abs/2105.15203>`_.
 
     Args:
         in_channels (int): Number of input channels. Default: 3.

--- a/mmseg/models/backbones/mobilenet_v2.py
+++ b/mmseg/models/backbones/mobilenet_v2.py
@@ -12,7 +12,9 @@ from ..utils import InvertedResidual, make_divisible
 
 @BACKBONES.register_module()
 class MobileNetV2(BaseModule):
-    """MobileNetV2 backbone.
+    """MobileNetV2 backbone. This backbone is the implementation of
+    `MobileNetV2: Inverted Residuals and Linear Bottlenecks
+    <https://arxiv.org/abs/1801.04381>`_.
 
     Args:
         widen_factor (float): Width multiplier, multiply number of

--- a/mmseg/models/backbones/mobilenet_v2.py
+++ b/mmseg/models/backbones/mobilenet_v2.py
@@ -12,7 +12,9 @@ from ..utils import InvertedResidual, make_divisible
 
 @BACKBONES.register_module()
 class MobileNetV2(BaseModule):
-    """MobileNetV2 backbone. This backbone is the implementation of
+    """MobileNetV2 backbone.
+
+    This backbone is the implementation of
     `MobileNetV2: Inverted Residuals and Linear Bottlenecks
     <https://arxiv.org/abs/1801.04381>`_.
 

--- a/mmseg/models/backbones/resnest.py
+++ b/mmseg/models/backbones/resnest.py
@@ -271,6 +271,9 @@ class Bottleneck(_Bottleneck):
 class ResNeSt(ResNetV1d):
     """ResNeSt backbone.
 
+    This backbone is the implementation of `ResNeSt:
+    Split-Attention Networks <https://arxiv.org/abs/2004.08955>`_.
+
     Args:
         groups (int): Number of groups of Bottleneck. Default: 1
         base_width (int): Base width of Bottleneck. Default: 4

--- a/mmseg/models/backbones/resnet.py
+++ b/mmseg/models/backbones/resnet.py
@@ -689,12 +689,10 @@ class ResNet(BaseModule):
 class ResNetV1c(ResNet):
     """ResNetV1c variant described in [1]_.
 
-    Compared with default ResNet(ResNetV1b), ResNetV1c replaces the 7x7 conv
-    in the input stem with three 3x3 convs.
-
-    References:
-        .. [1]  `Bag of Tricks for Image Classification with
-        Convolutional Neural Networks <https://arxiv.org/abs/1812.01187>`_.
+    Compared with default ResNet(ResNetV1b), ResNetV1c replaces the 7x7 conv in
+    the input stem with three 3x3 convs. For more details please refer to `Bag
+    of Tricks for Image Classification with Convolutional Neural Networks
+    <https://arxiv.org/abs/1812.01187>`_.
     """
 
     def __init__(self, **kwargs):

--- a/mmseg/models/backbones/resnet.py
+++ b/mmseg/models/backbones/resnet.py
@@ -693,7 +693,8 @@ class ResNetV1c(ResNet):
     in the input stem with three 3x3 convs.
 
     References:
-        .. [1] https://arxiv.org/pdf/1812.01187.pdf
+        .. [1]  `Bag of Tricks for Image Classification with
+        Convolutional Neural Networks <https://arxiv.org/abs/1812.01187>`_.
     """
 
     def __init__(self, **kwargs):

--- a/mmseg/models/backbones/resnet.py
+++ b/mmseg/models/backbones/resnet.py
@@ -311,6 +311,9 @@ class Bottleneck(BaseModule):
 class ResNet(BaseModule):
     """ResNet backbone.
 
+    This backbone is the improved implementation of `Deep Residual Learning
+    for Image Recognition <https://arxiv.org/abs/1512.03385>`_.
+
     Args:
         depth (int): Depth of resnet, from {18, 34, 50, 101, 152}.
         in_channels (int): Number of input image channels. Default: 3.

--- a/mmseg/models/backbones/resnext.py
+++ b/mmseg/models/backbones/resnext.py
@@ -88,6 +88,9 @@ class Bottleneck(_Bottleneck):
 class ResNeXt(ResNet):
     """ResNeXt backbone.
 
+    This backbone is the implementation of `ResNeSt:
+    Split-Attention Networks <https://arxiv.org/abs/1611.05431>`_.
+
     Args:
         depth (int): Depth of resnet, from {18, 34, 50, 101, 152}.
         in_channels (int): Number of input image channels. Normally 3.

--- a/mmseg/models/backbones/resnext.py
+++ b/mmseg/models/backbones/resnext.py
@@ -88,8 +88,9 @@ class Bottleneck(_Bottleneck):
 class ResNeXt(ResNet):
     """ResNeXt backbone.
 
-    This backbone is the implementation of `ResNeSt:
-    Split-Attention Networks <https://arxiv.org/abs/1611.05431>`_.
+    This backbone is the implementation of `Aggregated
+    Residual Transformations for Deep Neural
+    Networks <https://arxiv.org/abs/1611.05431>`_.
 
     Args:
         depth (int): Depth of resnet, from {18, 34, 50, 101, 152}.

--- a/mmseg/models/backbones/swin.py
+++ b/mmseg/models/backbones/swin.py
@@ -522,13 +522,12 @@ class SwinBlockSequence(BaseModule):
 
 @BACKBONES.register_module()
 class SwinTransformer(BaseModule):
-    """ Swin Transformer
-    A PyTorch implement of : `Swin Transformer:
-    Hierarchical Vision Transformer using Shifted Windows`  -
-        https://arxiv.org/abs/2103.14030
+    """Swin Transformer backbone.
 
-    Inspiration from
-    https://github.com/microsoft/Swin-Transformer
+    This backbone is the implementation of `Swin Transformer:
+    Hierarchical Vision Transformer using Shifted
+    Windows <https://arxiv.org/abs/2103.14030>`_.
+    Inspiration from https://github.com/microsoft/Swin-Transformer.
 
     Args:
         pretrain_img_size (int | tuple[int]): The size of input image when

--- a/mmseg/models/backbones/unet.py
+++ b/mmseg/models/backbones/unet.py
@@ -224,8 +224,9 @@ class InterpConv(nn.Module):
 @BACKBONES.register_module()
 class UNet(BaseModule):
     """UNet backbone.
-    U-Net: Convolutional Networks for Biomedical Image Segmentation.
-    https://arxiv.org/pdf/1505.04597.pdf
+
+    This backbone is the implementation of `U-Net: Convolutional Networks
+    for Biomedical Image Segmentation <https://arxiv.org/abs/1505.04597>`_.
 
     Args:
         in_channels (int): Number of input image channels. Default" 3.
@@ -277,7 +278,6 @@ class UNet(BaseModule):
         The input image size should be divisible by the whole downsample rate
         of the encoder. More detail of the whole downsample rate can be found
         in UNet._check_input_divisible.
-
     """
 
     def __init__(self,

--- a/mmseg/models/backbones/vit.py
+++ b/mmseg/models/backbones/vit.py
@@ -98,9 +98,9 @@ class TransformerEncoderLayer(BaseModule):
 class VisionTransformer(BaseModule):
     """Vision Transformer.
 
-    A PyTorch implement of : `An Image is Worth 16x16 Words:
-    Transformers for Image Recognition at Scale` -
-        https://arxiv.org/abs/2010.11929
+    This backbone is the implementation of `An Image is Worth 16x16 Words:
+    Transformers for Image Recognition at
+    Scale <https://arxiv.org/abs/2010.11929>`_.
 
     Args:
         img_size (int | tuple): Input image size. Default: 224.

--- a/mmseg/models/decode_heads/point_head.py
+++ b/mmseg/models/decode_heads/point_head.py
@@ -36,6 +36,8 @@ def calculate_uncertainty(seg_logits):
 class PointHead(BaseCascadeDecodeHead):
     """A mask point head use in PointRend.
 
+    This head is implemented of `PointRend: Image Segmentation as
+    Rendering <https://arxiv.org/abs/1912.08193>`_.
     ``PointHead`` use shared multi-layer perceptron (equivalent to
     nn.Conv1d) to predict the logit of input points. The fine-grained feature
     and coarse feature will be concatenate together for predication.

--- a/mmseg/models/decode_heads/sep_fcn_head.py
+++ b/mmseg/models/decode_heads/sep_fcn_head.py
@@ -10,7 +10,9 @@ class DepthwiseSeparableFCNHead(FCNHead):
     """Depthwise-Separable Fully Convolutional Network for Semantic
     Segmentation.
 
-    This head is implemented according to Fast-SCNN paper.
+    This head is implemented according to `Fast-SCNN: Fast Semantic
+    Segmentation Network <https://arxiv.org/abs/1902.04502>`_.
+
     Args:
         in_channels(int): Number of output channels of FFM.
         channels(int): Number of middle-stage channels in the decode head.

--- a/mmseg/models/necks/fpn.py
+++ b/mmseg/models/necks/fpn.py
@@ -12,8 +12,8 @@ from ..builder import NECKS
 class FPN(BaseModule):
     """Feature Pyramid Network.
 
-    This is an implementation of - Feature Pyramid Networks for Object
-    Detection (https://arxiv.org/abs/1612.03144)
+    This neck is the implementation of `Feature Pyramid Networks for Object
+    Detection <https://arxiv.org/abs/1612.03144>`_.
 
     Args:
         in_channels (List[int]): Number of input channels per scale.

--- a/mmseg/models/necks/mla_neck.py
+++ b/mmseg/models/necks/mla_neck.py
@@ -63,8 +63,8 @@ class MLAModule(nn.Module):
 class MLANeck(nn.Module):
     """Multi-level Feature Aggregation.
 
-    The Multi-level Feature Aggregation construction of SETR:
-    https://arxiv.org/pdf/2012.15840.pdf
+    This neck is `The Multi-level Feature Aggregation construction of
+    SETR <https://arxiv.org/abs/2012.15840>`_.
 
 
     Args:

--- a/mmseg/models/necks/multilevel_neck.py
+++ b/mmseg/models/necks/multilevel_neck.py
@@ -11,6 +11,7 @@ class MultiLevelNeck(nn.Module):
     """MultiLevelNeck.
 
     A neck structure connect vit backbone and decoder_heads.
+
     Args:
         in_channels (List[int]): Number of input channels per scale.
         out_channels (int): Number of output channels (used at each scale).


### PR DESCRIPTION
**Motivation:**

Fix some problems in `readthedocs` (https://mmsegmentation.readthedocs.io/en/latest/), it is caused by wrong docstring usage.

For example, the correct format should be: 
```
""" Encoder-Decoder with Atrous Separable Convolution for Semantic Image Segmentation.


This head is the implementation of `DeepLabV3+ <https://arxiv.org/abs/1802.02611>`_.

Args:
    c1_in_channels (int): The input channels of c1 decoder. If is 0,
        the no decoder will be used.
    c1_channels (int): The intermediate channels of c1 decoder.

"""
```

And in `readthedocs` it would show as below:
![image](https://user-images.githubusercontent.com/24582831/131794649-86f9e16b-9ed1-4e1f-9b9a-839a2a6d1c99.png)
