### PR TITLE
[Fix] Fix iSAID dataset conversion default setting in doc.

### DIFF
--- a/docs/en/dataset_prepare.md
+++ b/docs/en/dataset_prepare.md
@@ -374,4 +374,4 @@ You may need to follow the following structure for dataset preparation after dow
 python tools/convert_datasets/isaid.py /path/to/iSAID
 ```
 
-In our default setting (`clip_size` =512, `stride_size`=256), it will generate 33978 images for training and 11644 images for validation.
+In our default setting (`patch_width`=896, `patch_height`=896,　`overlap_area`=384), it will generate 33978 images for training and 11644 images for validation.


### PR DESCRIPTION
## Motivation

Fix iSAID dataset conversion default setting in doc.

Related PR: https://github.com/open-mmlab/mmsegmentation/pull/1115.

The default setting could be found here:https://github.com/open-mmlab/mmsegmentation/blob/master/tools/convert_datasets/isaid.py.

The chinese doc is correct: https://github.com/open-mmlab/mmsegmentation/blob/master/docs/zh_cn/dataset_prepare.md#isaid.

## Change
Default setting is: `patch_width`=896, `patch_height`=896,　`overlap_area`=384.