### PR TITLE
[Feature] Support FarSeg (CVPR'2020)

### DIFF
--- a/configs/farseg/farseg_r50-d32_896x896_80k_isaid.py
+++ b/configs/farseg/farseg_r50-d32_896x896_80k_isaid.py
@@ -1,0 +1,55 @@
+_base_ = [
+    '../_base_/datasets/isaid.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+# model settings
+norm_cfg = dict(type='SyncBN', requires_grad=True)
+model = dict(
+    type='EncoderDecoder',
+    pretrained='open-mmlab://resnet50_v1c',
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        dilations=(1, 1, 1, 1),
+        strides=(1, 2, 2, 2),
+        norm_cfg=norm_cfg,
+        norm_eval=False,
+        style='pytorch',
+        contract_dilation=True),
+    neck=dict(
+        type='FARNeck',
+        neck_cfg=dict(
+            type='FPN',
+            in_channels=[256, 512, 1024, 2048],
+            out_channels=256,
+            num_outs=4),
+        scene_relation_in_channels=2048,
+        scene_relation_channel_list=(256, 256, 256, 256),
+        scene_relation_out_channels=256,
+        scale_aware_proj=True,
+        norm_cfg=norm_cfg,
+    ),
+    decode_head=dict(
+        type='FARHead',
+        in_channels=256,
+        out_channels=128,
+        in_feat_output_strides=(4, 8, 16, 32),
+        out_feat_output_stride=4,
+        norm_cfg=norm_cfg,
+        num_classes=16,
+        align_corners=False,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))
+
+data = dict(samples_per_gpu=2, workers_per_gpu=2)
+
+# optimizer
+optimizer = dict(type='SGD', lr=0.007, momentum=0.9, weight_decay=0.0001)
+optimizer_config = dict()
+# learning policy
+lr_config = dict(policy='poly', power=0.9, min_lr=1e-5, by_epoch=False)

--- a/configs/farseg/farseg_r50-d8_896x896_80k_isaid.py
+++ b/configs/farseg/farseg_r50-d8_896x896_80k_isaid.py
@@ -1,0 +1,55 @@
+_base_ = [
+    '../_base_/datasets/isaid.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+# model settings
+norm_cfg = dict(type='SyncBN', requires_grad=True)
+model = dict(
+    type='EncoderDecoder',
+    pretrained='open-mmlab://resnet50_v1c',
+    backbone=dict(
+        type='ResNetV1c',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        dilations=(1, 1, 2, 4),
+        strides=(1, 2, 1, 1),
+        norm_cfg=norm_cfg,
+        norm_eval=False,
+        style='pytorch',
+        contract_dilation=True),
+    neck=dict(
+        type='FARNeck',
+        neck_cfg=dict(
+            type='FPN',
+            in_channels=[256, 512, 1024, 2048],
+            out_channels=256,
+            num_outs=4),
+        scene_relation_in_channels=2048,
+        scene_relation_channel_list=(256, 256, 256, 256),
+        scene_relation_out_channels=256,
+        scale_aware_proj=True,
+        norm_cfg=norm_cfg,
+    ),
+    decode_head=dict(
+        type='FARHead',
+        in_channels=256,
+        out_channels=128,
+        in_feat_output_strides=(4, 8, 8, 8),
+        out_feat_output_stride=4,
+        norm_cfg=norm_cfg,
+        num_classes=16,
+        align_corners=False,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))
+
+data = dict(samples_per_gpu=2, workers_per_gpu=2)
+
+# optimizer
+optimizer = dict(type='SGD', lr=0.007, momentum=0.9, weight_decay=0.0001)
+optimizer_config = dict()
+# learning policy
+lr_config = dict(policy='poly', power=0.9, min_lr=1e-5, by_epoch=False)

--- a/mmseg/models/decode_heads/__init__.py
+++ b/mmseg/models/decode_heads/__init__.py
@@ -9,6 +9,7 @@ from .dnl_head import DNLHead
 from .dpt_head import DPTHead
 from .ema_head import EMAHead
 from .enc_head import EncHead
+from .far_head import FARHead
 from .fcn_head import FCNHead
 from .fpn_head import FPNHead
 from .gc_head import GCHead
@@ -34,5 +35,5 @@ __all__ = [
     'EncHead', 'DepthwiseSeparableFCNHead', 'FPNHead', 'EMAHead', 'DNLHead',
     'PointHead', 'APCHead', 'DMHead', 'LRASPPHead', 'SETRUPHead',
     'SETRMLAHead', 'DPTHead', 'SETRMLAHead', 'SegmenterMaskTransformerHead',
-    'SegformerHead', 'ISAHead', 'STDCHead'
+    'SegformerHead', 'ISAHead', 'STDCHead', 'FARHead'
 ]

--- a/mmseg/models/decode_heads/far_head.py
+++ b/mmseg/models/decode_heads/far_head.py
@@ -1,0 +1,170 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import math
+
+import torch
+import torch.nn as nn
+from mmcv.cnn import ConvModule
+
+from mmseg.models.losses import cross_entropy
+from mmseg.ops import resize
+from ..builder import HEADS
+from .decode_head import BaseDecodeHead
+
+
+@HEADS.register_module()
+class FARHead(BaseDecodeHead):
+    """FarSeg Head.
+
+    This head is the implementation of Light-weight Decoder in
+    `Foreground-Aware Relation Network for Geospatial Object Segmentation
+    in High Spatial Resolution Remote Sensing Imagery
+    <https://arxiv.org/abs/2011.09766>`_.
+
+    Args:
+        in_channels (int): The number of input channels.
+            Default: 256.
+        out_channels (int): The number of output channels.
+            Default: 128.
+        in_feat_output_strides (Tuple[int]): The strides of each input
+            feature map, i.e., the ratio between shape of original
+            image input of backbone and feature map input of FARHead.
+            Default: (4, 8, 16, 32).
+        out_feat_output_stride (int): The stride of output feature map.
+            Default: 4.
+        max_step (int): Max step iteration for calculating scale value
+            in annealing function. Default: 10000.
+        ignore_index (int | None): The label index to be ignored.
+            Default: 255.
+        gamma (float, optional): The gamma for calculating the modulating
+            factor. Default: 2.0.
+        annealing_type (str): The type of annealing function.
+            Default: 'cosine'.
+    """
+
+    def __init__(self,
+                 in_channels=256,
+                 out_channels=128,
+                 in_feat_output_strides=(4, 8, 16, 32),
+                 out_feat_output_stride=4,
+                 max_step=10000,
+                 ignore_index=255,
+                 gamma=2.0,
+                 annealing_type='cosine',
+                 **kwargs):
+        super(FARHead, self).__init__(
+            in_channels=in_channels, channels=out_channels, **kwargs)
+        self.in_feat_output_strides = in_feat_output_strides
+        self.out_feat_output_stride = out_feat_output_stride
+        self.blocks = nn.ModuleList()
+        self.num_samples = []
+
+        # These parameters are used for FarSeg loss calculation
+        self.buffer_step = 0
+        self.max_step = max_step
+        self.ignore_index = ignore_index
+        self.gamma = gamma
+        self.annealing_type = annealing_type
+        for i, in_feat_os in enumerate(in_feat_output_strides):
+            num_upsample = int(math.log2(int(in_feat_os))) - int(
+                math.log2(int(out_feat_output_stride)))
+            self.num_samples.append(num_upsample)
+
+            num_layers = num_upsample if num_upsample != 0 else 1
+
+            self.blocks.append(
+                nn.Sequential(*[
+                    nn.Sequential(
+                        ConvModule(
+                            in_channels=in_channels if idx ==
+                            0 else out_channels,
+                            out_channels=out_channels,
+                            kernel_size=3,
+                            stride=1,
+                            padding=1,
+                            bias=False,
+                            conv_cfg=self.conv_cfg,
+                            norm_cfg=self.norm_cfg,
+                            act_cfg=self.act_cfg),
+                        nn.UpsamplingBilinear2d(scale_factor=2)
+                        if num_upsample != 0 else nn.Identity(),
+                    ) for idx in range(num_layers)
+                ]))
+
+    def forward(self, inputs):
+        self.buffer_step += 1
+        for i, stride in enumerate(self.in_feat_output_strides):
+            assert (stride /
+                    self.out_feat_output_stride == inputs[0].shape[-1] /
+                    inputs[i].shape[-1]), 'Input Feature map \
+                    stride ratio must be the same of backbone!'
+
+        inner_feat_list = []
+        for i, block in enumerate(self.blocks):
+            decoder_feat = block(inputs[i])
+            inner_feat_list.append(decoder_feat)
+        out_feats = sum(inner_feat_list) / 4.
+        output = self.cls_seg(out_feats)
+        return output
+
+    def cosine_annealing(self, lower_bound, upper_bound, _t, _t_max):
+        return upper_bound + 0.5 * (lower_bound - upper_bound) * (
+            math.cos(math.pi * _t / _t_max) + 1)
+
+    def poly_annealing(self, lower_bound, upper_bound, _t, _t_max):
+        factor = (1 - _t / _t_max)**0.9
+        return upper_bound + factor * (lower_bound - upper_bound)
+
+    def linear_annealing(self, lower_bound, upper_bound, _t, _t_max):
+        factor = 1 - _t / _t_max
+        return upper_bound + factor * (lower_bound - upper_bound)
+
+    def annealing_softmax_focalloss(self,
+                                    y_pred,
+                                    y_true,
+                                    t,
+                                    t_max,
+                                    ignore_index=255,
+                                    gamma=2.0,
+                                    annealing_function=cosine_annealing):
+        losses = cross_entropy(
+            y_pred, y_true, ignore_index=ignore_index, reduction='none')
+        with torch.no_grad():
+            p = y_pred.softmax(dim=1)
+            modulating_factor = (1 - p).pow(gamma)
+            valid_mask = ~y_true.eq(ignore_index)
+            masked_y_true = torch.where(valid_mask, y_true,
+                                        torch.zeros_like(y_true))
+            modulating_factor = torch.gather(
+                modulating_factor, dim=1,
+                index=masked_y_true.unsqueeze(dim=1)).squeeze_(dim=1)
+            normalizer = losses.sum() / (losses * modulating_factor).sum()
+            scales = modulating_factor * normalizer
+        if t > t_max:
+            scale = scales
+        else:
+            scale = annealing_function(1, scales, t, t_max)
+        losses = (losses * scale).sum() / (valid_mask.sum() + p.size(0))
+        return losses
+
+    def losses(self, seg_logit, seg_label):
+        """Compute annealing softmax focalloss."""
+        losses = dict()
+        seg_label = seg_label.float()
+        func_dict = dict(
+            cosine=self.cosine_annealing,
+            poly=self.poly_annealing,
+            linear=self.linear_annealing)
+        seg_logit = resize(
+            input=seg_logit,
+            size=seg_label.size()[2:],
+            mode='bilinear',
+            align_corners=False)
+        seg_label = seg_label.squeeze(1)
+        loss = self.annealing_softmax_focalloss(seg_logit, seg_label.long(),
+                                                self.buffer_step,
+                                                self.max_step,
+                                                self.ignore_index, self.gamma,
+                                                func_dict[self.annealing_type])
+        losses['loss_asfocal'] = loss
+
+        return losses

--- a/mmseg/models/necks/__init__.py
+++ b/mmseg/models/necks/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from .far_neck import FARNeck
 from .fpn import FPN
 from .ic_neck import ICNeck
 from .jpu import JPU
 from .mla_neck import MLANeck
 from .multilevel_neck import MultiLevelNeck
 
-__all__ = ['FPN', 'MultiLevelNeck', 'MLANeck', 'ICNeck', 'JPU']
+__all__ = ['FPN', 'MultiLevelNeck', 'MLANeck', 'ICNeck', 'JPU', 'FARNeck']

--- a/mmseg/models/necks/far_neck.py
+++ b/mmseg/models/necks/far_neck.py
@@ -1,0 +1,171 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch.nn as nn
+from mmcv.cnn import ConvModule, build_activation_layer
+from mmcv.runner import BaseModule, auto_fp16
+
+from ..builder import NECKS, build_neck
+
+
+class SceneRelation(BaseModule):
+    """Foreground-Scene Relation Module.
+
+    Args:
+        scene_relation_in_channels (int): The number of input channels for
+            Foreground-Scene Relation Module. Default: 2048.
+        scene_relation_channel_list　(List[int]): Number of channels per scale
+            in Foreground-Scene Relation Module Default: (256, 256, 256, 256).
+        scene_relation_out_channels (int): The number of output channels
+            for Foreground-Scene Relation Module. Default: 256.
+        scale_aware_proj (bool): Default: True.
+        conv_cfg (dict | None): Config of conv layers.
+            Default: None.
+        norm_cfg (dict | None): Config of norm layers.
+            Default: dict(type='BN').
+        act_cfg (dict): Config of activation layers.
+            Default: dict(type='ReLU').
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+            Default: None.
+    """
+
+    def __init__(self,
+                 scene_relation_in_channel=2048,
+                 scene_relation_channel_list=(256, 256, 256, 256),
+                 scene_relation_out_channel=256,
+                 scale_aware_proj=True,
+                 conv_cfg=None,
+                 norm_cfg=dict(type='BN'),
+                 act_cfg=dict(type='ReLU'),
+                 init_cfg=None):
+        super(SceneRelation, self).__init__(init_cfg=init_cfg)
+        self.scale_aware_proj = scale_aware_proj
+        self.in_channels = scene_relation_in_channel
+        self.channel_list = scene_relation_channel_list
+        self.out_channel = scene_relation_out_channel
+
+        self.scene_encoder = nn.ModuleList()
+        self.content_encoders = nn.ModuleList()
+        self.feature_reencoders = nn.ModuleList()
+
+        for i in range(len(self.channel_list) if self.scale_aware_proj else 1):
+            self.scene_encoder.append(
+                nn.Sequential(
+                    nn.Conv2d(self.in_channels, self.out_channel, 1),
+                    build_activation_layer(act_cfg),
+                    nn.Conv2d(self.out_channel, self.out_channel, 1)))
+        for channel in self.channel_list:
+            self.content_encoders.append(
+                ConvModule(
+                    in_channels=channel,
+                    out_channels=self.out_channel,
+                    kernel_size=1,
+                    bias=True,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    act_cfg=act_cfg))
+            self.feature_reencoders.append(
+                ConvModule(
+                    in_channels=channel,
+                    out_channels=self.out_channel,
+                    kernel_size=1,
+                    bias=True,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    act_cfg=act_cfg))
+        self.normalizer = nn.Sigmoid()
+
+    def forward(self, scene_feature, features):
+        content_feats = []
+        for i, feature in enumerate(features):
+            content_feats.append(self.content_encoders[i](feature))
+
+        scene_feats = []
+        relations = []
+        if self.scale_aware_proj:
+            for layer in self.scene_encoder:
+                scene_feats.append(layer(scene_feature))
+            for scene_feat, content_feat in zip(scene_feats, content_feats):
+                relations.append(
+                    self.normalizer(
+                        (scene_feat * content_feat).sum(dim=1, keepdim=True)))
+        else:
+            scene_feat = self.scene_encoder(scene_feature)
+            for content_feat in content_feats:
+                relations.append(
+                    self.normalizer(
+                        (scene_feat * content_feat).sum(dim=1, keepdim=True)))
+
+        p_feats = []
+        for i, feature in enumerate(features):
+            p_feats.append(self.feature_reencoders[i](feature))
+
+        refined_feats = [r * p for r, p in zip(relations, p_feats)]
+        return refined_feats
+
+
+@NECKS.register_module()
+class FARNeck(BaseModule):
+    """FarSeg Neck.
+
+    This neck is the implementation neck of `Foreground-Aware Relation Network
+    for Geospatial Object Segmentation in High Spatial Resolution Remote
+    Sensing Imagery <https://arxiv.org/abs/2011.09766>`_. Specifically,
+    it includes foreground branch, scene embedding branch and
+    Foreground-Scene Relation Module in original paper.
+
+    Args:
+        neck_cfg:(dict): Config of neck of foreground branch.
+        scene_relation_in_channels (int): The number of input channels for
+            Foreground-Scene Relation Module. Default: 2048.
+        scene_relation_channel_list　(List[int]): Number of channels per scale
+            in Foreground-Scene Relation Module Default: (256, 256, 256, 256).
+        scene_relation_out_channels (int): The number of output channels
+            for Foreground-Scene Relation Module. Default: 256.
+        scale_aware_proj (bool): Default: True.
+        conv_cfg (dict | None): Config of conv layers.
+            Default: None.
+        norm_cfg (dict | None): Config of norm layers.
+            Default: dict(type='BN').
+        act_cfg (dict): Config of activation layers.
+            Default: dict(type='ReLU').
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+            Default: None.
+    """
+
+    def __init__(self,
+                 neck_cfg=dict(
+                     type='FPN',
+                     in_channels=[256, 512, 1024, 2048],
+                     out_channels=256,
+                     num_outs=4),
+                 scene_relation_in_channels=2048,
+                 scene_relation_channel_list=(256, 256, 256, 256),
+                 scene_relation_out_channels=256,
+                 scale_aware_proj=True,
+                 conv_cfg=None,
+                 norm_cfg=dict(type='BN'),
+                 act_cfg=dict(type='ReLU'),
+                 init_cfg=None):
+        super(FARNeck, self).__init__(init_cfg)
+
+        self.foreground_branch = build_neck(neck_cfg)
+        self.global_avgpool = nn.AdaptiveAvgPool2d(1)
+        self.scene_relation = SceneRelation(
+            scene_relation_in_channels,
+            scene_relation_channel_list,
+            scene_relation_out_channels,
+            scale_aware_proj,
+            conv_cfg=conv_cfg,
+            norm_cfg=norm_cfg,
+            act_cfg=act_cfg,
+            init_cfg=init_cfg)
+
+    @auto_fp16()
+    def forward(self, inputs):
+        assert len(inputs) == 4, 'Length of input feature \
+                                        maps must be 4!'
+
+        scene_feat = self.global_avgpool(inputs[-1])
+        fpn_feat_lst = self.foreground_branch(inputs)
+        refined_fpn_feat_lst = self.scene_relation(scene_feat, fpn_feat_lst)
+
+        return refined_fpn_feat_lst

--- a/tests/test_models/test_heads/test_far_head.py
+++ b/tests/test_models/test_heads/test_far_head.py
@@ -1,0 +1,81 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+import torch
+
+from mmseg.models.decode_heads import FARHead
+from .utils import to_cuda
+
+
+def test_far_head():
+
+    # test R50-D32 feature map
+    inputs = [
+        torch.randn(1, 4, 16, 16),
+        torch.randn(1, 4, 8, 8),
+        torch.randn(1, 4, 4, 4),
+        torch.randn(1, 4, 2, 2),
+    ]
+    head = FARHead(
+        in_channels=4,
+        out_channels=2,
+        in_feat_output_strides=(4, 8, 16, 32),
+        out_feat_output_stride=4,
+        num_classes=16)
+    if torch.cuda.is_available():
+        head, inputs = to_cuda(head, inputs)
+    outputs = head(inputs)
+    assert outputs.shape == (1, head.num_classes, 16, 16)
+
+    # test R50-D8 feature map
+    inputs = [
+        torch.randn(1, 4, 16, 16),
+        torch.randn(1, 4, 8, 8),
+        torch.randn(1, 4, 8, 8),
+        torch.randn(1, 4, 8, 8),
+    ]
+    head = FARHead(
+        in_channels=4,
+        out_channels=2,
+        in_feat_output_strides=(4, 8, 8, 8),
+        out_feat_output_stride=4,
+        num_classes=16)
+    if torch.cuda.is_available():
+        head, inputs = to_cuda(head, inputs)
+    outputs = head(inputs)
+    assert outputs.shape == (1, head.num_classes, 16, 16)
+
+    with pytest.raises(AssertionError):
+        # FARHead input and output stride constraints.
+
+        # decoder head for R50-D32 feature map
+        head = FARHead(
+            in_channels=4,
+            out_channels=2,
+            in_feat_output_strides=(4, 8, 16, 32),
+            out_feat_output_stride=4,
+            num_classes=16)
+
+        # R50-D8 feature map
+        inputs = [
+            torch.randn(1, 4, 16, 16),
+            torch.randn(1, 4, 8, 8),
+            torch.randn(1, 4, 8, 8),
+            torch.randn(1, 4, 8, 8),
+        ]
+        head(inputs)
+
+    # test annealing softmax focalloss
+    fake_label = torch.ones_like(
+        outputs[:, 0:1, :, :], dtype=torch.int16).long()
+
+    head.annealing_type = 'cosine'
+    loss = head.losses(seg_logit=outputs, seg_label=fake_label)
+    assert loss['loss_asfocal'] != torch.zeros_like(loss['loss_asfocal'])
+
+    head.annealing_type = 'poly'
+    loss = head.losses(seg_logit=outputs, seg_label=fake_label)
+    assert loss['loss_asfocal'] != torch.zeros_like(loss['loss_asfocal'])
+
+    head.annealing_type = 'linear'
+    loss = head.losses(seg_logit=outputs, seg_label=fake_label)
+    assert loss['loss_asfocal'] != torch.zeros_like(loss['loss_asfocal'])

--- a/tests/test_models/test_necks/test_far_neck.py
+++ b/tests/test_models/test_necks/test_far_neck.py
@@ -1,0 +1,41 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+import torch
+
+from mmseg.models.necks import FARNeck
+
+
+def test_fastfcn_neck():
+    # Test FarNeck Standard Forward
+    model = FARNeck(
+        neck_cfg=dict(
+            type='FPN', in_channels=[2, 4, 8, 16], out_channels=2, num_outs=4),
+        scene_relation_in_channels=16,
+        scene_relation_channel_list=(2, 2, 2, 2),
+        scene_relation_out_channels=2,
+    )
+    model.init_weights()
+    model.train()
+    batch_size = 1
+    input = [
+        torch.randn(batch_size, 2, 56, 56),
+        torch.randn(batch_size, 4, 28, 28),
+        torch.randn(batch_size, 8, 14, 14),
+        torch.randn(batch_size, 16, 7, 7),
+    ]
+    feat = model(input)
+
+    assert len(feat) == 4
+    assert feat[0].shape == torch.Size([batch_size, 2, 56, 56])
+    assert feat[1].shape == torch.Size([batch_size, 2, 28, 28])
+    assert feat[2].shape == torch.Size([batch_size, 2, 14, 14])
+    assert feat[3].shape == torch.Size([batch_size, 2, 7, 7])
+
+    with pytest.raises(AssertionError):
+        # FARNeck input length constraints.
+        input = [
+            torch.randn(batch_size, 2, 56, 56),
+            torch.randn(batch_size, 4, 28, 28),
+            torch.randn(batch_size, 8, 14, 14),
+        ]
+        model(input)


### PR DESCRIPTION
## Motivation
Support FarSeg, one of the benchmark in Geospatial Object Segmentation.
Official repo: https://github.com/Z-Zheng/FarSeg.
Original paper: https://arxiv.org/abs/2011.09766.

Current results:


FarSeg setting is 

> lr=0.007, weight_decay=0.0001, min_lr=1e-5 

Original setting is MMSeg default setting:

> lr=0.01, weight_decay=0.0005, min_lr=1e-4

<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div style="white-space: pre;" data-zone-id="0" data-line-index="0">

  | backbone | Batch size | loss | Hyper parameters | mIoU
-- | -- | -- | -- | -- | --
farseg_r50-d8_4x2_896x896_80k_isaid.py | r50-d8 | 4x2 | CE | FarSeg setting | 61.04
farseg_r50-d8_4x2_896x896_80k_isaid.py | r50-d8 | 4x2 | Annealing Soft Focal | FarSeg setting | 60.65
farseg_r50-d8_4x4_896x896_80k_isaid.py | r50-d8 | 4x4 | CE | FarSeg setting | 61.61
pspnet_r50-d8_4x4_896x896_80k_isaid.py (**mmseg current model**)  | r50-d8 | 4x4 | CE | Original setting | 65.36
  |   |   |   |   |  
farseg_r50-d32_4x2_896x896_80k_isaid.py | r50-d32 | 4x2 | CE | FarSeg setting | 59.21
farseg_r50-d32_4x2_896x896_80k_isaid.py (**FarSeg original model**) | r50-d32 | 4x2 | Annealing Soft Focal | FarSeg setting | **62.72**
farseg_r50-d32_4x4_896x896_80k_isaid.py | r50-d32 | 4x4 | CE | FarSeg setting | 60.09
pspnet_r50-d32_4x4_896x896_80k_isaid.py | r50-d32 | 4x4 | CE | FarSeg setting | 55.08

</div>