### PR TITLE
[Fix] Delete unnecessary lines of STDCHead

### DIFF
--- a/configs/_base_/models/stdc.py
+++ b/configs/_base_/models/stdc.py
@@ -68,7 +68,7 @@ model = dict(
             in_index=0,
             norm_cfg=norm_cfg,
             concat_input=False,
-            align_corners=False,
+            align_corners=True,
             loss_decode=[
                 dict(
                     type='CrossEntropyLoss',

--- a/mmseg/models/decode_heads/stdc_head.py
+++ b/mmseg/models/decode_heads/stdc_head.py
@@ -80,11 +80,6 @@ class STDCHead(FCNHead):
         boudary_targets_pyramid[
             boudary_targets_pyramid <= self.boundary_threshold] = 0
 
-        seg_logit = F.interpolate(
-            seg_logit,
-            boundary_targets.shape[2:],
-            mode='bilinear',
-            align_corners=True)
         loss = super(STDCHead, self).losses(seg_logit,
                                             boudary_targets_pyramid.long())
         return loss


### PR DESCRIPTION
## Motivation

In related Issue: https://github.com/open-mmlab/mmsegmentation/issues/1230. 

It is unnecessary to use `F.interpolate` in `STDCHead` because in `BaseDecodeHead.losses` it already uses `resize( )` in https://github.com/open-mmlab/mmsegmentation/blob/4b905cbe2fb2a8afbb7e91c5453aa5fd8ac6b060/mmseg/models/decode_heads/decode_head.py#L232-L239.


<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div style="white-space: pre;" data-zone-id="0" data-line-index="0">

Config names | ss mIoU (old) | ss mIoU (this PR)
-- | -- | --
stdc1_512x1024_80k_cityscapes.py | 71.52 |  71.0
stdc1_in1k-pre_512x1024_80k_cityscapes.py | 75.10 | 75.06
stdc2_512x1024_80k_cityscapes.py | 73.20 | 73.62
stdc2_in1k-pre_512x1024_80k_cityscapes.py | 77.17 |  76.9

</div>