### PR TITLE
[Fix] Change LoveDA codalab server address

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -122,4 +122,4 @@ Assume that you have already downloaded the checkpoints to the directory `checkp
     ```
 
    You will get png files under `./pspnet_test_results` directory.
-   You may run `zip -r -j Results.zip pspnet_test_results/` and submit the zip file to [evaluation server](https://competitions.codalab.org/competitions/35865#participate-submit_results).
+   You may run `zip -r -j Results.zip pspnet_test_results/` and submit the zip file to [evaluation server](https://codalab.lisn.upsaclay.fr/competitions/421).

--- a/docs_zh-CN/inference.md
+++ b/docs_zh-CN/inference.md
@@ -118,4 +118,4 @@ python tools/test.py ${配置文件} ${检查点文件} [--out ${结果文件}] 
     ```
 
    您会在文件夹 `./pspnet_test_results` 里得到生成的 png 文件。
-   您也许可以运行 `zip -r -j Results.zip pspnet_test_results/` 并提交 zip 文件给 [evaluation server](https://competitions.codalab.org/competitions/35865#participate-submit_results) 。
+   您也许可以运行 `zip -r -j Results.zip pspnet_test_results/` 并提交 zip 文件给 [evaluation server](https://codalab.lisn.upsaclay.fr/competitions/421) 。


### PR DESCRIPTION
Old PR: https://github.com/open-mmlab/mmsegmentation/pull/1092

Motivation: Move Evaluation platform of LoveDA dataset to a new codalab server, where its evaluation speed is faster.