### PR TITLE
[Fix] Change `self.loss_decode` back to `dict` in Single Loss situation.

### DIFF
--- a/mmseg/core/seg/sampler/ohem_pixel_sampler.py
+++ b/mmseg/core/seg/sampler/ohem_pixel_sampler.py
@@ -63,8 +63,7 @@ class OHEMPixelSampler(BasePixelSampler):
                 threshold = max(min_threshold, self.thresh)
                 valid_seg_weight[seg_prob[valid_mask] < threshold] = 1.
             else:
-                if isinstance(self.context.loss_decode,
-                              nn.modules.container.ModuleList):
+                if isinstance(self.context.loss_decode, nn.ModuleList):
                     losses = 0.0
                     for loss_module in self.context.loss_decode:
                         losses += loss_module(

--- a/mmseg/core/seg/sampler/ohem_pixel_sampler.py
+++ b/mmseg/core/seg/sampler/ohem_pixel_sampler.py
@@ -63,17 +63,13 @@ class OHEMPixelSampler(BasePixelSampler):
                 threshold = max(min_threshold, self.thresh)
                 valid_seg_weight[seg_prob[valid_mask] < threshold] = 1.
             else:
-                if isinstance(self.context.loss_decode, nn.ModuleList):
-                    losses = 0.0
-                    for loss_module in self.context.loss_decode:
-                        losses += loss_module(
-                            seg_logit,
-                            seg_label,
-                            weight=None,
-                            ignore_index=self.context.ignore_index,
-                            reduction_override='none')
+                if not isinstance(self.context.loss_decode, nn.ModuleList):
+                    losses_decode = [self.context.loss_decode]
                 else:
-                    losses = self.context.loss_decode(
+                    losses_decode = self.context.loss_decode
+                losses = 0.0
+                for loss_module in losses_decode:
+                    losses += loss_module(
                         seg_logit,
                         seg_label,
                         weight=None,

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -243,7 +243,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             seg_weight = None
         seg_label = seg_label.squeeze(1)
 
-        if isinstance(self.loss_decode, nn.modules.container.ModuleList):
+        if isinstance(self.loss_decode, nn.ModuleList):
             for loss_decode in self.loss_decode:
                 if loss_decode.loss_name not in loss:
                     loss[loss_decode.loss_name] = loss_decode(

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -243,26 +243,23 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             seg_weight = None
         seg_label = seg_label.squeeze(1)
 
-        if isinstance(self.loss_decode, nn.ModuleList):
-            for loss_decode in self.loss_decode:
-                if loss_decode.loss_name not in loss:
-                    loss[loss_decode.loss_name] = loss_decode(
-                        seg_logit,
-                        seg_label,
-                        weight=seg_weight,
-                        ignore_index=self.ignore_index)
-                else:
-                    loss[loss_decode.loss_name] += loss_decode(
-                        seg_logit,
-                        seg_label,
-                        weight=seg_weight,
-                        ignore_index=self.ignore_index)
+        if not isinstance(self.loss_decode, nn.ModuleList):
+            losses_decode = [self.loss_decode]
         else:
-            loss[self.loss_decode.loss_name] = self.loss_decode(
-                seg_logit,
-                seg_label,
-                weight=seg_weight,
-                ignore_index=self.ignore_index)
+            losses_decode = self.loss_decode
+        for loss_decode in losses_decode:
+            if loss_decode.loss_name not in loss:
+                loss[loss_decode.loss_name] = loss_decode(
+                    seg_logit,
+                    seg_label,
+                    weight=seg_weight,
+                    ignore_index=self.ignore_index)
+            else:
+                loss[loss_decode.loss_name] += loss_decode(
+                    seg_logit,
+                    seg_label,
+                    weight=seg_weight,
+                    ignore_index=self.ignore_index)
 
         loss['acc_seg'] = accuracy(seg_logit, seg_label)
         return loss

--- a/mmseg/models/decode_heads/point_head.py
+++ b/mmseg/models/decode_heads/point_head.py
@@ -249,8 +249,12 @@ class PointHead(BaseCascadeDecodeHead):
     def losses(self, point_logits, point_label):
         """Compute segmentation loss."""
         loss = dict()
-        for loss_module in self.loss_decode:
-            loss['point' + loss_module.loss_name] = loss_module(
+        if isinstance(self.loss_decode, nn.modules.container.ModuleList):
+            for loss_module in self.loss_decode:
+                loss['point' + loss_module.loss_name] = loss_module(
+                    point_logits, point_label, ignore_index=self.ignore_index)
+        else:
+            loss['point' + self.loss_decode.loss_name] = self.loss_decode(
                 point_logits, point_label, ignore_index=self.ignore_index)
         loss['acc_point'] = accuracy(point_logits, point_label)
         return loss

--- a/mmseg/models/decode_heads/point_head.py
+++ b/mmseg/models/decode_heads/point_head.py
@@ -249,13 +249,14 @@ class PointHead(BaseCascadeDecodeHead):
     def losses(self, point_logits, point_label):
         """Compute segmentation loss."""
         loss = dict()
-        if isinstance(self.loss_decode, nn.ModuleList):
-            for loss_module in self.loss_decode:
-                loss['point' + loss_module.loss_name] = loss_module(
-                    point_logits, point_label, ignore_index=self.ignore_index)
+        if not isinstance(self.loss_decode, nn.ModuleList):
+            losses_decode = [self.loss_decode]
         else:
-            loss['point' + self.loss_decode.loss_name] = self.loss_decode(
+            losses_decode = self.loss_decode
+        for loss_module in losses_decode:
+            loss['point' + loss_module.loss_name] = loss_module(
                 point_logits, point_label, ignore_index=self.ignore_index)
+
         loss['acc_point'] = accuracy(point_logits, point_label)
         return loss
 

--- a/mmseg/models/decode_heads/point_head.py
+++ b/mmseg/models/decode_heads/point_head.py
@@ -249,7 +249,7 @@ class PointHead(BaseCascadeDecodeHead):
     def losses(self, point_logits, point_label):
         """Compute segmentation loss."""
         loss = dict()
-        if isinstance(self.loss_decode, nn.modules.container.ModuleList):
+        if isinstance(self.loss_decode, nn.ModuleList):
             for loss_module in self.loss_decode:
                 loss['point' + loss_module.loss_name] = loss_module(
                     point_logits, point_label, ignore_index=self.ignore_index)

--- a/tests/test_models/test_heads/test_point_head.py
+++ b/tests/test_models/test_heads/test_point_head.py
@@ -21,3 +21,34 @@ def test_point_head():
         subdivision_steps=2, subdivision_num_points=8196, scale_factor=2)
     output = point_head.forward_test(inputs, prev_output, None, test_cfg)
     assert output.shape == (1, point_head.num_classes, 180, 180)
+
+
+def test_point_head_multiple_loss():
+
+    inputs = [torch.randn(1, 32, 45, 45)]
+    point_head = PointHead(
+        in_channels=[32],
+        in_index=[0],
+        channels=16,
+        num_classes=19,
+        loss_decode=[
+            dict(type='CrossEntropyLoss', loss_name='loss_1'),
+            dict(type='CrossEntropyLoss', loss_name='loss_2')
+        ])
+    assert len(point_head.fcs) == 3
+    fcn_head = FCNHead(
+        in_channels=32,
+        channels=16,
+        num_classes=19,
+        loss_decode=[
+            dict(type='CrossEntropyLoss', loss_name='loss_1'),
+            dict(type='CrossEntropyLoss', loss_name='loss_2')
+        ])
+    if torch.cuda.is_available():
+        head, inputs = to_cuda(point_head, inputs)
+        head, inputs = to_cuda(fcn_head, inputs)
+    prev_output = fcn_head(inputs)
+    test_cfg = ConfigDict(
+        subdivision_steps=2, subdivision_num_points=8196, scale_factor=2)
+    output = point_head.forward_test(inputs, prev_output, None, test_cfg)
+    assert output.shape == (1, point_head.num_classes, 180, 180)

--- a/tests/test_models/test_heads/test_point_head.py
+++ b/tests/test_models/test_heads/test_point_head.py
@@ -54,6 +54,7 @@ def test_point_head_multiple_loss():
     assert output.shape == (1, point_head.num_classes, 180, 180)
 
     fake_label = torch.ones([1, 180, 180], dtype=torch.long)
+
     if torch.cuda.is_available():
         fake_label = fake_label.cuda()
     loss = point_head.losses(output, fake_label)

--- a/tests/test_models/test_heads/test_point_head.py
+++ b/tests/test_models/test_heads/test_point_head.py
@@ -52,3 +52,8 @@ def test_point_head_multiple_loss():
         subdivision_steps=2, subdivision_num_points=8196, scale_factor=2)
     output = point_head.forward_test(inputs, prev_output, None, test_cfg)
     assert output.shape == (1, point_head.num_classes, 180, 180)
+
+    fake_label = torch.ones([1, 180, 180], dtype=torch.long).cuda()
+    loss = point_head.losses(output, fake_label)
+    assert 'pointloss_1' in loss
+    assert 'pointloss_2' in loss

--- a/tests/test_models/test_heads/test_point_head.py
+++ b/tests/test_models/test_heads/test_point_head.py
@@ -53,7 +53,9 @@ def test_point_head_multiple_loss():
     output = point_head.forward_test(inputs, prev_output, None, test_cfg)
     assert output.shape == (1, point_head.num_classes, 180, 180)
 
-    fake_label = torch.ones([1, 180, 180], dtype=torch.long).cuda()
+    fake_label = torch.ones([1, 180, 180], dtype=torch.long)
+    if torch.cuda.is_available():
+        fake_label = fake_label.cuda()
     loss = point_head.losses(output, fake_label)
     assert 'pointloss_1' in loss
     assert 'pointloss_2' in loss

--- a/tests/test_models/test_heads/test_point_head.py
+++ b/tests/test_models/test_heads/test_point_head.py
@@ -22,11 +22,9 @@ def test_point_head():
     output = point_head.forward_test(inputs, prev_output, None, test_cfg)
     assert output.shape == (1, point_head.num_classes, 180, 180)
 
-
-def test_point_head_multiple_loss():
-
+    # test multiple losses case
     inputs = [torch.randn(1, 32, 45, 45)]
-    point_head = PointHead(
+    point_head_multiple_losses = PointHead(
         in_channels=[32],
         in_index=[0],
         channels=16,
@@ -35,8 +33,8 @@ def test_point_head_multiple_loss():
             dict(type='CrossEntropyLoss', loss_name='loss_1'),
             dict(type='CrossEntropyLoss', loss_name='loss_2')
         ])
-    assert len(point_head.fcs) == 3
-    fcn_head = FCNHead(
+    assert len(point_head_multiple_losses.fcs) == 3
+    fcn_head_multiple_losses = FCNHead(
         in_channels=32,
         channels=16,
         num_classes=19,
@@ -45,18 +43,19 @@ def test_point_head_multiple_loss():
             dict(type='CrossEntropyLoss', loss_name='loss_2')
         ])
     if torch.cuda.is_available():
-        head, inputs = to_cuda(point_head, inputs)
-        head, inputs = to_cuda(fcn_head, inputs)
-    prev_output = fcn_head(inputs)
+        head, inputs = to_cuda(point_head_multiple_losses, inputs)
+        head, inputs = to_cuda(fcn_head_multiple_losses, inputs)
+    prev_output = fcn_head_multiple_losses(inputs)
     test_cfg = ConfigDict(
         subdivision_steps=2, subdivision_num_points=8196, scale_factor=2)
-    output = point_head.forward_test(inputs, prev_output, None, test_cfg)
+    output = point_head_multiple_losses.forward_test(inputs, prev_output, None,
+                                                     test_cfg)
     assert output.shape == (1, point_head.num_classes, 180, 180)
 
     fake_label = torch.ones([1, 180, 180], dtype=torch.long)
 
     if torch.cuda.is_available():
         fake_label = fake_label.cuda()
-    loss = point_head.losses(output, fake_label)
+    loss = point_head_multiple_losses.losses(output, fake_label)
     assert 'pointloss_1' in loss
     assert 'pointloss_2' in loss

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -10,6 +10,17 @@ def _context_for_ohem():
     return FCNHead(in_channels=32, channels=16, num_classes=19)
 
 
+def _context_for_ohem_multiple_loss():
+    return FCNHead(
+        in_channels=32,
+        channels=16,
+        num_classes=19,
+        loss_decode=[
+            dict(type='CrossEntropyLoss', loss_name='loss_1'),
+            dict(type='CrossEntropyLoss', loss_name='loss_2')
+        ])
+
+
 def test_ohem_sampler():
 
     with pytest.raises(AssertionError):
@@ -31,6 +42,35 @@ def test_ohem_sampler():
 
     # test w.o thresh
     sampler = OHEMPixelSampler(context=_context_for_ohem(), min_kept=200)
+    seg_logit = torch.randn(1, 19, 45, 45)
+    seg_label = torch.randint(0, 19, size=(1, 1, 45, 45))
+    seg_weight = sampler.sample(seg_logit, seg_label)
+    assert seg_weight.shape[0] == seg_logit.shape[0]
+    assert seg_weight.shape[1:] == seg_logit.shape[2:]
+    assert seg_weight.sum() == 200
+
+
+def test_ohem_sampler_multiple_loss():
+    with pytest.raises(AssertionError):
+        # seg_logit and seg_label must be of the same size
+        sampler = OHEMPixelSampler(context=_context_for_ohem_multiple_loss())
+        seg_logit = torch.randn(1, 19, 45, 45)
+        seg_label = torch.randint(0, 19, size=(1, 1, 89, 89))
+        sampler.sample(seg_logit, seg_label)
+
+    # test with thresh
+    sampler = OHEMPixelSampler(
+        context=_context_for_ohem_multiple_loss(), thresh=0.7, min_kept=200)
+    seg_logit = torch.randn(1, 19, 45, 45)
+    seg_label = torch.randint(0, 19, size=(1, 1, 45, 45))
+    seg_weight = sampler.sample(seg_logit, seg_label)
+    assert seg_weight.shape[0] == seg_logit.shape[0]
+    assert seg_weight.shape[1:] == seg_logit.shape[2:]
+    assert seg_weight.sum() > 200
+
+    # test w.o thresh
+    sampler = OHEMPixelSampler(
+        context=_context_for_ohem_multiple_loss(), min_kept=200)
     seg_logit = torch.randn(1, 19, 45, 45)
     seg_label = torch.randint(0, 19, size=(1, 1, 45, 45))
     seg_weight = sampler.sample(seg_logit, seg_label)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -49,8 +49,7 @@ def test_ohem_sampler():
     assert seg_weight.shape[1:] == seg_logit.shape[2:]
     assert seg_weight.sum() == 200
 
-
-def test_ohem_sampler_multiple_loss():
+    # test multiple losses case
     with pytest.raises(AssertionError):
         # seg_logit and seg_label must be of the same size
         sampler = OHEMPixelSampler(context=_context_for_ohem_multiple_loss())
@@ -58,7 +57,7 @@ def test_ohem_sampler_multiple_loss():
         seg_label = torch.randint(0, 19, size=(1, 1, 89, 89))
         sampler.sample(seg_logit, seg_label)
 
-    # test with thresh
+    # test with thresh in multiple losses case
     sampler = OHEMPixelSampler(
         context=_context_for_ohem_multiple_loss(), thresh=0.7, min_kept=200)
     seg_logit = torch.randn(1, 19, 45, 45)
@@ -68,7 +67,7 @@ def test_ohem_sampler_multiple_loss():
     assert seg_weight.shape[1:] == seg_logit.shape[2:]
     assert seg_weight.sum() > 200
 
-    # test w.o thresh
+    # test w.o thresh in multiple losses case
     sampler = OHEMPixelSampler(
         context=_context_for_ohem_multiple_loss(), min_kept=200)
     seg_logit = torch.randn(1, 19, 45, 45)


### PR DESCRIPTION
In previous version of MMSegmentation, the `loss_decode` is a dict.

When using multiple losses pipeline, it is changed to `nn.ModuleList()` where each loss would be appended. It would raise BC-Breaking problem.

Thus, we change it back to dict of single loss situation.