### PR TITLE
[Feature] Add DUTS dataset

### DIFF
--- a/configs/_base_/datasets/duts.py
+++ b/configs/_base_/datasets/duts.py
@@ -1,0 +1,56 @@
+# dataset settings
+dataset_type = 'DUTSDataset'
+data_root = 'data/DUTS'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+img_scale = (352, 352)
+crop_size = (320, 320)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations'),
+    dict(type='Resize', img_scale=img_scale, ratio_range=(0.5, 2.0)),
+    dict(type='RandomCrop', crop_size=crop_size, cat_max_ratio=0.75),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size=crop_size, pad_val=0, seg_pad_val=255),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_semantic_seg'])
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=img_scale,
+        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img'])
+        ])
+]
+
+data = dict(
+    samples_per_gpu=4,
+    workers_per_gpu=4,
+    train=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/training',
+        ann_dir='annotations/training',
+        pipeline=train_pipeline),
+    val=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline),
+    test=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline))

--- a/docs_zh-CN/dataset_prepare.md
+++ b/docs_zh-CN/dataset_prepare.md
@@ -89,6 +89,13 @@ mmsegmentation
 |   |   └── leftImg8bit
 |   |   |   └── test
 |   |   |       └── night
+|   ├── DUTS
+│   │   ├── images
+│   │   │   ├── training
+│   │   │   ├── validation
+│   │   ├── annotations
+│   │   │   ├── training
+│   │   │   ├── validation
 ```
 
 ### Cityscapes
@@ -195,3 +202,13 @@ python tools/convert_datasets/stare.py /path/to/stare-images.tar /path/to/labels
 ### Nighttime Driving
 
 因为我们只支持在此数据集上测试模型，所以您只需下载[测试集](http://data.vision.ee.ethz.ch/daid/NighttimeDriving/NighttimeDrivingTest.zip)。
+
+### DUTS
+
+首先，下载 [DUTS-TR.zip](http://saliencydetection.net/duts/download/DUTS-TR.zip) 和 [DUTS-TE.zip](http://saliencydetection.net/duts/download/DUTS-TE.zip) 。
+
+为了将 DUTS 数据集转换成 MMSegmentation 格式，您需要运行如下命令：
+
+```shell
+python tools/convert_datasets/duts.py /path/to/DUTS-TR.zip /path/to/DUTS-TE.zip
+```

--- a/mmseg/datasets/__init__.py
+++ b/mmseg/datasets/__init__.py
@@ -8,6 +8,7 @@ from .custom import CustomDataset
 from .dark_zurich import DarkZurichDataset
 from .dataset_wrappers import ConcatDataset, RepeatDataset
 from .drive import DRIVEDataset
+from .duts import DUTSDataset
 from .hrf import HRFDataset
 from .night_driving import NightDrivingDataset
 from .pascal_context import PascalContextDataset, PascalContextDataset59
@@ -20,5 +21,5 @@ __all__ = [
     'PascalVOCDataset', 'ADE20KDataset', 'PascalContextDataset',
     'PascalContextDataset59', 'ChaseDB1Dataset', 'DRIVEDataset', 'HRFDataset',
     'STAREDataset', 'DarkZurichDataset', 'NightDrivingDataset',
-    'COCOStuffDataset'
+    'COCOStuffDataset', 'DUTSDataset'
 ]

--- a/mmseg/datasets/duts.py
+++ b/mmseg/datasets/duts.py
@@ -1,0 +1,27 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
+
+from .builder import DATASETS
+from .custom import CustomDataset
+
+
+@DATASETS.register_module()
+class DUTSDataset(CustomDataset):
+    """DUTS dataset.
+
+    In saliency map annotation for DUTS, 0 stands for background.
+    ``reduce_zero_label`` is fixed to False. The ``img_suffix`` is fixed to
+    '.png' and ``seg_map_suffix`` is fixed to '.png'.
+    """
+
+    CLASSES = ('background', 'foreground')
+
+    PALETTE = [[120, 120, 120], [6, 230, 230]]
+
+    def __init__(self, **kwargs):
+        super(DUTSDataset, self).__init__(
+            img_suffix='.png',
+            seg_map_suffix='.png',
+            reduce_zero_label=False,
+            **kwargs)
+        assert osp.exists(self.img_dir)

--- a/tools/convert_datasets/duts.py
+++ b/tools/convert_datasets/duts.py
@@ -1,0 +1,95 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import argparse
+import os
+import os.path as osp
+import shutil
+import tempfile
+import zipfile
+
+import mmcv
+
+TRAIN_LEN = 10553
+TEST_LEN = 5019
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Convert DUTS dataset to mmsegmentation format')
+    parser.add_argument('trainset_path', help='the path of DUTS-TR.zip')
+    parser.add_argument('testset_path', help='the path of DUTS-TE.zip')
+    parser.add_argument('--tmp_dir', help='path of the temporary directory')
+    parser.add_argument('-o', '--out_dir', help='output path')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    if args.out_dir is None:
+        out_dir = osp.join('data', 'DUTS')
+    else:
+        out_dir = args.out_dir
+
+    print('Making directories...')
+    mmcv.mkdir_or_exist(out_dir)
+    mmcv.mkdir_or_exist(osp.join(out_dir, 'images'))
+    mmcv.mkdir_or_exist(osp.join(out_dir, 'images', 'training'))
+    mmcv.mkdir_or_exist(osp.join(out_dir, 'images', 'validation'))
+    mmcv.mkdir_or_exist(osp.join(out_dir, 'annotations'))
+    mmcv.mkdir_or_exist(osp.join(out_dir, 'annotations', 'training'))
+    mmcv.mkdir_or_exist(osp.join(out_dir, 'annotations', 'validation'))
+
+    print('Generating images...')
+    # DUTS-TR
+    with tempfile.TemporaryDirectory(dir=args.tmp_dir) as tmp_dir:
+        zip_file = zipfile.ZipFile(args.trainset_path)
+        zip_file.extractall(tmp_dir)
+        image_dir = osp.join(tmp_dir, 'DUTS-TR', 'DUTS-TR-Image')
+        mask_dir = osp.join(tmp_dir, 'DUTS-TR', 'DUTS-TR-Mask')
+
+        assert len(os.listdir(image_dir)) == TRAIN_LEN \
+               and len(os.listdir(mask_dir)) == \
+               TRAIN_LEN, 'len(train_set) != {}'.format(TRAIN_LEN)
+
+        for filename in sorted(os.listdir(image_dir)):
+            shutil.copy(
+                osp.join(image_dir, filename),
+                osp.join(out_dir, 'images', 'training',
+                         osp.splitext(filename)[0] + '.png'))
+
+        for filename in sorted(os.listdir(mask_dir)):
+            img = mmcv.imread(osp.join(mask_dir, filename))
+            mmcv.imwrite(
+                img[:, :, 0] // 128,
+                osp.join(out_dir, 'annotations', 'training',
+                         osp.splitext(filename)[0] + '.png'))
+
+    # DUTS-TE
+    with tempfile.TemporaryDirectory(dir=args.tmp_dir) as tmp_dir:
+        zip_file = zipfile.ZipFile(args.testset_path)
+        zip_file.extractall(tmp_dir)
+        image_dir = osp.join(tmp_dir, 'DUTS-TE', 'DUTS-TE-Image')
+        mask_dir = osp.join(tmp_dir, 'DUTS-TE', 'DUTS-TE-Mask')
+
+        assert len(os.listdir(image_dir)) == TEST_LEN \
+               and len(os.listdir(mask_dir)) == \
+               TEST_LEN, 'len(test_set) != {}'.format(TEST_LEN)
+
+        for filename in sorted(os.listdir(image_dir)):
+            shutil.copy(
+                osp.join(image_dir, filename),
+                osp.join(out_dir, 'images', 'validation',
+                         osp.splitext(filename)[0] + '.png'))
+
+        for filename in sorted(os.listdir(mask_dir)):
+            img = mmcv.imread(osp.join(mask_dir, filename))
+            mmcv.imwrite(
+                img[:, :, 0] // 128,
+                osp.join(out_dir, 'annotations', 'validation',
+                         osp.splitext(filename)[0] + '.png'))
+
+    print('Done!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Support [DUTS](http://saliencydetection.net/duts/) dataset, which is the most popular dataset in salient object detection.

DUTS contains 10,553 training images and 5,019 test images. All training images are collected from the ImageNet DET training/val sets, while test images are collected from the ImageNet DET test set and the SUN data set. Both the training and test set contain very challenging scenarios for saliency detection. Accurate pixel-level ground truths are manually annotated by 50 subjects.

DUTS is currently the largest saliency detection benchmark with the explicit training/test evaluation protocol. For fair comparison in the future research, the training set of DUTS serves as a good candidate for learning DNNs, while the test set and other public data sets can be used for evaluation.
