### PR TITLE
[Feature] Support dataset initialization with file_client

### DIFF
--- a/mmseg/datasets/chase_db1.py
+++ b/mmseg/datasets/chase_db1.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
 
 from .builder import DATASETS
 from .custom import CustomDataset
@@ -25,4 +24,4 @@ class ChaseDB1Dataset(CustomDataset):
             seg_map_suffix='_1stHO.png',
             reduce_zero_label=False,
             **kwargs)
-        assert osp.exists(self.img_dir)
+        assert self.file_client.exists(self.img_dir)

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -87,7 +87,8 @@ class CustomDataset(Dataset):
                  reduce_zero_label=False,
                  classes=None,
                  palette=None,
-                 gt_seg_map_loader_cfg=None):
+                 gt_seg_map_loader_cfg=None,
+                 file_client_args=dict(backend='disk')):
         self.pipeline = Compose(pipeline)
         self.img_dir = img_dir
         self.img_suffix = img_suffix
@@ -104,6 +105,9 @@ class CustomDataset(Dataset):
         self.gt_seg_map_loader = LoadAnnotations(
         ) if gt_seg_map_loader_cfg is None else LoadAnnotations(
             **gt_seg_map_loader_cfg)
+
+        self.file_client_args = file_client_args
+        self.file_client = mmcv.FileClient.infer_client(self.file_client_args)
 
         if test_mode:
             assert self.CLASSES is not None, \
@@ -146,16 +150,21 @@ class CustomDataset(Dataset):
 
         img_infos = []
         if split is not None:
-            with open(split) as f:
-                for line in f:
-                    img_name = line.strip()
-                    img_info = dict(filename=img_name + img_suffix)
-                    if ann_dir is not None:
-                        seg_map = img_name + seg_map_suffix
-                        img_info['ann'] = dict(seg_map=seg_map)
-                    img_infos.append(img_info)
+            lines = mmcv.list_from_file(
+                split, file_client_args=self.file_client_args)
+            for line in lines:
+                img_name = line.strip()
+                img_info = dict(filename=img_name + img_suffix)
+                if ann_dir is not None:
+                    seg_map = img_name + seg_map_suffix
+                    img_info['ann'] = dict(seg_map=seg_map)
+                img_infos.append(img_info)
         else:
-            for img in mmcv.scandir(img_dir, img_suffix, recursive=True):
+            for img in self.file_client.list_dir_or_file(
+                    dir_path=img_dir,
+                    list_dir=False,
+                    suffix=img_suffix,
+                    recursive=True):
                 img_info = dict(filename=img)
                 if ann_dir is not None:
                     seg_map = img.replace(img_suffix, seg_map_suffix)

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -68,6 +68,9 @@ class CustomDataset(Dataset):
             Default: None
         gt_seg_map_loader_cfg (dict, optional): build LoadAnnotations to
             load gt for evaluation, load from disk by default. Default: None.
+        file_client_args (dict): Arguments to instantiate a FileClient.
+            See :class:`mmcv.fileio.FileClient` for details.
+            Defaults to ``dict(backend='disk')``.
     """
 
     CLASSES = None

--- a/mmseg/datasets/drive.py
+++ b/mmseg/datasets/drive.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
 
 from .builder import DATASETS
 from .custom import CustomDataset
@@ -25,4 +24,4 @@ class DRIVEDataset(CustomDataset):
             seg_map_suffix='_manual1.png',
             reduce_zero_label=False,
             **kwargs)
-        assert osp.exists(self.img_dir)
+        assert self.file_client.exists(self.img_dir)

--- a/mmseg/datasets/hrf.py
+++ b/mmseg/datasets/hrf.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
 
 from .builder import DATASETS
 from .custom import CustomDataset
@@ -25,4 +24,4 @@ class HRFDataset(CustomDataset):
             seg_map_suffix='.png',
             reduce_zero_label=False,
             **kwargs)
-        assert osp.exists(self.img_dir)
+        assert self.file_client.exists(self.img_dir)

--- a/mmseg/datasets/isaid.py
+++ b/mmseg/datasets/isaid.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
 
 import mmcv
 from mmcv.utils import print_log
@@ -35,7 +34,7 @@ class iSAIDDataset(CustomDataset):
             seg_map_suffix='.png',
             ignore_index=255,
             **kwargs)
-        assert osp.exists(self.img_dir)
+        assert self.file_client.exists(self.img_dir)
 
     def load_annotations(self,
                          img_dir,

--- a/mmseg/datasets/pascal_context.py
+++ b/mmseg/datasets/pascal_context.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
 
 from .builder import DATASETS
 from .custom import CustomDataset
@@ -52,7 +51,7 @@ class PascalContextDataset(CustomDataset):
             split=split,
             reduce_zero_label=False,
             **kwargs)
-        assert osp.exists(self.img_dir) and self.split is not None
+        assert self.file_client.exists(self.img_dir) and self.split is not None
 
 
 @DATASETS.register_module()
@@ -101,4 +100,4 @@ class PascalContextDataset59(CustomDataset):
             split=split,
             reduce_zero_label=True,
             **kwargs)
-        assert osp.exists(self.img_dir) and self.split is not None
+        assert self.file_client.exists(self.img_dir) and self.split is not None


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support to initialize dataset from file_client

## Modification

1. Add `file_client_args` in `__init__` with default value `dict(backend='disk')`
2. scan directory  with `file_client.list_dir_or_file` in `load_annotations`
3. Read split file with `mmcv.list_from_file` in `load_annotations`

## Use cases (Optional)

```
file_client_args = dict(
    backend='petrel',
    path_mapping=dict({
        '.data/cityscapes/': 'openmmlab:s3://openmmlab/datasets/segmentation/cityscapes/',
        'data/cityscapes/': 'openmmlab:s3://openmmlab/datasets/segmentation/cityscapes/'
    }))

data = dict(
...
    train=dict(
    ...
           file_client_args=file_client_args),
    val=dict(
    ...
        gt_seg_map_loader_cfg=dict(file_client_args=file_client_args),
        file_client_args=file_client_args),
    test=dict(
    ...
        gt_seg_map_loader_cfg=dict(file_client_args=file_client_args),
        file_client_args=file_client_args))
```
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
5. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
6. The documentation has been modified accordingly, like docstring or example tutorials.
