### PR TITLE
[Improvement] Exclude data loading time when benchmarking speed

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -36,9 +36,10 @@ def main():
     data_loader = build_dataloader(
         dataset,
         samples_per_gpu=1,
-        workers_per_gpu=cfg.data.workers_per_gpu,
+        workers_per_gpu=0,
         dist=False,
-        shuffle=False)
+        shuffle=False,
+        persistent_workers=False)
 
     # build the model and load checkpoint
     cfg.model.train_cfg = None
@@ -57,8 +58,11 @@ def main():
     pure_inf_time = 0
     total_iters = 200
 
+    data_loader_iter = iter(data_loader)
     # benchmark with 200 image and take the average
-    for i, data in enumerate(data_loader):
+    for i in range(total_iters):
+
+        data = next(data_loader_iter)
 
         torch.cuda.synchronize()
         start_time = time.perf_counter()
@@ -76,10 +80,8 @@ def main():
                 print(f'Done image [{i + 1:<3}/ {total_iters}], '
                       f'fps: {fps:.2f} img / s')
 
-        if (i + 1) == total_iters:
-            fps = (i + 1 - num_warmup) / pure_inf_time
-            print(f'Overall fps: {fps:.2f} img / s')
-            break
+    fps = (total_iters - num_warmup) / pure_inf_time
+    print(f'Overall fps: {fps:.2f} img / s')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

Exclude data loading time when benchmarking speed

## Modification

Call `data = next(data_loader_iter)` explicitly. 

## BC-breaking (Optional)

May need to re-run all inference speed benchmark. 
