### PR TITLE
[Fix] Fix Dice Metric in `.yml` file

### DIFF
--- a/.dev/md2yml.py
+++ b/.dev/md2yml.py
@@ -176,7 +176,7 @@ def parse_md(md_file):
                                 'Task': 'Semantic Segmentation',
                                 'Dataset': current_dataset,
                                 'Metrics': {
-                                    'mIoU': float(els[ss_id]),
+                                    cols[ss_id]: float(els[ss_id]),
                                 },
                             },
                         ],

--- a/configs/unet/unet.yml
+++ b/configs/unet/unet.yml
@@ -27,7 +27,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: DRIVE
     Metrics:
-      mIoU: 78.67
+      Dice: 78.67
   Config: configs/unet/fcn_unet_s5-d16_64x64_40k_drive.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/fcn_unet_s5-d16_64x64_40k_drive/fcn_unet_s5-d16_64x64_40k_drive_20201223_191051-5daf6d3b.pth
 - Name: pspnet_unet_s5-d16_64x64_40k_drive
@@ -41,7 +41,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: DRIVE
     Metrics:
-      mIoU: 78.62
+      Dice: 78.62
   Config: configs/unet/pspnet_unet_s5-d16_64x64_40k_drive.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_64x64_40k_drive/pspnet_unet_s5-d16_64x64_40k_drive_20201227_181818-aac73387.pth
 - Name: deeplabv3_unet_s5-d16_64x64_40k_drive
@@ -55,7 +55,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: DRIVE
     Metrics:
-      mIoU: 78.69
+      Dice: 78.69
   Config: configs/unet/deeplabv3_unet_s5-d16_64x64_40k_drive.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_64x64_40k_drive/deeplabv3_unet_s5-d16_64x64_40k_drive_20201226_094047-0671ff20.pth
 - Name: fcn_unet_s5-d16_128x128_40k_stare
@@ -69,7 +69,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: STARE
     Metrics:
-      mIoU: 81.02
+      Dice: 81.02
   Config: configs/unet/fcn_unet_s5-d16_128x128_40k_stare.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/fcn_unet_s5-d16_128x128_40k_stare/fcn_unet_s5-d16_128x128_40k_stare_20201223_191051-7d77e78b.pth
 - Name: pspnet_unet_s5-d16_128x128_40k_stare
@@ -83,7 +83,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: STARE
     Metrics:
-      mIoU: 81.22
+      Dice: 81.22
   Config: configs/unet/pspnet_unet_s5-d16_128x128_40k_stare.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_128x128_40k_stare/pspnet_unet_s5-d16_128x128_40k_stare_20201227_181818-3c2923c4.pth
 - Name: deeplabv3_unet_s5-d16_128x128_40k_stare
@@ -97,7 +97,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: STARE
     Metrics:
-      mIoU: 80.93
+      Dice: 80.93
   Config: configs/unet/deeplabv3_unet_s5-d16_128x128_40k_stare.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_128x128_40k_stare/deeplabv3_unet_s5-d16_128x128_40k_stare_20201226_094047-93dcb93c.pth
 - Name: fcn_unet_s5-d16_128x128_40k_chase_db1
@@ -111,7 +111,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: CHASE_DB1
     Metrics:
-      mIoU: 80.24
+      Dice: 80.24
   Config: configs/unet/fcn_unet_s5-d16_128x128_40k_chase_db1.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/fcn_unet_s5-d16_128x128_40k_chase_db1/fcn_unet_s5-d16_128x128_40k_chase_db1_20201223_191051-11543527.pth
 - Name: pspnet_unet_s5-d16_128x128_40k_chase_db1
@@ -125,7 +125,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: CHASE_DB1
     Metrics:
-      mIoU: 80.36
+      Dice: 80.36
   Config: configs/unet/pspnet_unet_s5-d16_128x128_40k_chase_db1.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_128x128_40k_chase_db1/pspnet_unet_s5-d16_128x128_40k_chase_db1_20201227_181818-68d4e609.pth
 - Name: deeplabv3_unet_s5-d16_128x128_40k_chase_db1
@@ -139,7 +139,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: CHASE_DB1
     Metrics:
-      mIoU: 80.47
+      Dice: 80.47
   Config: configs/unet/deeplabv3_unet_s5-d16_128x128_40k_chase_db1.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_128x128_40k_chase_db1/deeplabv3_unet_s5-d16_128x128_40k_chase_db1_20201226_094047-4c5aefa3.pth
 - Name: fcn_unet_s5-d16_256x256_40k_hrf
@@ -153,7 +153,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: HRF
     Metrics:
-      mIoU: 79.45
+      Dice: 79.45
   Config: configs/unet/fcn_unet_s5-d16_256x256_40k_hrf.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/fcn_unet_s5-d16_256x256_40k_hrf/fcn_unet_s5-d16_256x256_40k_hrf_20201223_173724-d89cf1ed.pth
 - Name: pspnet_unet_s5-d16_256x256_40k_hrf
@@ -167,7 +167,7 @@ Models:
   - Task: Semantic Segmentation
     Dataset: HRF
     Metrics:
-      mIoU: 80.07
+      Dice: 80.07
   Config: configs/unet/pspnet_unet_s5-d16_256x256_40k_hrf.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/pspnet_unet_s5-d16_256x256_40k_hrf/pspnet_unet_s5-d16_256x256_40k_hrf_20201227_181818-fdb7e29b.pth
 - Name: deeplabv3_unet_s5-d16_256x256_40k_hrf
@@ -181,6 +181,6 @@ Models:
   - Task: Semantic Segmentation
     Dataset: HRF
     Metrics:
-      mIoU: 80.21
+      Dice: 80.21
   Config: configs/unet/deeplabv3_unet_s5-d16_256x256_40k_hrf.py
   Weights: https://download.openmmlab.com/mmsegmentation/v0.5/unet/deeplabv3_unet_s5-d16_256x256_40k_hrf/deeplabv3_unet_s5-d16_256x256_40k_hrf_20201226_094047-3a1fdf85.pth


### PR DESCRIPTION
In the past, the metric in yml is usually `mIoU`, where some metric such as `Dice` in UNet is wrong.