### PR TITLE
[Fix] Fix repeating log by `setup_multi_processes`.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -109,9 +109,6 @@ def main():
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
 
-    # set multi-process settings
-    setup_multi_processes(cfg)
-
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True
@@ -162,6 +159,9 @@ def main():
     timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())
     log_file = osp.join(cfg.work_dir, f'{timestamp}.log')
     logger = get_root_logger(log_file=log_file, log_level=cfg.log_level)
+
+    # set multi-process settings
+    setup_multi_processes(cfg)
 
     # init the meta dict to record some important information such as
     # environment info and seed, which will be logged


### PR DESCRIPTION
The issue: https://github.com/open-mmlab/mmsegmentation/issues/1261 reports the error.

In `setup_multi_processes`, it uses `get_logger` from MMCV which would initialize new logger if no log initialized. 

If `setup_multi_processes` is used before dump config in `train.py`, it would create two different logs in mmseg.

Solution is simple, just move `setup_multi_processes` behind of `get_logger` part of `train.py`.