### PR TITLE
[Fix] Change the upper version of mmcv to 1.5.0

### DIFF
--- a/mmseg/__init__.py
+++ b/mmseg/__init__.py
@@ -7,7 +7,7 @@ from packaging.version import parse
 from .version import __version__, version_info
 
 MMCV_MIN = '1.3.13'
-MMCV_MAX = '1.4.0'
+MMCV_MAX = '1.5.0'
 
 
 def digit_version(version_str: str, length: int = 4):


### PR DESCRIPTION
Related PR: https://github.com/open-mmlab/mmocr/pull/628

MMCV released v1.4.0 lately so the downstream repos should modify their upper version of mmcv.