### PR TITLE
[Docs] Change ConvNeXt journal infomation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Supported backbones:
 - [x] [Vision Transformer (ICLR'2021)](configs/vit)
 - [x] [Swin Transformer (ICCV'2021)](configs/swin)
 - [x] [Twins (NeurIPS'2021)](configs/twins)
-- [x] [ConvNeXt (ArXiv'2022)](configs/convnext)
+- [x] [ConvNeXt (CVPR'2022)](configs/convnext)
 
 Supported methods:
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -83,7 +83,7 @@ MMSegmentation 是一个基于 PyTorch 的语义分割开源工具箱。它是 O
 - [x] [Vision Transformer (ICLR'2021)](configs/vit)
 - [x] [Swin Transformer (ICCV'2021)](configs/swin)
 - [x] [Twins (NeurIPS'2021)](configs/twins)
-- [x] [ConvNeXt (ArXiv'2022)](configs/convnext)
+- [x] [ConvNeXt (CVPR'2022)](configs/convnext)
 
 已支持的算法：
 

--- a/configs/convnext/README.md
+++ b/configs/convnext/README.md
@@ -25,7 +25,7 @@ The "Roaring 20s" of visual recognition began with the introduction of Vision Tr
 @article{liu2022convnet,
   title={A ConvNet for the 2020s},
   author={Liu, Zhuang and Mao, Hanzi and Wu, Chao-Yuan and Feichtenhofer, Christoph and Darrell, Trevor and Xie, Saining},
-  journal={arXiv preprint arXiv:2201.03545},
+  journal={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
   year={2022}
 }
 ```


### PR DESCRIPTION
## Motivation

ConvNeXt has been accepted by CVPR'2022. 6 hours ago official repo has also modified its journal info.

https://github.com/facebookresearch/ConvNeXt/commit/6e08219f9e4c527443d2e44643a9dba79d995b07