### PR TITLE
[Fix] Use `fork` for multi processing start method.

### DIFF
--- a/mmseg/utils/set_env.py
+++ b/mmseg/utils/set_env.py
@@ -14,7 +14,7 @@ def setup_multi_processes(cfg):
 
     # set multi-process start method
     if platform.system() != 'Windows':
-        mp_start_method = cfg.get('mp_start_method', None)
+        mp_start_method = cfg.get('mp_start_method', 'fork')
         current_method = mp.get_start_method(allow_none=True)
         if mp_start_method in ('fork', 'spawn', 'forkserver'):
             logger.info(


### PR DESCRIPTION
We found in MMSegmentation, in the start phase of model training (i.e., from `tools/train.py` being used to print out `mmcv - INFO - Reducer buckets have been rebuilt in this iteration.`), using `fork` method is faster than `spawn`.

Thus we set the start method back to `fork`.

Here are our detailed results:

CONFIG=./configs/bisenetv2/bisenetv2_fcn_4x4_1024x1024_160k_cityscapes.py
Repeat 3 times.

<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div style="white-space: pre;" data-zone-id="0" data-line-index="0">

OMP&MKL Thread | OpenCV thread | MP start method | Start time | Eta @ Iter [5000/160000]
-- | -- | -- | -- | --
No Limitation | No Limitation | spawn | 3min 55s; 4min 29s; 3min 43s | 1 day, 2:35:52; 1 day, 2:31:41; 1 day, 3:00:34
No Limitation | No Limitation | fork | 28s; 31s; 31s | 1 day, 1:58:25; 1 day, 1:58:20; 1 day, 1:42:48
No Limitation | 0 | spawn | 3min 55s; 4min 29s; 3min 43s | 1 day, 2:32:57; 1 day, 2:37:30; 1 day, 3:00:33
No Limitation | 0 | fork | 28s; 33s; 31s | 1 day, 1:25:01; 1 day, 2:59:59; 1 day, 2:00:22
1 | No Limitation | spawn | 3min 53s; 4min 27s; 3min 39s | 1 day, 14:26:19; 1 day, 3:50:52; 1 day, 2:11:20
1 | No Limitation | fork | 32s; 33s; 32s | 1 day, 1:32:15;  1 day, 14:05:04; 1 day, 14:37:22
1 | 0 | spawn | 1min 07s; 3min 55s; 6min 34s | 3 days, 19:36:49; 1 day, 3:05:28; 1 day, 4:58:42
1 | 0 | fork | 29s; 33s; 51s | 1 day, 3:17:47; 1 day, 3:00:00; 3 days, 20:10:07

</div>