### PR TITLE
Fix bug in conversion of potsdam

### DIFF
--- a/tools/convert_datasets/potsdam.py
+++ b/tools/convert_datasets/potsdam.py
@@ -126,8 +126,8 @@ def main():
     zipp_list = glob.glob(os.path.join(dataset_path, '*.zip'))
     print('Find the data', zipp_list)
 
-    with tempfile.TemporaryDirectory(dir=args.tmp_dir) as tmp_dir:
-        for zipp in zipp_list:
+    for zipp in zipp_list:
+        with tempfile.TemporaryDirectory(dir=args.tmp_dir) as tmp_dir:
             zip_file = zipfile.ZipFile(zipp)
             zip_file.extractall(tmp_dir)
             src_path_list = glob.glob(os.path.join(tmp_dir, '*.tif'))


### PR DESCRIPTION
## Motivation

Currently, the success of the conversion of the potsdam dataset depends on the order of the files returned by `os.listdir(tmp_dir)[0]`. This works correctly for the first zip file, but can potentially break the processing of the second zip file.

## Modification
Ensure that a new temporary directory is created for each zip file. This ensures, that the temporary contains only the zip file. In this case os.listdir(tmp_dir)[0] will return the correct string.

