### PR TITLE
[Feature] Add UNet benchmark on cityscapes

### DIFF
--- a/configs/_base_/datasets/cityscapes_512x512.py
+++ b/configs/_base_/datasets/cityscapes_512x512.py
@@ -1,0 +1,35 @@
+_base_ = './cityscapes.py'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+crop_size = (512, 512)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations'),
+    dict(type='Resize', img_scale=(2048, 1024), ratio_range=(0.5, 2.0)),
+    dict(type='RandomCrop', crop_size=crop_size, cat_max_ratio=0.75),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size=crop_size, pad_val=0, seg_pad_val=255),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_semantic_seg']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(2048, 1024),
+        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    train=dict(pipeline=train_pipeline),
+    val=dict(pipeline=test_pipeline),
+    test=dict(pipeline=test_pipeline))

--- a/configs/_base_/datasets/cityscapes_768x768.py
+++ b/configs/_base_/datasets/cityscapes_768x768.py
@@ -1,0 +1,35 @@
+_base_ = './cityscapes.py'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+crop_size = (768, 768)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations'),
+    dict(type='Resize', img_scale=(2048, 1024), ratio_range=(0.5, 2.0)),
+    dict(type='RandomCrop', crop_size=crop_size, cat_max_ratio=0.75),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size=crop_size, pad_val=0, seg_pad_val=255),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_semantic_seg']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(2048, 1024),
+        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    train=dict(pipeline=train_pipeline),
+    val=dict(pipeline=test_pipeline),
+    test=dict(pipeline=test_pipeline))

--- a/configs/_base_/datasets/cityscapes_832x832.py
+++ b/configs/_base_/datasets/cityscapes_832x832.py
@@ -1,0 +1,35 @@
+_base_ = './cityscapes.py'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+crop_size = (832, 832)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations'),
+    dict(type='Resize', img_scale=(2048, 1024), ratio_range=(0.5, 2.0)),
+    dict(type='RandomCrop', crop_size=crop_size, cat_max_ratio=0.75),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size=crop_size, pad_val=0, seg_pad_val=255),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_semantic_seg']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(2048, 1024),
+        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    train=dict(pipeline=train_pipeline),
+    val=dict(pipeline=test_pipeline),
+    test=dict(pipeline=test_pipeline))

--- a/configs/_base_/schedules/schedule_320k.py
+++ b/configs/_base_/schedules/schedule_320k.py
@@ -1,0 +1,9 @@
+# optimizer
+optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0005)
+optimizer_config = dict()
+# learning policy
+lr_config = dict(policy='poly', power=0.9, min_lr=1e-4, by_epoch=False)
+# runtime settings
+runner = dict(type='IterBasedRunner', max_iters=320000)
+checkpoint_config = dict(by_epoch=False, interval=32000)
+evaluation = dict(interval=32000, metric='mIoU', pre_eval=True)

--- a/configs/unet/fcn_unet_s5-d16_512x1024_160k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_512x1024_160k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py', '../_base_/datasets/cityscapes.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_512x1024_320k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_512x1024_320k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py', '../_base_/datasets/cityscapes.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_320k.py'
+]
+
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_512x1024_80k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_512x1024_80k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py', '../_base_/datasets/cityscapes.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_80k.py'
+]
+
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_512x512_160k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_512x512_160k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_512x512.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_512x512_320k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_512x512_320k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_512x512.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_320k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_512x512_80k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_512x512_80k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_512x512.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_768x768_160k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_768x768_160k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_768x768.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_768x768_320k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_768x768_320k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_768x768.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_320k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_768x768_80k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_768x768_80k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_768x768.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_832x832_160k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_832x832_160k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_832x832.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_832x832_320k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_832x832_320k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_832x832.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_320k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/configs/unet/fcn_unet_s5-d16_832x832_80k_cityscapes.py
+++ b/configs/unet/fcn_unet_s5-d16_832x832_80k_cityscapes.py
@@ -1,0 +1,11 @@
+_base_ = [
+    '../_base_/models/fcn_unet_s5-d16.py',
+    '../_base_/datasets/cityscapes_832x832.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=19),
+    auxiliary_head=dict(num_classes=19),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))


### PR DESCRIPTION
## Motivation

Add UNet benchmark on cityscapes with different crop size

## Modification

Add more configs in `./configs`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
No.

Benchmark results:
![image](https://user-images.githubusercontent.com/16716329/133262959-db055bea-b7ac-4f11-b40a-c0f667f2fda7.png)

