### PR TITLE
[Fix] Remove the inplace operation in  uper_head and fpn_neck

### DIFF
--- a/mmseg/models/backbones/mit.py
+++ b/mmseg/models/backbones/mit.py
@@ -22,7 +22,6 @@ class MixFFN(BaseModule):
     The differences between MixFFN & FFN:
         1. Use 1X1 Conv to replace Linear layer.
         2. Introduce 3X3 Conv to encode positional information.
-
     Args:
         embed_dims (int): The feature dimension. Same as
             `MultiheadAttention`. Defaults: 256.
@@ -94,7 +93,6 @@ class EfficientMultiheadAttention(MultiheadAttention):
 
     This module is modified from MultiheadAttention which is a module from
     mmcv.cnn.bricks.transformer.
-
     Args:
         embed_dims (int): The embedding dimension.
         num_heads (int): Parallel attention heads.
@@ -291,7 +289,6 @@ class MixVisionTransformer(BaseModule):
     This backbone is the implementation of `SegFormer: Simple and
     Efficient Design for Semantic Segmentation with
     Transformers <https://arxiv.org/abs/2105.15203>`_.
-
     Args:
         in_channels (int): Number of input channels. Default: 3.
         embed_dims (int): Embedding dimension. Default: 768.

--- a/mmseg/models/decode_heads/uper_head.py
+++ b/mmseg/models/decode_heads/uper_head.py
@@ -101,7 +101,7 @@ class UPerHead(BaseDecodeHead):
         used_backbone_levels = len(laterals)
         for i in range(used_backbone_levels - 1, 0, -1):
             prev_shape = laterals[i - 1].shape[2:]
-            laterals[i - 1] += resize(
+            laterals[i - 1] = laterals[i - 1] + resize(
                 laterals[i],
                 size=prev_shape,
                 mode='bilinear',

--- a/mmseg/models/necks/fpn.py
+++ b/mmseg/models/necks/fpn.py
@@ -175,10 +175,11 @@ class FPN(BaseModule):
             # In some cases, fixing `scale factor` (e.g. 2) is preferred, but
             #  it cannot co-exist with `size` in `F.interpolate`.
             if 'scale_factor' in self.upsample_cfg:
-                laterals[i - 1] += resize(laterals[i], **self.upsample_cfg)
+                laterals[i - 1] = laterals[i - 1] + resize(
+                    laterals[i], **self.upsample_cfg)
             else:
                 prev_shape = laterals[i - 1].shape[2:]
-                laterals[i - 1] += resize(
+                laterals[i - 1] = laterals[i - 1] + resize(
                     laterals[i], size=prev_shape, **self.upsample_cfg)
 
         # build outputs

--- a/tests/test_models/test_necks/test_fpn.py
+++ b/tests/test_models/test_necks/test_fpn.py
@@ -17,3 +17,14 @@ def test_fpn():
     assert outputs[1].shape == torch.Size([1, 64, 28, 28])
     assert outputs[2].shape == torch.Size([1, 64, 14, 14])
     assert outputs[3].shape == torch.Size([1, 64, 7, 7])
+
+    fpn = FPN(
+        in_channels,
+        64,
+        len(in_channels),
+        upsample_cfg=dict(mode='nearest', scale_factor=2.0))
+    outputs = fpn(inputs)
+    assert outputs[0].shape == torch.Size([1, 64, 56, 56])
+    assert outputs[1].shape == torch.Size([1, 64, 28, 28])
+    assert outputs[2].shape == torch.Size([1, 64, 14, 14])
+    assert outputs[3].shape == torch.Size([1, 64, 7, 7])


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Remove the inplace operation in uper_head，which may cause RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation.

## Modification

Remove the inplace operation in uper_head，which may cause RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation.