### PR TITLE
[Improve] Add exception for PointRend for support CPU-only usage

### DIFF
--- a/mmseg/models/decode_heads/point_head.py
+++ b/mmseg/models/decode_heads/point_head.py
@@ -4,6 +4,7 @@
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
+
 try:
     from mmcv.ops import point_sample
 except ModuleNotFoundError:

--- a/mmseg/models/decode_heads/point_head.py
+++ b/mmseg/models/decode_heads/point_head.py
@@ -4,7 +4,10 @@
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops import point_sample
+try:
+    from mmcv.ops import point_sample
+except ModuleNotFoundError:
+    point_sample = None
 
 from mmseg.models.builder import HEADS
 from mmseg.ops import resize
@@ -75,6 +78,9 @@ class PointHead(BaseCascadeDecodeHead):
             init_cfg=dict(
                 type='Normal', std=0.01, override=dict(name='fc_seg')),
             **kwargs)
+        if point_sample is None:
+            raise RuntimeError('Please install mmcv-full for '
+                               'point_sample ops')
 
         self.num_fcs = num_fcs
         self.coarse_pred_each_layer = coarse_pred_each_layer


### PR DESCRIPTION
## Motivation

Support CPU-only usage. User may need to run mmseg on CPU-only. But `mmcv.ops` import will fail on CPU-only installation. Add exception handler to fix that. 

## Modification

Add an exception for PointRend imports

## BC-breaking (Optional)

No

