### PR TITLE
[Fix] Remove unexist arg in docstring

### DIFF
--- a/mmseg/models/losses/dice_loss.py
+++ b/mmseg/models/losses/dice_loss.py
@@ -55,8 +55,6 @@ class DiceLoss(nn.Module):
     Volumetric Medical Image Segmentation <https://arxiv.org/abs/1606.04797>`_.
 
     Args:
-        loss_type (str, optional): Binary or multi-class loss.
-            Default: 'multi_class'. Options are "binary" and "multi_class".
         smooth (float): A float number to smooth loss, and avoid NaN error.
             Default: 1
         exponent (float): An float number to calculate denominator


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Might be trivial but it may be confusing to someone.

## Modification

It seems that the `loss_type` arg in `DiceLoss`  is not used anywhere but it exists in the docstring and docs.
