### PR TITLE
[Fix] Make accuracy take into account ignore_index 

### DIFF
--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -261,5 +261,6 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
                     weight=seg_weight,
                     ignore_index=self.ignore_index)
 
-        loss['acc_seg'] = accuracy(seg_logit, seg_label)
+        loss['acc_seg'] = accuracy(
+            seg_logit, seg_label, ignore_index=self.ignore_index)
         return loss

--- a/mmseg/models/decode_heads/point_head.py
+++ b/mmseg/models/decode_heads/point_head.py
@@ -264,7 +264,8 @@ class PointHead(BaseCascadeDecodeHead):
             loss['point' + loss_module.loss_name] = loss_module(
                 point_logits, point_label, ignore_index=self.ignore_index)
 
-        loss['acc_point'] = accuracy(point_logits, point_label)
+        loss['acc_point'] = accuracy(
+            point_logits, point_label, ignore_index=self.ignore_index)
         return loss
 
     def get_points_train(self, seg_logits, uncertainty_func, cfg):

--- a/mmseg/models/losses/accuracy.py
+++ b/mmseg/models/losses/accuracy.py
@@ -2,12 +2,13 @@
 import torch.nn as nn
 
 
-def accuracy(pred, target, topk=1, thresh=None):
+def accuracy(pred, target, topk=1, thresh=None, ignore_index=None):
     """Calculate accuracy according to the prediction and target.
 
     Args:
         pred (torch.Tensor): The model prediction, shape (N, num_class, ...)
         target (torch.Tensor): The target of each prediction, shape (N, , ...)
+        ignore_index (int | None): The label index to be ignored. Default: None
         topk (int | tuple[int], optional): If the predictions in ``topk``
             matches the target, the predictions will be regarded as
             correct ones. Defaults to 1.
@@ -43,17 +44,19 @@ def accuracy(pred, target, topk=1, thresh=None):
     if thresh is not None:
         # Only prediction values larger than thresh are counted as correct
         correct = correct & (pred_value > thresh).t()
+    correct = correct[:, target != ignore_index]
     res = []
     for k in topk:
         correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
-        res.append(correct_k.mul_(100.0 / target.numel()))
+        res.append(
+            correct_k.mul_(100.0 / target[target != ignore_index].numel()))
     return res[0] if return_single else res
 
 
 class Accuracy(nn.Module):
     """Accuracy calculation module."""
 
-    def __init__(self, topk=(1, ), thresh=None):
+    def __init__(self, topk=(1, ), thresh=None, ignore_index=None):
         """Module to calculate the accuracy.
 
         Args:
@@ -65,6 +68,7 @@ class Accuracy(nn.Module):
         super().__init__()
         self.topk = topk
         self.thresh = thresh
+        self.ignore_index = ignore_index
 
     def forward(self, pred, target):
         """Forward function to calculate accuracy.
@@ -76,4 +80,5 @@ class Accuracy(nn.Module):
         Returns:
             tuple[float]: The accuracies under different topk criterions.
         """
-        return accuracy(pred, target, self.topk, self.thresh)
+        return accuracy(pred, target, self.topk, self.thresh,
+                        self.ignore_index)

--- a/tests/test_models/test_losses/test_utils.py
+++ b/tests/test_models/test_losses/test_utils.py
@@ -52,6 +52,30 @@ def test_accuracy():
     pred = torch.Tensor([[0.2, 0.3, 0.6, 0.5], [0.1, 0.1, 0.2, 0.6],
                          [0.9, 0.0, 0.0, 0.1], [0.4, 0.7, 0.1, 0.1],
                          [0.0, 0.0, 0.99, 0]])
+    # test for ignore_index
+    true_label = torch.Tensor([2, 3, 0, 1, 2]).long()
+    accuracy = Accuracy(topk=1, ignore_index=None)
+    acc = accuracy(pred, true_label)
+    assert acc.item() == 100
+
+    # test for ignore_index with a wrong prediction of that index
+    true_label = torch.Tensor([2, 3, 1, 1, 2]).long()
+    accuracy = Accuracy(topk=1, ignore_index=1)
+    acc = accuracy(pred, true_label)
+    assert acc.item() == 100
+
+    # test for ignore_index 1 with a wrong prediction of other index
+    true_label = torch.Tensor([2, 0, 0, 1, 2]).long()
+    accuracy = Accuracy(topk=1, ignore_index=1)
+    acc = accuracy(pred, true_label)
+    assert acc.item() == 75
+
+    # test for ignore_index 4 with a wrong prediction of other index
+    true_label = torch.Tensor([2, 0, 0, 1, 2]).long()
+    accuracy = Accuracy(topk=1, ignore_index=4)
+    acc = accuracy(pred, true_label)
+    assert acc.item() == 80
+
     # test for top1
     true_label = torch.Tensor([2, 3, 0, 1, 2]).long()
     accuracy = Accuracy(topk=1)


### PR DESCRIPTION
## Motivation

Your repository has been so helpful for my projects and I deeply appreciate it. 
My opinion can be wrong, but please look into it and I hope it can be helpful a bit at least.  

I tried to apply 
``` 
reduce_zero_label=True 
``` 
to ignore the background label, and it turned out that the value of acc_seg from the decode_head was weirdly low while other values such as loss and IoU were all looking good. Looking into the decode_head.py, 
```python
    @force_fp32(apply_to=('seg_logit', ))
    def losses(self, seg_logit, seg_label):
        """Compute segmentation loss."""
        loss = dict()
        seg_logit = resize(
            input=seg_logit,
            size=seg_label.shape[2:],
            mode='bilinear',
            align_corners=self.align_corners)
        if self.sampler is not None:
            seg_weight = self.sampler.sample(seg_logit, seg_label)
        else:
            seg_weight = None
        seg_label = seg_label.squeeze(1)

        if not isinstance(self.loss_decode, nn.ModuleList):
            losses_decode = [self.loss_decode]
        else:
            losses_decode = self.loss_decode
        for loss_decode in losses_decode:
            if loss_decode.loss_name not in loss:
                loss[loss_decode.loss_name] = loss_decode(
                    seg_logit,
                    seg_label,
                    weight=seg_weight,
                    ignore_index=self.ignore_index)
            else:
                loss[loss_decode.loss_name] += loss_decode(
                    seg_logit,
                    seg_label,
                    weight=seg_weight,
                    ignore_index=self.ignore_index)

        loss['acc_seg'] = accuracy(seg_logit, seg_label)
        return loss
```  
the loss_decode receives self.ignore_index as an input argument, while the accuracy doesn't. I think it explains why the accuracy seemed so different from other metrics. Thus, I think the accuracy function should receive the ignore index as an argument as well to take into account the ignore_index to calculate the accuracy of the decode head. 

And, I found that the point_head.py also uses the same function without receiving the ignore_index. So I guess both of them should be fixed.

## Modification

Firstly, the accuracy function can be defined like this
``` 
def accuracy(pred, target, ignore_index=255, topk=1, thresh=None): 
```

and inside of the function, the accuracy can be calculated like this to exclude the ignored index, 
```  
res.append(correct_k.mul_(100.0 / target[target!=ignore_index].numel())) 
```

Secondly, in decode_head.py, we can simply put self.ignore_index into one of the arguments like this, 
``` 
loss['acc_seg'] = accuracy(seg_logit, seg_label, ignore_index=self.ignore_index) 
```

Finally, the same strategy can be applied to point_head.py like this, 
``` 
loss['acc_point'] = accuracy(point_logits, point_label, ignore_index=self.ignore_index)
 ```


## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
