### PR TITLE
[Feature] Supporting Tversky loss

### DIFF
--- a/mmseg/models/losses/__init__.py
+++ b/mmseg/models/losses/__init__.py
@@ -4,10 +4,12 @@ from .cross_entropy_loss import (CrossEntropyLoss, binary_cross_entropy,
                                  cross_entropy, mask_cross_entropy)
 from .dice_loss import DiceLoss
 from .lovasz_loss import LovaszLoss
+from .tversky_loss import TverskyLoss
 from .utils import reduce_loss, weight_reduce_loss, weighted_loss
 
 __all__ = [
     'accuracy', 'Accuracy', 'cross_entropy', 'binary_cross_entropy',
     'mask_cross_entropy', 'CrossEntropyLoss', 'reduce_loss',
-    'weight_reduce_loss', 'weighted_loss', 'LovaszLoss', 'DiceLoss'
+    'weight_reduce_loss', 'weighted_loss', 'LovaszLoss', 'DiceLoss',
+    'TverskyLoss'
 ]

--- a/mmseg/models/losses/dice_loss.py
+++ b/mmseg/models/losses/dice_loss.py
@@ -118,7 +118,7 @@ class DiceLoss(nn.Module):
             smooth=self.smooth,
             exponent=self.exponent,
             class_weight=class_weight,
-            ignore_index=self.ignore_index)
+            **kwargs)
         return loss
 
     @property

--- a/mmseg/models/losses/dice_loss.py
+++ b/mmseg/models/losses/dice_loss.py
@@ -65,7 +65,6 @@ class DiceLoss(nn.Module):
         class_weight (list[float] | str, optional): Weight of each class. If in
             str format, read them from a file. Defaults to None.
         loss_weight (float, optional): Weight of the loss. Default to 1.0.
-        ignore_index (int | None): The label index to be ignored. Default: 255.
         loss_name (str, optional): Name of the loss item. If you want this loss
             item to be included into the backward graph, `loss_` must be the
             prefix of the name. Defaults to 'loss_dice'.
@@ -77,7 +76,6 @@ class DiceLoss(nn.Module):
                  reduction='mean',
                  class_weight=None,
                  loss_weight=1.0,
-                 ignore_index=255,
                  loss_name='loss_dice'):
         super(DiceLoss, self).__init__()
         self.smooth = smooth
@@ -85,7 +83,6 @@ class DiceLoss(nn.Module):
         self.reduction = reduction
         self.class_weight = get_class_weight(class_weight)
         self.loss_weight = loss_weight
-        self.ignore_index = ignore_index
         self._loss_name = loss_name
 
     def forward(self,
@@ -93,6 +90,7 @@ class DiceLoss(nn.Module):
                 target,
                 avg_factor=None,
                 reduction_override=None,
+                ignore_index=255,
                 **kwargs):
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
@@ -107,7 +105,7 @@ class DiceLoss(nn.Module):
         one_hot_target = F.one_hot(
             torch.clamp(target.long(), 0, num_classes - 1),
             num_classes=num_classes)
-        valid_mask = (target != self.ignore_index).long()
+        valid_mask = (target != ignore_index).long()
 
         loss = self.loss_weight * dice_loss(
             pred,

--- a/mmseg/models/losses/dice_loss.py
+++ b/mmseg/models/losses/dice_loss.py
@@ -35,7 +35,7 @@ def dice_loss(pred,
 
 
 @weighted_loss
-def binary_dice_loss(pred, target, valid_mask, smooth=1, exponent=2, **kwards):
+def binary_dice_loss(pred, target, valid_mask, smooth=1, exponent=2):
     assert pred.shape[0] == target.shape[0]
     pred = pred.reshape(pred.shape[0], -1)
     target = target.reshape(target.shape[0], -1)
@@ -55,8 +55,6 @@ class DiceLoss(nn.Module):
     Volumetric Medical Image Segmentation <https://arxiv.org/abs/1606.04797>`_.
 
     Args:
-        loss_type (str, optional): Binary or multi-class loss.
-            Default: 'multi_class'. Options are "binary" and "multi_class".
         smooth (float): A float number to smooth loss, and avoid NaN error.
             Default: 1
         exponent (float): An float number to calculate denominator
@@ -80,8 +78,7 @@ class DiceLoss(nn.Module):
                  class_weight=None,
                  loss_weight=1.0,
                  ignore_index=255,
-                 loss_name='loss_dice',
-                 **kwards):
+                 loss_name='loss_dice'):
         super(DiceLoss, self).__init__()
         self.smooth = smooth
         self.exponent = exponent
