### PR TITLE
[Fix] #916 expection string type classes

### DIFF
--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -319,7 +319,7 @@ class CustomDataset(Dataset):
             raise ValueError(f'Unsupported type {type(classes)} of classes.')
 
         if self.CLASSES:
-            if not set(classes).issubset(self.CLASSES):
+            if not set(class_names).issubset(self.CLASSES):
                 raise ValueError('classes is not a subset of CLASSES.')
 
             # dictionary, its keys are the old label ids and its values
@@ -330,7 +330,7 @@ class CustomDataset(Dataset):
                 if c not in class_names:
                     self.label_map[i] = -1
                 else:
-                    self.label_map[i] = classes.index(c)
+                    self.label_map[i] = class_names.index(c)
 
         palette = self.get_palette_for_custom_classes(class_names, palette)
 

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os
 import os.path as osp
 import shutil
 from typing import Generator
@@ -26,6 +27,40 @@ def test_classes():
         get_classes('unsupported')
 
 
+def test_classes_file_path():
+    train_pipeline = [dict(type='LoadImageFromFile')]
+    classes_path = '../data/classes.txt'
+
+    # classes.txt with full categories
+    categories = get_classes('cityscapes')
+    with open(classes_path, 'w') as f:
+        f.write('\n'.join(categories))
+
+    kwargs = dict(
+        pipeline=train_pipeline,
+        img_dir='./',
+        classes=classes_path
+    )
+    assert list(CityscapesDataset(**kwargs).CLASSES) == categories
+
+    # classes.txt with sub categories
+    categories = ['road', 'sidewalk', 'building']
+    with open(classes_path, 'w') as f:
+        f.write('\n'.join(categories))
+    assert list(CityscapesDataset(**kwargs).CLASSES) == categories
+
+    # classes.txt with unknown categories
+    categories = ['road', 'sidewalk', 'unknown']
+    with open(classes_path, 'w') as f:
+        f.write('\n'.join(categories))
+
+    with pytest.raises(ValueError):
+        CityscapesDataset(**kwargs)
+
+    os.remove(classes_path)
+    assert not osp.exists(classes_path)
+        
+        
 def test_palette():
     assert CityscapesDataset.PALETTE == get_palette('cityscapes')
     assert PascalVOCDataset.PALETTE == get_palette('voc') == get_palette(

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -59,8 +59,8 @@ def test_classes_file_path():
 
     os.remove(classes_path)
     assert not osp.exists(classes_path)
-        
-        
+
+
 def test_palette():
     assert CityscapesDataset.PALETTE == get_palette('cityscapes')
     assert PascalVOCDataset.PALETTE == get_palette('voc') == get_palette(


### PR DESCRIPTION
expection occurs when classes variable is a string file path

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

fix a bug in custom.py, Exception occurs when `classes` is a string type file path .

## Modification

modify `classes` to `class_names` in https://github.com/ShoupingShan/mmsegmentation/blob/1df3a93d0d169c4bd7bc538c378ed9f2d43d50d6/mmseg/datasets/custom.py#L322 and https://github.com/ShoupingShan/mmsegmentation/blob/1df3a93d0d169c4bd7bc538c378ed9f2d43d50d6/mmseg/datasets/custom.py#L333

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
