### PR TITLE
fix typo in datasets/custom.py

### DIFF
--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -364,7 +364,7 @@ class CustomDataset(Dataset):
         """Evaluate the dataset.
 
         Args:
-            results (list[tuple[torch.Tensor]] | list[str]): per image pre_eval
+            results (list[list[torch.Tensor]] | list[str]): per image pre_eval
                  results or predict segmentation map for computing evaluation
                  metric.
             metric (str | list[str]): Metrics to be evaluated. 'mIoU',


### PR DESCRIPTION
## Motivation

fix typo in datasets/custom.py.

## Modification

Change the docs about `results` from `list[tuple[torch.Tensor]` to `list[list[torch.Tensor]`

The reason why it is `list[list[torch.Tensor]`, not `list[tuple[torch.Tensor]` is listed as follows in parts of Chinese:

看一下脱水的 `single_gpu_test` 代码:

```Python
results = []
for batch_indices, data in zip(loader_indices, data_loader):
    with torch.no_grad():
        result = model(return_loss=False, **data)
    result = dataset.pre_eval(result, indices=batch_indices)
    results.extend(result)
```

也就是说 `dataset.pre_eval` 返回的 `result` 是 `tuple[torch.Tensor]`. 不过我们先来看下 `model` 返回的结果.

对于 mmseg 来说, model 就是 `EncoderDecoder` 了, 在 validation 的时候, `model(・)` 其实就是 `EncoderDecoder.forward_test(・)`.

```Mermaid
flowchart TD
%%{init: {'theme': 'base', 'themeVariables': { 'fontSize': '13px', 'fontFamily': 'Monaco'}}}%%

single_gpu_test --> EncoderDecoder.forward --> EncoderDecoder.forward_test --> EncoderDecoder.simple_test --> EncoderDecoder.inference --> EncoderDecoder.whole_inference --> EncoderDecoder.encode_decode --> EncoderDecoder._decode_head_forward_test
```

虽然如上图所示, `forward_test` 的调用链条很长, 但其实返回的 `result` 就是 `simple_test` 的返回结果. 而 `simple_test` 的代码如下

```Python
def simple_test(self, img, img_meta, rescale=True):
    seg_logit = self.inference(img, img_meta, rescale)
    seg_pred = seg_logit.argmax(dim=1)
    seg_pred = seg_pred.cpu().numpy()
    # unravel batch dim
    seg_pred = list(seg_pred)
    return seg_pred
```

- `seg_logit` 是 `(N, C, H, W)` 的 Tensor
- `seg_logit.argmax(dim=1)` 得到的 `seg_pred` 是 `(N, H, W)` 的 Tensor;
- 经过 `seg_pred = list(seg_pred)` 得到的 `seg_pred` 是 `list[np.ndarray]`.

因此, `model(・)` 也就是 `EncoderDecoder.forward_test(・)` 返回的 `result` 是 `list[np.ndarray]`. 接下来要看一下 `dataset.pre_eval` 的代码.

- `pre_eval` 这个函数的功能本身就是 Collect eval result from each iteration. 从下面的代码可以看到, 返回的 `pre_eval_results` 还是一个 `list[torch.Tensor]`.
- 注意, `intersect_and_union` 这个函数会将 np.ndarray 的输入变为 torch.Tensor 再计算, 所以返回的结果是 torch.Tensor, 因此, 返回的 `pre_eval_results` 就是 `list[torch.Tensor]`.

```Python
def pre_eval(self, preds, indices):
    pre_eval_results = []

    for pred, index in zip(preds, indices):
        seg_map = self.get_gt_seg_map_by_idx(index)
        pre_eval_results.append(
            intersect_and_union(pred, seg_map, len(self.CLASSES),
                                self.ignore_index, self.label_map,
                                self.reduce_zero_label))

    return pre_eval_results
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?

No. It is only a modification to the comments.