@@ -96,7 +93,7 @@ class DiceLoss(nn.Module):
                 target,
                 avg_factor=None,
                 reduction_override=None,
-                **kwards):
+                **kwargs):
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)

--- a/mmseg/models/losses/tversky_loss.py
+++ b/mmseg/models/losses/tversky_loss.py
@@ -44,7 +44,6 @@ def binary_tversky_loss(pred,
                         target,
                         valid_mask,
                         smooth=1,
-                        exponent=2,
                         alpha=0.3,
                         beta=0.7,
                         **kwards):
@@ -66,12 +65,13 @@ class TverskyLoss(nn.Module):
     """TverskyLoss. This loss is proposed in `Tversky loss function for image
     segmentation using 3D fully convolutional deep networks.
 
-    <https://arxiv.org/abs/1706.05721>`
+    <https://arxiv.org/abs/1706.05721>`_.
+
     Args:
         loss_type (str, optional): Binary or multi-class loss.
             Default: 'multi_class'. Options are "binary" and "multi_class".
         smooth (float): A float number to smooth loss, and avoid NaN error.
-            Default: 1
+            Default: 1.
         exponent (float): An float number to calculate denominator
             value: \\sum{x^exponent} + \\sum{y^exponent}. Default: 2.
         reduction (str, optional): The method used to reduce the loss. Options
@@ -82,10 +82,10 @@ class TverskyLoss(nn.Module):
         loss_weight (float, optional): Weight of the loss. Default to 1.0.
         ignore_index (int | None): The label index to be ignored. Default: 255.
         alpha(float, in [0, 1]):
-            The coefficient of false positives. Default: 0.3
+            The coefficient of false positives. Default: 0.3.
         beta (float, in [0, 1]):
-            The coefficient of false negatives. Default: 0.7
-            Note: alpha + beta = 1
+            The coefficient of false negatives. Default: 0.7.
+            Note: alpha + beta = 1.
         loss_name (str, optional): Name of the loss item. If you want this loss
             item to be included into the backward graph, `loss_` must be the
             prefix of the name. Defaults to 'loss_tversky'.

--- a/mmseg/models/losses/tversky_loss.py
+++ b/mmseg/models/losses/tversky_loss.py
@@ -16,9 +16,9 @@ def tversky_loss(pred,
                  valid_mask,
                  smooth=1,
                  class_weight=None,
-                 ignore_index=255,
                  alpha=0.3,
-                 beta=0.7):
+                 beta=0.7,
+                 ignore_index=255):
     assert pred.shape[0] == target.shape[0]
     total_loss = 0
     num_classes = pred.shape[1]
@@ -132,9 +132,9 @@ class TverskyLoss(nn.Module):
             avg_factor=avg_factor,
             smooth=self.smooth,
             class_weight=class_weight,
-            ignore_index=self.ignore_index,
             alpha=self.alpha,
-            beta=self.beta)
+            beta=self.beta,
+            **kwargs)
         return loss
 
     @property

--- a/mmseg/models/losses/tversky_loss.py
+++ b/mmseg/models/losses/tversky_loss.py
@@ -73,7 +73,6 @@ class TverskyLoss(nn.Module):
         class_weight (list[float] | str, optional): Weight of each class. If in
             str format, read them from a file. Defaults to None.
         loss_weight (float, optional): Weight of the loss. Default to 1.0.
-        ignore_index (int | None): The label index to be ignored. Default: 255.
         alpha(float, in [0, 1]):
             The coefficient of false positives. Default: 0.3.
         beta (float, in [0, 1]):
@@ -89,7 +88,6 @@ class TverskyLoss(nn.Module):
                  reduction='mean',
                  class_weight=None,
                  loss_weight=1.0,
-                 ignore_index=255,
                  alpha=0.3,
                  beta=0.7,
                  loss_name='loss_tversky'):
@@ -98,7 +96,6 @@ class TverskyLoss(nn.Module):
         self.reduction = reduction
         self.class_weight = get_class_weight(class_weight)
         self.loss_weight = loss_weight
-        self.ignore_index = ignore_index
         self.alpha = alpha
         self.beta = beta
         self._loss_name = loss_name
@@ -108,6 +105,7 @@ class TverskyLoss(nn.Module):
                 target,
                 avg_factor=None,
                 reduction_override=None,
+                ignore_index=255,
                 **kwargs):
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
@@ -122,7 +120,7 @@ class TverskyLoss(nn.Module):
         one_hot_target = F.one_hot(
             torch.clamp(target.long(), 0, num_classes - 1),
             num_classes=num_classes)
-        valid_mask = (target != self.ignore_index).long()
+        valid_mask = (target != ignore_index).long()
 
         loss = self.loss_weight * tversky_loss(
             pred,

--- a/mmseg/models/losses/tversky_loss.py
+++ b/mmseg/models/losses/tversky_loss.py
@@ -107,7 +107,8 @@ class TverskyLoss(nn.Module):
                 pred,
                 target,
                 avg_factor=None,
-                reduction_override=None):
+                reduction_override=None,
+                **kwargs):
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)

--- a/mmseg/models/losses/tversky_loss.py
+++ b/mmseg/models/losses/tversky_loss.py
@@ -15,7 +15,6 @@ def tversky_loss(pred,
                  target,
                  valid_mask,
                  smooth=1,
-                 exponent=2,
                  class_weight=None,
                  ignore_index=255,
                  alpha=0.3,
@@ -30,7 +29,6 @@ def tversky_loss(pred,
                 target[..., i],
                 valid_mask=valid_mask,
                 smooth=smooth,
-                exponent=exponent,
                 alpha=alpha,
                 beta=beta)
             if class_weight is not None:
@@ -45,8 +43,7 @@ def binary_tversky_loss(pred,
                         valid_mask,
                         smooth=1,
                         alpha=0.3,
-                        beta=0.7,
-                        **kwards):
+                        beta=0.7):
     assert pred.shape[0] == target.shape[0]
     pred = pred.reshape(pred.shape[0], -1)
     target = target.reshape(target.shape[0], -1)
@@ -68,12 +65,8 @@ class TverskyLoss(nn.Module):
     <https://arxiv.org/abs/1706.05721>`_.
 
     Args:
-        loss_type (str, optional): Binary or multi-class loss.
-            Default: 'multi_class'. Options are "binary" and "multi_class".
         smooth (float): A float number to smooth loss, and avoid NaN error.
             Default: 1.
-        exponent (float): An float number to calculate denominator
-            value: \\sum{x^exponent} + \\sum{y^exponent}. Default: 2.
         reduction (str, optional): The method used to reduce the loss. Options
             are "none", "mean" and "sum". This parameter only works when
             per_image is True. Default: 'mean'.
@@ -93,18 +86,15 @@ class TverskyLoss(nn.Module):
 
     def __init__(self,
                  smooth=1,
-                 exponent=2,
                  reduction='mean',
                  class_weight=None,
                  loss_weight=1.0,
                  ignore_index=255,
                  alpha=0.3,
                  beta=0.7,
-                 loss_name='loss_tversky',
-                 **kwards):
+                 loss_name='loss_tversky'):
         super(TverskyLoss, self).__init__()
         self.smooth = smooth
-        self.exponent = exponent
         self.reduction = reduction
         self.class_weight = get_class_weight(class_weight)
         self.loss_weight = loss_weight
@@ -118,7 +108,7 @@ class TverskyLoss(nn.Module):
                 target,
                 avg_factor=None,
                 reduction_override=None,
-                **kwards):
+                **kwargs):
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)
@@ -141,7 +131,6 @@ class TverskyLoss(nn.Module):
             reduction=reduction,
             avg_factor=avg_factor,
             smooth=self.smooth,
-            exponent=self.exponent,
             class_weight=class_weight,
             ignore_index=self.ignore_index,
             alpha=self.alpha,

--- a/mmseg/models/losses/tversky_loss.py
+++ b/mmseg/models/losses/tversky_loss.py
@@ -1,0 +1,163 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Modified from
+https://github.com/JunMa11/SegLoss/blob/master/losses_pytorch/dice_loss.py
+(Apache-2.0 License)"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ..builder import LOSSES
+from .utils import get_class_weight, weighted_loss
+
+
+@weighted_loss
+def tversky_loss(pred,
+                 target,
+                 valid_mask,
+                 smooth=1,
+                 exponent=2,
+                 class_weight=None,
+                 ignore_index=255,
+                 alpha=0.3,
+                 beta=0.7):
+    assert pred.shape[0] == target.shape[0]
+    total_loss = 0
+    num_classes = pred.shape[1]
+    for i in range(num_classes):
+        if i != ignore_index:
+            tversky_loss = binary_tversky_loss(
+                pred[:, i],
+                target[..., i],
+                valid_mask=valid_mask,
+                smooth=smooth,
+                exponent=exponent,
+                alpha=alpha,
+                beta=beta)
+            if class_weight is not None:
+                tversky_loss *= class_weight[i]
+            total_loss += tversky_loss
+    return total_loss / num_classes
+
+
+@weighted_loss
+def binary_tversky_loss(pred,
+                        target,
+                        valid_mask,
+                        smooth=1,
+                        exponent=2,
+                        alpha=0.3,
+                        beta=0.7,
+                        **kwards):
+    assert pred.shape[0] == target.shape[0]
+    pred = pred.reshape(pred.shape[0], -1)
+    target = target.reshape(target.shape[0], -1)
+    valid_mask = valid_mask.reshape(valid_mask.shape[0], -1)
+
+    TP = torch.sum(torch.mul(pred, target) * valid_mask, dim=1)
+    FP = torch.sum(torch.mul(pred, 1 - target) * valid_mask, dim=1)
+    FN = torch.sum(torch.mul(1 - pred, target) * valid_mask, dim=1)
+    tversky = (TP + smooth) / (TP + alpha * FP + beta * FN + smooth)
+
+    return 1 - tversky
+
+
+@LOSSES.register_module()
+class TverskyLoss(nn.Module):
+    """TverskyLoss. This loss is proposed in `Tversky loss function for image
+    segmentation using 3D fully convolutional deep networks.
+
+    <https://arxiv.org/abs/1706.05721>`
+    Args:
+        loss_type (str, optional): Binary or multi-class loss.
+            Default: 'multi_class'. Options are "binary" and "multi_class".
+        smooth (float): A float number to smooth loss, and avoid NaN error.
+            Default: 1
+        exponent (float): An float number to calculate denominator
+            value: \\sum{x^exponent} + \\sum{y^exponent}. Default: 2.
+        reduction (str, optional): The method used to reduce the loss. Options
+            are "none", "mean" and "sum". This parameter only works when
+            per_image is True. Default: 'mean'.
+        class_weight (list[float] | str, optional): Weight of each class. If in
+            str format, read them from a file. Defaults to None.
+        loss_weight (float, optional): Weight of the loss. Default to 1.0.
+        ignore_index (int | None): The label index to be ignored. Default: 255.
+        alpha(float, in [0, 1]):
+            The coefficient of false positives. Default: 0.3
+        beta (float, in [0, 1]):
+            The coefficient of false negatives. Default: 0.7
+            Note: alpha + beta = 1
+        loss_name (str, optional): Name of the loss item. If you want this loss
+            item to be included into the backward graph, `loss_` must be the
+            prefix of the name. Defaults to 'loss_tversky'.
+    """
+
+    def __init__(self,
+                 smooth=1,
+                 exponent=2,
+                 reduction='mean',
+                 class_weight=None,
+                 loss_weight=1.0,
+                 ignore_index=255,
+                 alpha=0.3,
+                 beta=0.7,
+                 loss_name='loss_tversky',
+                 **kwards):
+        super(TverskyLoss, self).__init__()
+        self.smooth = smooth
+        self.exponent = exponent
+        self.reduction = reduction
+        self.class_weight = get_class_weight(class_weight)
+        self.loss_weight = loss_weight
+        self.ignore_index = ignore_index
+        self.alpha = alpha
+        self.beta = beta
+        self._loss_name = loss_name
+
+    def forward(self,
+                pred,
+                target,
+                avg_factor=None,
+                reduction_override=None,
+                **kwards):
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
+        if self.class_weight is not None:
+            class_weight = pred.new_tensor(self.class_weight)
+        else:
+            class_weight = None
+
+        pred = F.softmax(pred, dim=1)
+        num_classes = pred.shape[1]
+        one_hot_target = F.one_hot(
+            torch.clamp(target.long(), 0, num_classes - 1),
+            num_classes=num_classes)
+        valid_mask = (target != self.ignore_index).long()
+
+        loss = self.loss_weight * tversky_loss(
+            pred,
+            one_hot_target,
+            valid_mask=valid_mask,
+            reduction=reduction,
+            avg_factor=avg_factor,
+            smooth=self.smooth,
+            exponent=self.exponent,
+            class_weight=class_weight,
+            ignore_index=self.ignore_index,
+            alpha=self.alpha,
+            beta=self.beta)
+        return loss
+
+    @property
+    def loss_name(self):
+        """Loss Name.
+
+        This function must be implemented and will return the name of this
+        loss function. This name will be used to combine different loss items
+        by simple sum operation. In addition, if you want this loss item to be
+        included into the backward graph, `loss_` must be the prefix of the
+        name.
+        Returns:
+            str: The name of this loss item.
+        """
+        return self._loss_name

--- a/mmseg/models/losses/tversky_loss.py
+++ b/mmseg/models/losses/tversky_loss.py
@@ -107,8 +107,7 @@ class TverskyLoss(nn.Module):
                 pred,
                 target,
                 avg_factor=None,
-                reduction_override=None,
-                **kwargs):
+                reduction_override=None):
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)

--- a/tests/test_models/test_losses/test_dice_loss.py
+++ b/tests/test_models/test_losses/test_dice_loss.py
@@ -11,12 +11,11 @@ def test_dice_lose():
         reduction='none',
         class_weight=[1.0, 2.0, 3.0],
         loss_weight=1.0,
-        ignore_index=1,
         loss_name='loss_dice')
     dice_loss = build_loss(loss_cfg)
     logits = torch.rand(8, 3, 4, 4)
     labels = (torch.rand(8, 4, 4) * 3).long()
-    dice_loss(logits, labels)
+    dice_loss(logits, labels, ignore_index=1)
 
     # test loss with class weights from file
     import os
@@ -31,10 +30,9 @@ def test_dice_lose():
         reduction='none',
         class_weight=f'{tmp_file.name}.pkl',
         loss_weight=1.0,
-        ignore_index=1,
         loss_name='loss_dice')
     dice_loss = build_loss(loss_cfg)
-    dice_loss(logits, labels, ignore_index=None)
+    dice_loss(logits, labels, ignore_index=1)
 
     np.save(f'{tmp_file.name}.npy', np.array([1.0, 2.0, 3.0]))  # from npy file
     loss_cfg = dict(
@@ -42,10 +40,9 @@ def test_dice_lose():
         reduction='none',
         class_weight=f'{tmp_file.name}.pkl',
         loss_weight=1.0,
-        ignore_index=1,
         loss_name='loss_dice')
     dice_loss = build_loss(loss_cfg)
-    dice_loss(logits, labels, ignore_index=None)
+    dice_loss(logits, labels, ignore_index=1)
     tmp_file.close()
     os.remove(f'{tmp_file.name}.pkl')
     os.remove(f'{tmp_file.name}.npy')
@@ -57,12 +54,11 @@ def test_dice_lose():
         exponent=3,
         reduction='sum',
         loss_weight=1.0,
-        ignore_index=0,
         loss_name='loss_dice')
     dice_loss = build_loss(loss_cfg)
     logits = torch.rand(8, 2, 4, 4)
     labels = (torch.rand(8, 4, 4) * 2).long()
-    dice_loss(logits, labels)
+    dice_loss(logits, labels, ignore_index=0)
 
     # test dice loss has name `loss_dice`
     loss_cfg = dict(
@@ -71,7 +67,6 @@ def test_dice_lose():
         exponent=3,
         reduction='sum',
         loss_weight=1.0,
-        ignore_index=0,
         loss_name='loss_dice')
     dice_loss = build_loss(loss_cfg)
     assert dice_loss.loss_name == 'loss_dice'

--- a/tests/test_models/test_losses/test_tversky_loss.py
+++ b/tests/test_models/test_losses/test_tversky_loss.py
@@ -53,7 +53,6 @@ def test_tversky_lose():
     loss_cfg = dict(
         type='TverskyLoss',
         smooth=2,
-        exponent=3,
         reduction='sum',
         loss_weight=1.0,
         ignore_index=0,
@@ -69,7 +68,6 @@ def test_tversky_lose():
     loss_cfg = dict(
         type='TverskyLoss',
         smooth=2,
-        exponent=3,
         reduction='sum',
         loss_weight=1.0,
         ignore_index=0,

--- a/tests/test_models/test_losses/test_tversky_loss.py
+++ b/tests/test_models/test_losses/test_tversky_loss.py
@@ -10,12 +10,11 @@ def test_tversky_lose():
         reduction='none',
         class_weight=[1.0, 2.0, 3.0],
         loss_weight=1.0,
-        ignore_index=1,
         loss_name='loss_tversky')
     tversky_loss = build_loss(loss_cfg)
     logits = torch.rand(8, 3, 4, 4)
     labels = (torch.rand(8, 4, 4) * 3).long()
-    tversky_loss(logits, labels)
+    tversky_loss(logits, labels, ignore_index=1)
 
     # test loss with class weights from file
     import os
@@ -30,10 +29,9 @@ def test_tversky_lose():
         reduction='none',
         class_weight=f'{tmp_file.name}.pkl',
         loss_weight=1.0,
-        ignore_index=1,
         loss_name='loss_tversky')
     tversky_loss = build_loss(loss_cfg)
-    tversky_loss(logits, labels, ignore_index=None)
+    tversky_loss(logits, labels, ignore_index=1)
 
     np.save(f'{tmp_file.name}.npy', np.array([1.0, 2.0, 3.0]))  # from npy file
     loss_cfg = dict(
@@ -41,10 +39,9 @@ def test_tversky_lose():
         reduction='none',
         class_weight=f'{tmp_file.name}.pkl',
         loss_weight=1.0,
-        ignore_index=1,
         loss_name='loss_tversky')
     tversky_loss = build_loss(loss_cfg)
-    tversky_loss(logits, labels, ignore_index=None)
+    tversky_loss(logits, labels, ignore_index=1)
     tmp_file.close()
     os.remove(f'{tmp_file.name}.pkl')
     os.remove(f'{tmp_file.name}.npy')
@@ -55,14 +52,13 @@ def test_tversky_lose():
         smooth=2,
         reduction='sum',
         loss_weight=1.0,
-        ignore_index=0,
         alpha=0.3,
         beta=0.7,
         loss_name='loss_tversky')
     tversky_loss = build_loss(loss_cfg)
     logits = torch.rand(8, 2, 4, 4)
     labels = (torch.rand(8, 4, 4) * 2).long()
-    tversky_loss(logits, labels)
+    tversky_loss(logits, labels, ignore_index=0)
 
     # test tversky loss has name `loss_tversky`
     loss_cfg = dict(
@@ -70,7 +66,6 @@ def test_tversky_lose():
         smooth=2,
         reduction='sum',
         loss_weight=1.0,
-        ignore_index=0,
         alpha=0.3,
         beta=0.7,
         loss_name='loss_tversky')

--- a/tests/test_models/test_losses/test_tversky_loss.py
+++ b/tests/test_models/test_losses/test_tversky_loss.py
@@ -1,0 +1,80 @@
+import torch
+
+
+def test_tversky_lose():
+    from mmseg.models import build_loss
+
+    # test tversky loss with loss_type = 'multi_class'
+    loss_cfg = dict(
+        type='TverskyLoss',
+        reduction='none',
+        class_weight=[1.0, 2.0, 3.0],
+        loss_weight=1.0,
+        ignore_index=1,
+        loss_name='loss_tversky')
+    tversky_loss = build_loss(loss_cfg)
+    logits = torch.rand(8, 3, 4, 4)
+    labels = (torch.rand(8, 4, 4) * 3).long()
+    tversky_loss(logits, labels)
+
+    # test loss with class weights from file
+    import os
+    import tempfile
+    import mmcv
+    import numpy as np
+    tmp_file = tempfile.NamedTemporaryFile()
+
+    mmcv.dump([1.0, 2.0, 3.0], f'{tmp_file.name}.pkl', 'pkl')  # from pkl file
+    loss_cfg = dict(
+        type='TverskyLoss',
+        reduction='none',
+        class_weight=f'{tmp_file.name}.pkl',
+        loss_weight=1.0,
+        ignore_index=1,
+        loss_name='loss_tversky')
+    tversky_loss = build_loss(loss_cfg)
+    tversky_loss(logits, labels, ignore_index=None)
+
+    np.save(f'{tmp_file.name}.npy', np.array([1.0, 2.0, 3.0]))  # from npy file
+    loss_cfg = dict(
+        type='TverskyLoss',
+        reduction='none',
+        class_weight=f'{tmp_file.name}.pkl',
+        loss_weight=1.0,
+        ignore_index=1,
+        loss_name='loss_tversky')
+    tversky_loss = build_loss(loss_cfg)
+    tversky_loss(logits, labels, ignore_index=None)
+    tmp_file.close()
+    os.remove(f'{tmp_file.name}.pkl')
+    os.remove(f'{tmp_file.name}.npy')
+
+    # test tversky loss with loss_type = 'binary'
+    loss_cfg = dict(
+        type='TverskyLoss',
+        smooth=2,
+        exponent=3,
+        reduction='sum',
+        loss_weight=1.0,
+        ignore_index=0,
+        alpha=0.3,
+        beta=0.7,
+        loss_name='loss_tversky')
+    tversky_loss = build_loss(loss_cfg)
+    logits = torch.rand(8, 2, 4, 4)
+    labels = (torch.rand(8, 4, 4) * 2).long()
+    tversky_loss(logits, labels)
+
+    # test tversky loss has name `loss_tversky`
+    loss_cfg = dict(
+        type='TverskyLoss',
+        smooth=2,
+        exponent=3,
+        reduction='sum',
+        loss_weight=1.0,
+        ignore_index=0,
+        alpha=0.3,
+        beta=0.7,
+        loss_name='loss_tversky')
+    tversky_loss = build_loss(loss_cfg)
+    assert tversky_loss.loss_name == 'loss_tversky'


### PR DESCRIPTION
## Motivation

Adding new loss function named `Tversky Loss`. https://arxiv.org/abs/1706.05721

Old PR: https://github.com/open-mmlab/mmsegmentation/pull/634

## Modification

Adding `loss_name` which may be useful for multi losses training.

Note: Not too much difference with original dice_loss.py, just adding weight on false positives and false negatives.

|    Datasets    | loss_ce (from [repo config](https://github.com/open-mmlab/mmsegmentation/tree/master/configs/unet)) | loss_ce + loss_tversky (1:1) | loss_ce + loss_tversky (1:3) | loss_tversky |
| ---------- | --- | --- | --- | --- |
| DRIVE |  <u> 78.67 </u> | 79.58 | 80.08 | **79.78** |
| STARE       |  81.02 | 81.97 | **82.74** | 82.36 |
| CHASE_DB1       |  80.24 | **80.36** | 80.1 | 77.49 |
| HRF       |  79.45 | **81.16** | 80.98 | 78.69 |
