### PR TITLE
[Fix] Fix iter bug when resuming checkpoint in distributed train

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -7,7 +7,7 @@ import time
 
 import mmcv
 import torch
-from mmcv.runner import init_dist
+from mmcv.runner import init_dist, get_dist_info
 from mmcv.utils import Config, DictAction, get_git_hash
 
 from mmseg import __version__
@@ -94,6 +94,9 @@ def main():
     else:
         distributed = True
         init_dist(args.launcher, **cfg.dist_params)
+        # gpu_ids is used to calculate iter when resuming checkpoint,
+        _, world_size = get_dist_info()
+        cfg.gpu_ids = range(world_size)
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))

--- a/tools/train.py
+++ b/tools/train.py
@@ -7,7 +7,7 @@ import time
 
 import mmcv
 import torch
-from mmcv.runner import init_dist, get_dist_info
+from mmcv.runner import get_dist_info, init_dist
 from mmcv.utils import Config, DictAction, get_git_hash
 
 from mmseg import __version__


### PR DESCRIPTION
## Motivation
As show in 
https://github.com/open-mmlab/mmcv/blob/b4bfeb53c57f2c843cb5015f9c0a2d1689dba9c4/mmcv/runner/base_runner.py#L379 ,
`cfg.gpu_ids` is used to calculate current iteration when resuming checkpoint in `epoch_based_runner` and `based_runner`, but it is `range(1)` in distributed training in default, which will lead to a wrong iteration. Here fix it to `range(world_size)` 


