### PR TITLE
[Fix] Fix wrong palette value in vaihingen

### DIFF
--- a/mmseg/core/evaluation/class_names.py
+++ b/mmseg/core/evaluation/class_names.py
@@ -232,7 +232,7 @@ def potsdam_palette():
 
 def vaihingen_palette():
     """Vaihingen palette for external use."""
-    return [[255, 255, 255], [0, 0, 255], [0, 0, 255], [0, 255, 0],
+    return [[255, 255, 255], [0, 0, 255], [0, 255, 255], [0, 255, 0],
             [255, 255, 0], [255, 0, 0]]
 
 

--- a/mmseg/datasets/isprs.py
+++ b/mmseg/datasets/isprs.py
@@ -14,7 +14,7 @@ class ISPRSDataset(CustomDataset):
     CLASSES = ('impervious_surface', 'building', 'low_vegetation', 'tree',
                'car', 'clutter')
 
-    PALETTE = [[255, 255, 255], [0, 0, 255], [0, 0, 255], [0, 255, 0],
+    PALETTE = [[255, 255, 255], [0, 0, 255], [0, 255, 255], [0, 255, 0],
                [255, 255, 0], [255, 0, 0]]
 
     def __init__(self, **kwargs):


### PR DESCRIPTION

## Motivation

In original vaihingen dataset pr: https://github.com/open-mmlab/mmsegmentation/pull/1171.

The value of palette is wrong, which should be the same like [Potsdam](https://github.com/open-mmlab/mmsegmentation/blob/master/mmseg/datasets/potsdam.py#L17-L18) because those two datasets have same class names.

