### PR TITLE
[Fix] Change key name `memory (GB)` to `Training Memory (GB)` in metafile.

### DIFF
--- a/.dev/md2yml.py
+++ b/.dev/md2yml.py
@@ -206,7 +206,7 @@ def parse_md(md_file):
                             f'({crop_size[0]},{crop_size[1]})'
                         }]
                     if mem != -1:
-                        model['Metadata']['memory (GB)'] = float(mem)
+                        model['Metadata']['Training Memory (GB)'] = float(mem)
                     # Only have semantic segmentation now
                     if ms_id and els[ms_id] != '-' and els[ms_id] != '':
                         model['Results'][0]['Metrics'][

--- a/configs/ann/ann.yml
+++ b/configs/ann/ann.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.0
+    Training Memory (GB): 6.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -50,7 +50,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.5
+    Training Memory (GB): 9.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.8
+    Training Memory (GB): 6.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.7
+    Training Memory (GB): 10.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -172,7 +172,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.1
+    Training Memory (GB): 9.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -194,7 +194,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.5
+    Training Memory (GB): 12.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -244,7 +244,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.0
+    Training Memory (GB): 6.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -266,7 +266,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.5
+    Training Memory (GB): 9.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/apcnet/apcnet.yml
+++ b/configs/apcnet/apcnet.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.7
+    Training Memory (GB): 7.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 11.2
+    Training Memory (GB): 11.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -71,7 +71,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 8.7
+    Training Memory (GB): 8.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -93,7 +93,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 12.7
+    Training Memory (GB): 12.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -171,7 +171,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 10.1
+    Training Memory (GB): 10.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -193,7 +193,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 13.6
+    Training Memory (GB): 13.6
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/bisenetv1/bisenetv1.yml
+++ b/configs/bisenetv1/bisenetv1.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (1024,1024)
-    memory (GB): 5.69
+    Training Memory (GB): 5.69
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (1024,1024)
-    memory (GB): 5.69
+    Training Memory (GB): 5.69
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -71,7 +71,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (1024,1024)
-    memory (GB): 11.17
+    Training Memory (GB): 11.17
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -93,7 +93,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (1024,1024)
-    memory (GB): 15.39
+    Training Memory (GB): 15.39
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -115,7 +115,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (1024,1024)
-    memory (GB): 15.39
+    Training Memory (GB): 15.39
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -151,7 +151,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.33
+    Training Memory (GB): 6.33
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 164k
@@ -187,7 +187,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.28
+    Training Memory (GB): 9.28
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 164k
@@ -223,7 +223,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 10.36
+    Training Memory (GB): 10.36
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 164k

--- a/configs/bisenetv2/bisenetv2.yml
+++ b/configs/bisenetv2/bisenetv2.yml
@@ -25,7 +25,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (1024,1024)
-    memory (GB): 7.64
+    Training Memory (GB): 7.64
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -40,7 +40,7 @@ Models:
     backbone: BiSeNetV2
     crop size: (1024,1024)
     lr schd: 160000
-    memory (GB): 7.64
+    Training Memory (GB): 7.64
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -55,7 +55,7 @@ Models:
     backbone: BiSeNetV2
     crop size: (1024,1024)
     lr schd: 160000
-    memory (GB): 15.05
+    Training Memory (GB): 15.05
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -77,7 +77,7 @@ Models:
       batch size: 1
       mode: FP16
       resolution: (1024,1024)
-    memory (GB): 5.77
+    Training Memory (GB): 5.77
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes

--- a/configs/ccnet/ccnet.yml
+++ b/configs/ccnet/ccnet.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.0
+    Training Memory (GB): 6.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -50,7 +50,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.5
+    Training Memory (GB): 9.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.8
+    Training Memory (GB): 6.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.7
+    Training Memory (GB): 10.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -172,7 +172,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.8
+    Training Memory (GB): 8.8
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -194,7 +194,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.2
+    Training Memory (GB): 12.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -244,7 +244,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.0
+    Training Memory (GB): 6.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -266,7 +266,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.5
+    Training Memory (GB): 9.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/cgnet/cgnet.yml
+++ b/configs/cgnet/cgnet.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (680,680)
-    memory (GB): 7.5
+    Training Memory (GB): 7.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.3
+    Training Memory (GB): 8.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes

--- a/configs/danet/danet.yml
+++ b/configs/danet/danet.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.4
+    Training Memory (GB): 7.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 10.9
+    Training Memory (GB): 10.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -70,7 +70,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 8.8
+    Training Memory (GB): 8.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -92,7 +92,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 12.8
+    Training Memory (GB): 12.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -168,7 +168,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 11.5
+    Training Memory (GB): 11.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -190,7 +190,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 15.0
+    Training Memory (GB): 15.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -240,7 +240,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.5
+    Training Memory (GB): 6.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -262,7 +262,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.9
+    Training Memory (GB): 9.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/deeplabv3/deeplabv3.yml
+++ b/configs/deeplabv3/deeplabv3.yml
@@ -32,7 +32,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.1
+    Training Memory (GB): 6.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -54,7 +54,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -76,7 +76,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.9
+    Training Memory (GB): 6.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -98,7 +98,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.9
+    Training Memory (GB): 10.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -120,7 +120,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 1.7
+    Training Memory (GB): 1.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -170,7 +170,7 @@ Models:
       batch size: 1
       mode: FP16
       resolution: (512,1024)
-    memory (GB): 5.75
+    Training Memory (GB): 5.75
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -191,7 +191,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 1.9
+    Training Memory (GB): 1.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -255,7 +255,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 1.6
+    Training Memory (GB): 1.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -277,7 +277,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.0
+    Training Memory (GB): 6.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -299,7 +299,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.5
+    Training Memory (GB): 9.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -321,7 +321,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 1.8
+    Training Memory (GB): 1.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -343,7 +343,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.8
+    Training Memory (GB): 6.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -365,7 +365,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.7
+    Training Memory (GB): 10.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -387,7 +387,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.9
+    Training Memory (GB): 8.9
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -409,7 +409,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.4
+    Training Memory (GB): 12.4
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -459,7 +459,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.1
+    Training Memory (GB): 6.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -481,7 +481,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -531,7 +531,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (480,480)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal Context
@@ -595,7 +595,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 10k
@@ -617,7 +617,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 13.2
+    Training Memory (GB): 13.2
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 10k
@@ -667,7 +667,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 164k
@@ -689,7 +689,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 13.2
+    Training Memory (GB): 13.2
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 164k

--- a/configs/deeplabv3plus/deeplabv3plus.yml
+++ b/configs/deeplabv3plus/deeplabv3plus.yml
@@ -31,7 +31,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.5
+    Training Memory (GB): 7.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 11.0
+    Training Memory (GB): 11.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -75,7 +75,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 8.5
+    Training Memory (GB): 8.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -97,7 +97,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 12.5
+    Training Memory (GB): 12.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -119,7 +119,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 2.2
+    Training Memory (GB): 2.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -169,7 +169,7 @@ Models:
       batch size: 1
       mode: FP16
       resolution: (512,1024)
-    memory (GB): 6.35
+    Training Memory (GB): 6.35
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -190,7 +190,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 2.5
+    Training Memory (GB): 2.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -240,7 +240,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.8
+    Training Memory (GB): 5.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -255,7 +255,7 @@ Models:
     backbone: R-101-D16-MG124
     crop size: (512,1024)
     lr schd: 80000
-    memory (GB): 9.9
+    Training Memory (GB): 9.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -277,7 +277,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 2.1
+    Training Memory (GB): 2.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -299,7 +299,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.4
+    Training Memory (GB): 7.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -321,7 +321,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 10.9
+    Training Memory (GB): 10.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -343,7 +343,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 2.4
+    Training Memory (GB): 2.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -365,7 +365,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 8.4
+    Training Memory (GB): 8.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -387,7 +387,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 12.3
+    Training Memory (GB): 12.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -409,7 +409,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 10.6
+    Training Memory (GB): 10.6
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -431,7 +431,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 14.1
+    Training Memory (GB): 14.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -481,7 +481,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.6
+    Training Memory (GB): 7.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -503,7 +503,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 11.0
+    Training Memory (GB): 11.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -616,7 +616,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 1.93
+    Training Memory (GB): 1.93
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA
@@ -638,7 +638,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.37
+    Training Memory (GB): 7.37
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA
@@ -660,7 +660,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 10.84
+    Training Memory (GB): 10.84
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA

--- a/configs/dmnet/dmnet.yml
+++ b/configs/dmnet/dmnet.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.0
+    Training Memory (GB): 7.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 10.6
+    Training Memory (GB): 10.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -71,7 +71,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 7.9
+    Training Memory (GB): 7.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -93,7 +93,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 12.0
+    Training Memory (GB): 12.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -171,7 +171,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.4
+    Training Memory (GB): 9.4
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -193,7 +193,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 13.0
+    Training Memory (GB): 13.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/dnlnet/dnlnet.yml
+++ b/configs/dnlnet/dnlnet.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.3
+    Training Memory (GB): 7.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 10.9
+    Training Memory (GB): 10.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -69,7 +69,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -91,7 +91,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 12.6
+    Training Memory (GB): 12.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -167,7 +167,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.8
+    Training Memory (GB): 8.8
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -189,7 +189,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.8
+    Training Memory (GB): 12.8
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/dpt/dpt.yml
+++ b/configs/dpt/dpt.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.09
+    Training Memory (GB): 8.09
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/emanet/emanet.yml
+++ b/configs/emanet/emanet.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.4
+    Training Memory (GB): 5.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.2
+    Training Memory (GB): 6.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -70,7 +70,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 8.9
+    Training Memory (GB): 8.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -92,7 +92,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.1
+    Training Memory (GB): 10.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes

--- a/configs/encnet/encnet.yml
+++ b/configs/encnet/encnet.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.6
+    Training Memory (GB): 8.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 12.1
+    Training Memory (GB): 12.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -71,7 +71,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 9.8
+    Training Memory (GB): 9.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -93,7 +93,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 13.7
+    Training Memory (GB): 13.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -171,7 +171,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 10.1
+    Training Memory (GB): 10.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -193,7 +193,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 13.6
+    Training Memory (GB): 13.6
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/fastfcn/fastfcn.yml
+++ b/configs/fastfcn/fastfcn.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.67
+    Training Memory (GB): 5.67
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -42,7 +42,7 @@ Models:
     backbone: R-50-D32
     crop size: (512,1024)
     lr schd: 80000
-    memory (GB): 9.79
+    Training Memory (GB): 9.79
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -64,7 +64,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.67
+    Training Memory (GB): 5.67
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -79,7 +79,7 @@ Models:
     backbone: R-50-D32
     crop size: (512,1024)
     lr schd: 80000
-    memory (GB): 9.94
+    Training Memory (GB): 9.94
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -101,7 +101,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.15
+    Training Memory (GB): 8.15
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -116,7 +116,7 @@ Models:
     backbone: R-50-D32
     crop size: (512,1024)
     lr schd: 80000
-    memory (GB): 15.45
+    Training Memory (GB): 15.45
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -138,7 +138,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.46
+    Training Memory (GB): 8.46
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -174,7 +174,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.02
+    Training Memory (GB): 8.02
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -210,7 +210,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.67
+    Training Memory (GB): 9.67
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/fastscnn/fastscnn.yml
+++ b/configs/fastscnn/fastscnn.yml
@@ -24,7 +24,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.3
+    Training Memory (GB): 3.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes

--- a/configs/fcn/fcn.yml
+++ b/configs/fcn/fcn.yml
@@ -30,7 +30,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.7
+    Training Memory (GB): 5.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -52,7 +52,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -74,7 +74,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.5
+    Training Memory (GB): 6.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -96,7 +96,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.4
+    Training Memory (GB): 10.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -118,7 +118,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 1.7
+    Training Memory (GB): 1.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -168,7 +168,7 @@ Models:
       batch size: 1
       mode: FP16
       resolution: (512,1024)
-    memory (GB): 5.37
+    Training Memory (GB): 5.37
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -189,7 +189,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 1.9
+    Training Memory (GB): 1.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -239,7 +239,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 1.6
+    Training Memory (GB): 1.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -261,7 +261,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.6
+    Training Memory (GB): 5.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -283,7 +283,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.1
+    Training Memory (GB): 9.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -305,7 +305,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 1.7
+    Training Memory (GB): 1.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -327,7 +327,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.3
+    Training Memory (GB): 6.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -349,7 +349,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.3
+    Training Memory (GB): 10.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -371,7 +371,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.4
+    Training Memory (GB): 3.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -414,7 +414,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 3.7
+    Training Memory (GB): 3.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -457,7 +457,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 4.5
+    Training Memory (GB): 4.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -500,7 +500,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 5.0
+    Training Memory (GB): 5.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -543,7 +543,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.2
+    Training Memory (GB): 3.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -565,7 +565,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 3.6
+    Training Memory (GB): 3.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -587,7 +587,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 4.3
+    Training Memory (GB): 4.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -609,7 +609,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 4.8
+    Training Memory (GB): 4.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -631,7 +631,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.5
+    Training Memory (GB): 8.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -653,7 +653,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.0
+    Training Memory (GB): 12.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -703,7 +703,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.7
+    Training Memory (GB): 5.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -725,7 +725,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/gcnet/gcnet.yml
+++ b/configs/gcnet/gcnet.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.8
+    Training Memory (GB): 5.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -50,7 +50,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.5
+    Training Memory (GB): 6.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.5
+    Training Memory (GB): 10.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -172,7 +172,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.5
+    Training Memory (GB): 8.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -194,7 +194,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.0
+    Training Memory (GB): 12.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -244,7 +244,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.8
+    Training Memory (GB): 5.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -266,7 +266,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/hrnet/hrnet.yml
+++ b/configs/hrnet/hrnet.yml
@@ -31,7 +31,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 1.7
+    Training Memory (GB): 1.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -53,7 +53,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 2.9
+    Training Memory (GB): 2.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -75,7 +75,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.2
+    Training Memory (GB): 6.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -181,7 +181,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 3.8
+    Training Memory (GB): 3.8
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -203,7 +203,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 4.9
+    Training Memory (GB): 4.9
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -225,7 +225,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.2
+    Training Memory (GB): 8.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -289,7 +289,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 1.8
+    Training Memory (GB): 1.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -311,7 +311,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 2.9
+    Training Memory (GB): 2.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -333,7 +333,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.2
+    Training Memory (GB): 6.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -397,7 +397,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (480,480)
-    memory (GB): 6.1
+    Training Memory (GB): 6.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal Context
@@ -461,7 +461,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 1.72
+    Training Memory (GB): 1.72
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA
@@ -483,7 +483,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 2.9
+    Training Memory (GB): 2.9
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA
@@ -505,7 +505,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.25
+    Training Memory (GB): 6.25
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA

--- a/configs/icnet/icnet.yml
+++ b/configs/icnet/icnet.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (832,832)
-    memory (GB): 1.7
+    Training Memory (GB): 1.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -90,7 +90,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (832,832)
-    memory (GB): 2.53
+    Training Memory (GB): 2.53
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -154,7 +154,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (832,832)
-    memory (GB): 3.08
+    Training Memory (GB): 3.08
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes

--- a/configs/isanet/isanet.yml
+++ b/configs/isanet/isanet.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.869
+    Training Memory (GB): 5.869
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -50,7 +50,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.869
+    Training Memory (GB): 5.869
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.759
+    Training Memory (GB): 6.759
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.759
+    Training Memory (GB): 6.759
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -116,7 +116,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.425
+    Training Memory (GB): 9.425
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -138,7 +138,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.425
+    Training Memory (GB): 9.425
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -160,7 +160,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.815
+    Training Memory (GB): 10.815
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -182,7 +182,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.815
+    Training Memory (GB): 10.815
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -204,7 +204,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.0
+    Training Memory (GB): 9.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -226,7 +226,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.0
+    Training Memory (GB): 9.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -248,7 +248,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.562
+    Training Memory (GB): 12.562
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -270,7 +270,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.562
+    Training Memory (GB): 12.562
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -292,7 +292,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.9
+    Training Memory (GB): 5.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -314,7 +314,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.9
+    Training Memory (GB): 5.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -336,7 +336,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.465
+    Training Memory (GB): 9.465
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -358,7 +358,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.465
+    Training Memory (GB): 9.465
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/mobilenet_v2/mobilenet_v2.yml
+++ b/configs/mobilenet_v2/mobilenet_v2.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.4
+    Training Memory (GB): 3.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.6
+    Training Memory (GB): 3.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -69,7 +69,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.9
+    Training Memory (GB): 3.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -90,7 +90,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.1
+    Training Memory (GB): 5.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -111,7 +111,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.5
+    Training Memory (GB): 6.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -132,7 +132,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.5
+    Training Memory (GB): 6.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -153,7 +153,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.8
+    Training Memory (GB): 6.8
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -174,7 +174,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.2
+    Training Memory (GB): 8.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k

--- a/configs/mobilenet_v3/mobilenet_v3.yml
+++ b/configs/mobilenet_v3/mobilenet_v3.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.9
+    Training Memory (GB): 8.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.9
+    Training Memory (GB): 8.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -70,7 +70,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.3
+    Training Memory (GB): 5.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -92,7 +92,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 5.3
+    Training Memory (GB): 5.3
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes

--- a/configs/nonlocal_net/nonlocal_net.yml
+++ b/configs/nonlocal_net/nonlocal_net.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.4
+    Training Memory (GB): 7.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 10.9
+    Training Memory (GB): 10.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -70,7 +70,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 8.9
+    Training Memory (GB): 8.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -92,7 +92,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 12.8
+    Training Memory (GB): 12.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -168,7 +168,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.1
+    Training Memory (GB): 9.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -190,7 +190,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.6
+    Training Memory (GB): 12.6
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -240,7 +240,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.4
+    Training Memory (GB): 6.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -262,7 +262,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.8
+    Training Memory (GB): 9.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/ocrnet/ocrnet.yml
+++ b/configs/ocrnet/ocrnet.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.5
+    Training Memory (GB): 3.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -50,7 +50,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 4.7
+    Training Memory (GB): 4.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.0
+    Training Memory (GB): 8.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -191,7 +191,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.8
+    Training Memory (GB): 8.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -212,7 +212,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 8.8
+    Training Memory (GB): 8.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -233,7 +233,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.7
+    Training Memory (GB): 6.7
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -255,7 +255,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.9
+    Training Memory (GB): 7.9
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -277,7 +277,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 11.2
+    Training Memory (GB): 11.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -341,7 +341,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 3.5
+    Training Memory (GB): 3.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -363,7 +363,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 4.7
+    Training Memory (GB): 4.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -385,7 +385,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.1
+    Training Memory (GB): 8.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/point_rend/point_rend.yml
+++ b/configs/point_rend/point_rend.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.1
+    Training Memory (GB): 3.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 4.2
+    Training Memory (GB): 4.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -71,7 +71,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.1
+    Training Memory (GB): 5.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -93,7 +93,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.1
+    Training Memory (GB): 6.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/psanet/psanet.yml
+++ b/configs/psanet/psanet.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.0
+    Training Memory (GB): 7.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -50,7 +50,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 10.5
+    Training Memory (GB): 10.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 7.9
+    Training Memory (GB): 7.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 11.9
+    Training Memory (GB): 11.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -172,7 +172,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.0
+    Training Memory (GB): 9.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -194,7 +194,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.5
+    Training Memory (GB): 12.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -244,7 +244,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.9
+    Training Memory (GB): 6.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -266,7 +266,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 10.4
+    Training Memory (GB): 10.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/pspnet/pspnet.yml
+++ b/configs/pspnet/pspnet.yml
@@ -34,7 +34,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.1
+    Training Memory (GB): 6.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -56,7 +56,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -78,7 +78,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.9
+    Training Memory (GB): 6.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -100,7 +100,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.9
+    Training Memory (GB): 10.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -122,7 +122,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 1.7
+    Training Memory (GB): 1.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -172,7 +172,7 @@ Models:
       batch size: 1
       mode: FP16
       resolution: (512,1024)
-    memory (GB): 5.34
+    Training Memory (GB): 5.34
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -193,7 +193,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 1.9
+    Training Memory (GB): 1.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -243,7 +243,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 1.5
+    Training Memory (GB): 1.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -265,7 +265,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.0
+    Training Memory (GB): 6.0
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -287,7 +287,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 9.5
+    Training Memory (GB): 9.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -309,7 +309,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 1.7
+    Training Memory (GB): 1.7
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -331,7 +331,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 6.8
+    Training Memory (GB): 6.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -353,7 +353,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 10.8
+    Training Memory (GB): 10.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -375,7 +375,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.5
+    Training Memory (GB): 8.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -397,7 +397,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 12.0
+    Training Memory (GB): 12.0
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -447,7 +447,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.1
+    Training Memory (GB): 6.1
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -469,7 +469,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -519,7 +519,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (480,480)
-    memory (GB): 8.8
+    Training Memory (GB): 8.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal Context
@@ -583,7 +583,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 10k
@@ -605,7 +605,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 13.2
+    Training Memory (GB): 13.2
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 10k
@@ -655,7 +655,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.6
+    Training Memory (GB): 9.6
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 164k
@@ -677,7 +677,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 13.2
+    Training Memory (GB): 13.2
   Results:
   - Task: Semantic Segmentation
     Dataset: COCO-Stuff 164k
@@ -755,7 +755,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 1.45
+    Training Memory (GB): 1.45
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA
@@ -777,7 +777,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.14
+    Training Memory (GB): 6.14
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA
@@ -799,7 +799,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.61
+    Training Memory (GB): 9.61
   Results:
   - Task: Semantic Segmentation
     Dataset: LoveDA

--- a/configs/resnest/resnest.yml
+++ b/configs/resnest/resnest.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 11.4
+    Training Memory (GB): 11.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 11.8
+    Training Memory (GB): 11.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -71,7 +71,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 11.9
+    Training Memory (GB): 11.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -93,7 +93,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 13.2
+    Training Memory (GB): 13.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -115,7 +115,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 14.2
+    Training Memory (GB): 14.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -137,7 +137,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 14.2
+    Training Memory (GB): 14.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -159,7 +159,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 14.6
+    Training Memory (GB): 14.6
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -181,7 +181,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 16.2
+    Training Memory (GB): 16.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k

--- a/configs/segformer/segformer.yml
+++ b/configs/segformer/segformer.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 2.1
+    Training Memory (GB): 2.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 2.6
+    Training Memory (GB): 2.6
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -70,7 +70,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 3.6
+    Training Memory (GB): 3.6
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -92,7 +92,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 4.8
+    Training Memory (GB): 4.8
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -114,7 +114,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.1
+    Training Memory (GB): 6.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -136,7 +136,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.2
+    Training Memory (GB): 7.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k
@@ -158,7 +158,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (640,640)
-    memory (GB): 11.5
+    Training Memory (GB): 11.5
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20k

--- a/configs/sem_fpn/sem_fpn.yml
+++ b/configs/sem_fpn/sem_fpn.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 2.8
+    Training Memory (GB): 2.8
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 3.9
+    Training Memory (GB): 3.9
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -71,7 +71,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 4.9
+    Training Memory (GB): 4.9
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -93,7 +93,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.9
+    Training Memory (GB): 5.9
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/setr/setr.yml
+++ b/configs/setr/setr.yml
@@ -27,7 +27,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 18.4
+    Training Memory (GB): 18.4
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -49,7 +49,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 19.54
+    Training Memory (GB): 19.54
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -64,7 +64,7 @@ Models:
     backbone: ViT-L
     crop size: (512,512)
     lr schd: 160000
-    memory (GB): 10.96
+    Training Memory (GB): 10.96
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -86,7 +86,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 17.3
+    Training Memory (GB): 17.3
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/swin/swin.yml
+++ b/configs/swin/swin.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.02
+    Training Memory (GB): 5.02
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.17
+    Training Memory (GB): 6.17
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -70,7 +70,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.61
+    Training Memory (GB): 7.61
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -106,7 +106,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.52
+    Training Memory (GB): 8.52
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K

--- a/configs/unet/unet.yml
+++ b/configs/unet/unet.yml
@@ -22,7 +22,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (64,64)
     lr schd: 40000
-    memory (GB): 0.68
+    Training Memory (GB): 0.68
   Results:
   - Task: Semantic Segmentation
     Dataset: DRIVE
@@ -36,7 +36,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (64,64)
     lr schd: 40000
-    memory (GB): 0.599
+    Training Memory (GB): 0.599
   Results:
   - Task: Semantic Segmentation
     Dataset: DRIVE
@@ -50,7 +50,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (64,64)
     lr schd: 40000
-    memory (GB): 0.596
+    Training Memory (GB): 0.596
   Results:
   - Task: Semantic Segmentation
     Dataset: DRIVE
@@ -64,7 +64,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
-    memory (GB): 0.968
+    Training Memory (GB): 0.968
   Results:
   - Task: Semantic Segmentation
     Dataset: STARE
@@ -78,7 +78,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
-    memory (GB): 0.982
+    Training Memory (GB): 0.982
   Results:
   - Task: Semantic Segmentation
     Dataset: STARE
@@ -92,7 +92,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
-    memory (GB): 0.999
+    Training Memory (GB): 0.999
   Results:
   - Task: Semantic Segmentation
     Dataset: STARE
@@ -106,7 +106,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
-    memory (GB): 0.968
+    Training Memory (GB): 0.968
   Results:
   - Task: Semantic Segmentation
     Dataset: CHASE_DB1
@@ -120,7 +120,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
-    memory (GB): 0.982
+    Training Memory (GB): 0.982
   Results:
   - Task: Semantic Segmentation
     Dataset: CHASE_DB1
@@ -134,7 +134,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (128,128)
     lr schd: 40000
-    memory (GB): 0.999
+    Training Memory (GB): 0.999
   Results:
   - Task: Semantic Segmentation
     Dataset: CHASE_DB1
@@ -148,7 +148,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (256,256)
     lr schd: 40000
-    memory (GB): 2.525
+    Training Memory (GB): 2.525
   Results:
   - Task: Semantic Segmentation
     Dataset: HRF
@@ -162,7 +162,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (256,256)
     lr schd: 40000
-    memory (GB): 2.588
+    Training Memory (GB): 2.588
   Results:
   - Task: Semantic Segmentation
     Dataset: HRF
@@ -176,7 +176,7 @@ Models:
     backbone: UNet-S5-D16
     crop size: (256,256)
     lr schd: 40000
-    memory (GB): 2.604
+    Training Memory (GB): 2.604
   Results:
   - Task: Semantic Segmentation
     Dataset: HRF

--- a/configs/upernet/upernet.yml
+++ b/configs/upernet/upernet.yml
@@ -28,7 +28,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 6.4
+    Training Memory (GB): 6.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -50,7 +50,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,1024)
-    memory (GB): 7.4
+    Training Memory (GB): 7.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -72,7 +72,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 7.2
+    Training Memory (GB): 7.2
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -94,7 +94,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (769,769)
-    memory (GB): 8.4
+    Training Memory (GB): 8.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Cityscapes
@@ -172,7 +172,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 8.1
+    Training Memory (GB): 8.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -194,7 +194,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.1
+    Training Memory (GB): 9.1
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -244,7 +244,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 6.4
+    Training Memory (GB): 6.4
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug
@@ -266,7 +266,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.5
+    Training Memory (GB): 7.5
   Results:
   - Task: Semantic Segmentation
     Dataset: Pascal VOC 2012 + Aug

--- a/configs/vit/vit.yml
+++ b/configs/vit/vit.yml
@@ -26,7 +26,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -48,7 +48,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.2
+    Training Memory (GB): 9.2
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -70,7 +70,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.21
+    Training Memory (GB): 9.21
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -92,7 +92,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 4.68
+    Training Memory (GB): 4.68
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -114,7 +114,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 4.68
+    Training Memory (GB): 4.68
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -136,7 +136,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.69
+    Training Memory (GB): 5.69
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -158,7 +158,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 5.69
+    Training Memory (GB): 5.69
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -180,7 +180,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.75
+    Training Memory (GB): 7.75
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -202,7 +202,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 7.75
+    Training Memory (GB): 7.75
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -224,7 +224,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.21
+    Training Memory (GB): 9.21
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K
@@ -246,7 +246,7 @@ Models:
       batch size: 1
       mode: FP32
       resolution: (512,512)
-    memory (GB): 9.21
+    Training Memory (GB): 9.21
   Results:
   - Task: Semantic Segmentation
     Dataset: ADE20K


### PR DESCRIPTION
Fix incorrect keys in metafile.  

Changing key name from `memory (GB)` to `Training Memory (GB)`.

