### PR TITLE
fix a bug in _expand_onehot_labels

### DIFF
--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -49,7 +49,7 @@ def _expand_onehot_labels(labels, label_weights, target_shape, ignore_index):
     if label_weights is None:
         bin_label_weights = valid_mask
     else:
-        bin_label_weights = label_weights.unsqueeze(1).expand(target_shape)
+        bin_label_weights = label_weights.unsqueeze(1).expand(target_shape).clone()
         bin_label_weights *= valid_mask
 
     return bin_labels, bin_label_weights


### PR DESCRIPTION
File "/home//anaconda3/envs/mmseg020/lib/python3.8/site-packages/mmseg/models/losses/cross_entropy_loss.py", line 86, in binary_cross_entropy
label, weight = _expand_onehot_labels(label, weight, pred.shape,
File "/home//anaconda3/envs/mmseg020/lib/python3.8/site-packages/mmseg/models/losses/cross_entropy_loss.py", line 53, in _expand_onehot_labels
bin_label_weights *= valid_mask
RuntimeError: unsupported operation: more than one element of the written-to tensor refers to a single memory location. Please clone() the tensor before performing the operation.
