### PR TITLE
The val function code in the workflow process does not work properly, and the code parameters do not match

### DIFF
--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -145,7 +145,7 @@ class BaseSegmentor(BaseModule, metaclass=ABCMeta):
 
         return outputs
 
-    def val_step(self, data_batch, **kwargs):
+    def val_step(self, data_batch,optimizer=None, **kwargs):
         """The iteration step during validation.
 
         This method shares the same signature as :func:`train_step`, but used


### PR DESCRIPTION
Def val_step(self, data_batch, **kwargs) in base.py has no optimizer， 
However,the outputs = self.model. val_step(data_batch, self. optimizer, **kwargs) in epoch_based_runner.py contains the parameter "optimizer".