### PR TITLE
fix dnl_head export onnx inference difference type Cast error

### DIFF
--- a/mmseg/models/decode_heads/dnl_head.py
+++ b/mmseg/models/decode_heads/dnl_head.py
@@ -26,7 +26,9 @@ class DisentangledNonLocal2d(NonLocal2d):
         pairwise_weight = torch.matmul(theta_x, phi_x)
         if self.use_scale:
             # theta_x.shape[-1] is `self.inter_channels`
-            pairwise_weight /= torch.tensor(theta_x.shape[-1], dtype=torch.float)**torch.tensor(0.5)
+            pairwise_weight /= torch.tensor(
+                theta_x.shape[-1], dtype=torch.float
+            ) ** torch.tensor(0.5)
         pairwise_weight /= torch.tensor(self.temperature)
         pairwise_weight = pairwise_weight.softmax(dim=-1)
         return pairwise_weight

--- a/mmseg/models/decode_heads/dnl_head.py
+++ b/mmseg/models/decode_heads/dnl_head.py
@@ -27,8 +27,7 @@ class DisentangledNonLocal2d(NonLocal2d):
         if self.use_scale:
             # theta_x.shape[-1] is `self.inter_channels`
             pairwise_weight /= torch.tensor(
-                theta_x.shape[-1], dtype=torch.float
-            ) ** torch.tensor(0.5)
+                theta_x.shape[-1], dtype=torch.float)**torch.tensor(0.5)
         pairwise_weight /= torch.tensor(self.temperature)
         pairwise_weight = pairwise_weight.softmax(dim=-1)
         return pairwise_weight

--- a/mmseg/models/decode_heads/dnl_head.py
+++ b/mmseg/models/decode_heads/dnl_head.py
@@ -27,8 +27,12 @@ class DisentangledNonLocal2d(NonLocal2d):
         if self.use_scale:
             # theta_x.shape[-1] is `self.inter_channels`
             pairwise_weight /= torch.tensor(
-                theta_x.shape[-1], dtype=torch.float)**torch.tensor(0.5)
-        pairwise_weight /= torch.tensor(self.temperature)
+                theta_x.shape[-1],
+                dtype=torch.float,
+                device=pairwise_weight.device)**torch.tensor(
+                    0.5, device=pairwise_weight.device)
+        pairwise_weight /= torch.tensor(
+            self.temperature, device=pairwise_weight.device)
         pairwise_weight = pairwise_weight.softmax(dim=-1)
         return pairwise_weight
 

--- a/mmseg/models/decode_heads/dnl_head.py
+++ b/mmseg/models/decode_heads/dnl_head.py
@@ -26,8 +26,8 @@ class DisentangledNonLocal2d(NonLocal2d):
         pairwise_weight = torch.matmul(theta_x, phi_x)
         if self.use_scale:
             # theta_x.shape[-1] is `self.inter_channels`
-            pairwise_weight /= theta_x.shape[-1]**0.5
-        pairwise_weight /= self.temperature
+            pairwise_weight /= torch.tensor(theta_x.shape[-1], dtype=torch.float)**torch.tensor(0.5)
+        pairwise_weight /= torch.tensor(self.temperature)
         pairwise_weight = pairwise_weight.softmax(dim=-1)
         return pairwise_weight
 


### PR DESCRIPTION
## Motivation

fix export onnx inference difference type Cast error.

## Modification

When use this class in model, if export to onnx, and use onnx runtime inference, It will case the Cast difference format error.

![image](https://user-images.githubusercontent.com/5787131/147311145-872a7427-7afa-421f-9a5d-9a46d5fed4ab.png)

and the orginal onnx graph is:
- first Cast output is Float, but the `Pow` need Float64.
-  second Cast output is Int64, but the `Div` Op is need Float64

![image](https://user-images.githubusercontent.com/5787131/147311326-766f23ac-0711-425c-a881-91c7877fb1e8.png)

After modify the code used in this PR, the output onnx graph is 
![image](https://user-images.githubusercontent.com/5787131/147311694-ec15e219-b72b-413d-bbc3-b6f1843b9351.png)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
