### PR TITLE
[Fix] change BiSeNetV1 r50 no pretrained config

### DIFF
--- a/configs/bisenetv1/bisenetv1_r50-d32_4x4_1024x1024_160k_cityscapes.py
+++ b/configs/bisenetv1/bisenetv1_r50-d32_4x4_1024x1024_160k_cityscapes.py
@@ -11,11 +11,7 @@ model = dict(
         context_channels=(512, 1024, 2048),
         spatial_channels=(256, 256, 256, 512),
         out_channels=1024,
-        backbone_cfg=dict(
-            init_cfg=dict(
-                type='Pretrained', checkpoint='open-mmlab://resnet50_v1c'),
-            type='ResNet',
-            depth=50)),
+        backbone_cfg=dict(type='ResNet', depth=50)),
     decode_head=dict(
         type='FCNHead', in_channels=1024, in_index=0, channels=1024),
     auxiliary_head=[


### PR DESCRIPTION
This is a mistake of config caused by post processing of my experiments.

**But it's OK about numerical result.** 
(1) From log of bisenetv1_r50-d32_4x4_1024x1024_160k_cityscapes, **no `init_cfg` of backbone.**

[log of mIoU 76.92](https://github.com/open-mmlab/mmsegmentation/files/7315442/20210923_222639.log)

![image](https://user-images.githubusercontent.com/24582831/136655109-2611b0de-b366-4287-b7a0-c6ff26399425.png)




(2) From log of bisenetv1_r50-d32_in1k-pre_4x4_1024x1024_160k_cityscapes, **it has pretrained model.**
[log of mIoU 77.68](https://github.com/open-mmlab/mmsegmentation/files/7315443/20210917_234628.log)


![image](https://user-images.githubusercontent.com/24582831/136655201-57b15a14-6d12-4eb1-a292-10e337bc2abf.png)
