### PR TITLE
[Enhancement] Upgrade isort in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,8 @@ repos:
     rev: 3.8.3
     hooks:
       - id: flake8
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-        args: ["--exclude", ".dev"]
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf

--- a/mmseg/datasets/builder.py
+++ b/mmseg/datasets/builder.py
@@ -64,8 +64,8 @@ def _concat_dataset(cfg, default_args=None):
 
 def build_dataset(cfg, default_args=None):
     """Build datasets."""
-    from .dataset_wrappers import (ConcatDataset, RepeatDataset,
-                                   MultiImageMixDataset)
+    from .dataset_wrappers import (ConcatDataset, MultiImageMixDataset,
+                                   RepeatDataset)
     if isinstance(cfg, (list, tuple)):
         dataset = ConcatDataset([build_dataset(c, default_args) for c in cfg])
     elif cfg['type'] == 'RepeatDataset':

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ split_before_expression_after_opening_paren = true
 [isort]
 line_length = 79
 multi_line_output = 0
-known_standard_library = setuptools
+extra_standard_library = setuptools
 known_first_party = mmseg
 known_third_party = PIL,cityscapesscripts,cv2,detail,matplotlib,mmcv,numpy,onnxruntime,packaging,prettytable,pytest,pytorch_sphinx_theme,requests,scipy,seaborn,torch,ts
 no_lines_before = STDLIB,LOCALFOLDER

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,9 +66,10 @@ def test_config_data_pipeline():
     CommandLine:
         xdoctest -m tests/test_config.py test_config_build_data_pipeline
     """
-    from mmcv import Config
-    from mmseg.datasets.pipelines import Compose
     import numpy as np
+    from mmcv import Config
+
+    from mmseg.datasets.pipelines import Compose
 
     config_dpath = _get_config_directory()
     print('Found config_dpath = {!r}'.format(config_dpath))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -308,8 +308,9 @@ def test_mean_fscore():
 
 
 def test_filename_inputs():
-    import cv2
     import tempfile
+
+    import cv2
 
     def save_arr(input_arrays: list, title: str, is_image: bool, dir: str):
         filenames = []

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -30,6 +30,7 @@ def test_ce_loss():
     # test loss with class weights from file
     import os
     import tempfile
+
     import mmcv
     import numpy as np
     tmp_file = tempfile.NamedTemporaryFile()

--- a/tests/test_models/test_losses/test_dice_loss.py
+++ b/tests/test_models/test_losses/test_dice_loss.py
@@ -21,6 +21,7 @@ def test_dice_lose():
     # test loss with class weights from file
     import os
     import tempfile
+
     import mmcv
     import numpy as np
     tmp_file = tempfile.NamedTemporaryFile()

--- a/tests/test_models/test_losses/test_lovasz_loss.py
+++ b/tests/test_models/test_losses/test_lovasz_loss.py
@@ -51,6 +51,7 @@ def test_lovasz_loss():
     # test loss with class weights from file
     import os
     import tempfile
+
     import mmcv
     import numpy as np
     tmp_file = tempfile.NamedTemporaryFile()

--- a/tools/pytorch2onnx.py
+++ b/tools/pytorch2onnx.py
@@ -242,8 +242,9 @@ def pytorch2onnx(model,
             None, {net_feed_input[0]: img_list[0].detach().numpy()})[0][0]
         # show segmentation results
         if show:
-            import cv2
             import os.path as osp
+
+            import cv2
             img = img_meta_list[0][0]['filename']
             if not osp.exists(img):
                 img = imgs[0][:3, ...].permute(1, 2, 0) * 255


### PR DESCRIPTION
Related PR: https://github.com/open-mmlab/mmflow/pull/87.

1. Remove seed-isort-config in pre-commit hook
2. Upgrade isort to v5.10.1 (latest version)
3. Replace known_standard_library with extra_standard_library

Note: Due to isort upgradation, some .py files would automatically modified by new isort package.
