### PR TITLE
[Fix] Add avg_non_ignore in cross entropy loss

### DIFF
--- a/docs/en/tutorials/training_tricks.md
+++ b/docs/en/tutorials/training_tricks.md
@@ -68,3 +68,21 @@ model = dict(
 In this way, `loss_weight` and `loss_name` will be weight and name in training log of corresponding loss, respectively.
 
 Note: If you want this loss item to be included into the backward graph, `loss_` must be the prefix of the name.
+
+## Ignore specified label index in loss calculation
+
+For loss calculation, we support ignore index of certain label by `avg_non_ignore` and `ignore_index`. Here is an example config of training `unet` on `DRIVE` dataset: in loss calculation it would ignore label 0 which is background and loss average is only calculated on non-ignore labels:
+
+```python
+_base_ = './fcn_unet_s5-d16_64x64_40k_drive.py'
+model = dict(
+    decode_head=dict(
+        ignore_index=0,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0, avg_non_ignore=True),
+    auxiliary_head=dict(
+        ignore_index=0,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0, avg_non_ignore=True)),
+    ))
+```

--- a/docs/en/tutorials/training_tricks.md
+++ b/docs/en/tutorials/training_tricks.md
@@ -73,7 +73,7 @@ Note: If you want this loss item to be included into the backward graph, `loss_`
 
 In default setting, `avg_non_ignore=False` which means each pixel counts for loss calculation although some of them belong to ignore-index labels.
 
-For loss calculation, we support ignore index of certain label by `avg_non_ignore` and `ignore_index`. In this way, the average loss would only be calculated in non-ignored labels which may achieve better performance. Here is an example config of training `unet` on `Cityscapes` dataset: in loss calculation it would ignore label 0 which is background and loss average is only calculated on non-ignore labels:
+For loss calculation, we support ignore index of certain label by `avg_non_ignore` and `ignore_index`. In this way, the average loss would only be calculated in non-ignored labels which may achieve better performance, and here is the [reference](https://github.com/open-mmlab/mmsegmentation/pull/1409). Here is an example config of training `unet` on `Cityscapes` dataset: in loss calculation it would ignore label 0 which is background and loss average is only calculated on non-ignore labels:
 
 ```python
 _base_ = './fcn_unet_s5-d16_4x4_512x1024_160k_cityscapes.py'

--- a/docs/en/tutorials/training_tricks.md
+++ b/docs/en/tutorials/training_tricks.md
@@ -71,10 +71,12 @@ Note: If you want this loss item to be included into the backward graph, `loss_`
 
 ## Ignore specified label index in loss calculation
 
-For loss calculation, we support ignore index of certain label by `avg_non_ignore` and `ignore_index`. Here is an example config of training `unet` on `DRIVE` dataset: in loss calculation it would ignore label 0 which is background and loss average is only calculated on non-ignore labels:
+In default setting, `avg_non_ignore=False` which means each pixel counts for loss calculation although some of them belong to ignore-index labels.
+
+For loss calculation, we support ignore index of certain label by `avg_non_ignore` and `ignore_index`. In this way, the average loss would only be calculated in non-ignored labels which may achieve better performance. Here is an example config of training `unet` on `Cityscapes` dataset: in loss calculation it would ignore label 0 which is background and loss average is only calculated on non-ignore labels:
 
 ```python
-_base_ = './fcn_unet_s5-d16_64x64_40k_drive.py'
+_base_ = './fcn_unet_s5-d16_4x4_512x1024_160k_cityscapes.py'
 model = dict(
     decode_head=dict(
         ignore_index=0,

--- a/docs/zh_cn/tutorials/training_tricks.md
+++ b/docs/zh_cn/tutorials/training_tricks.md
@@ -73,7 +73,7 @@ model = dict(
 
 默认设置 `avg_non_ignore=False`， 即每个像素都用来计算损失函数。尽管其中的一些像素属于需要被忽略的类别。
 
-对于训练时损失函数的计算，我们目前支持使用 `avg_non_ignore` 和 `ignore_index` 来忽略 label 特定的类别。 这样损失函数将只在非忽略类别像素中求平均值，会获得更好的表现。以 `unet` 使用 `Cityscapes` 数据集训练为例，
+对于训练时损失函数的计算，我们目前支持使用 `avg_non_ignore` 和 `ignore_index` 来忽略 label 特定的类别。 这样损失函数将只在非忽略类别像素中求平均值，会获得更好的表现。这里是[相关 PR](https://github.com/open-mmlab/mmsegmentation/pull/1409)。以 `unet` 使用 `Cityscapes` 数据集训练为例，
 在计算损失函数时，忽略 label 为0的背景，并且仅在不被忽略的像素上计算均值。配置文件写为:
 
 ```python

--- a/docs/zh_cn/tutorials/training_tricks.md
+++ b/docs/zh_cn/tutorials/training_tricks.md
@@ -71,11 +71,13 @@ model = dict(
 
 ## 在损失函数中忽略特定的 label 类别
 
-对于训练时损失函数的计算，我们目前支持使用 `avg_non_ignore` 和 `ignore_index` 来忽略 label 特定的类别。 以 `unet` 使用 `DRIVE` 数据集训练为例，
+默认设置 `avg_non_ignore=False`， 即每个像素都用来计算损失函数。尽管其中的一些像素属于需要被忽略的类别。
+
+对于训练时损失函数的计算，我们目前支持使用 `avg_non_ignore` 和 `ignore_index` 来忽略 label 特定的类别。 这样损失函数将只在非忽略类别像素中求平均值，会获得更好的表现。以 `unet` 使用 `Cityscapes` 数据集训练为例，
 在计算损失函数时，忽略 label 为0的背景，并且仅在不被忽略的像素上计算均值。配置文件写为:
 
 ```python
-_base_ = './fcn_unet_s5-d16_64x64_40k_drive.py'
+_base_ = './fcn_unet_s5-d16_4x4_512x1024_160k_cityscapes.py'
 model = dict(
     decode_head=dict(
         ignore_index=0,

--- a/docs/zh_cn/tutorials/training_tricks.md
+++ b/docs/zh_cn/tutorials/training_tricks.md
@@ -68,3 +68,26 @@ model = dict(
 通过这种方式，确定训练过程中损失函数的权重 `loss_weight` 和在训练日志里的名字 `loss_name`。
 
 注意： `loss_name` 的名字必须带有 `loss_` 前缀，这样它才能被包括在反传的图里。
+
+## 在损失函数中忽略特定的 label 类别
+
+对于训练时损失函数的计算，我们目前支持使用 `avg_non_ignore` 和 `ignore_index` 来忽略 label 特定的类别。 以 `unet` 使用 `DRIVE` 数据集训练为例，
+在计算损失函数时，忽略 label 为0的背景，并且仅在不被忽略的像素上计算均值。配置文件写为:
+
+```python
+_base_ = './fcn_unet_s5-d16_64x64_40k_drive.py'
+model = dict(
+    decode_head=dict(
+        ignore_index=0,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0, avg_non_ignore=True),
+    auxiliary_head=dict(
+        ignore_index=0,
+        loss_decode=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0, avg_non_ignore=True)),
+    ))
+```
+
+通过这种方式，确定训练过程中损失函数的权重 `loss_weight` 和在训练日志里的名字 `loss_name`。
+
+注意： `loss_name` 的名字必须带有 `loss_` 前缀，这样它才能被包括在反传的图里。

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -110,7 +110,8 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
         """Extra repr."""
         s = f'input_transform={self.input_transform}, ' \
             f'ignore_index={self.ignore_index}, ' \
-            f'align_corners={self.align_corners}'
+            f'align_corners={self.align_corners}' \
+            f'avg_non_ignore={self.avg_non_ignore}'
         return s
 
     def _init_inputs(self, in_channels, in_index, input_transform):

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -110,8 +110,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
         """Extra repr."""
         s = f'input_transform={self.input_transform}, ' \
             f'ignore_index={self.ignore_index}, ' \
-            f'align_corners={self.align_corners}' \
-            f'avg_non_ignore={self.avg_non_ignore}'
+            f'align_corners={self.align_corners}'
         return s
 
     def _init_inputs(self, in_channels, in_index, input_transform):

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -37,6 +37,7 @@ def cross_entropy(pred,
             Defaults: -100.
         avg_non_ignore (bool): The flag decides to whether the loss is
             only averaged over non-ignored targets. Default: False.
+            `New in version 0.23.0.`
     """
 
     # class_weight is a manual rescaling weight given to each class.
@@ -110,6 +111,7 @@ def binary_cross_entropy(pred,
             Default: -100.
         avg_non_ignore (bool): The flag decides to whether the loss is
             only averaged over non-ignored targets. Default: False.
+            `New in version 0.23.0.`
 
     Returns:
         torch.Tensor: The calculated loss
@@ -130,7 +132,7 @@ def binary_cross_entropy(pred,
             weight *= valid_mask
         else:
             weight = valid_mask
-    # average loss over non-ignored elements
+    # average loss over non-ignored and valid elements
     if reduction == 'mean' and avg_factor is None and avg_non_ignore:
         avg_factor = valid_mask.sum().item()
 
@@ -201,6 +203,7 @@ class CrossEntropyLoss(nn.Module):
             prefix of the name. Defaults to 'loss_ce'.
         avg_non_ignore (bool): The flag decides to whether the loss is
             only averaged over non-ignored targets. Default: False.
+            `New in version 0.23.0.`
     """
 
     def __init__(self,
@@ -255,7 +258,7 @@ class CrossEntropyLoss(nn.Module):
             class_weight = cls_score.new_tensor(self.class_weight)
         else:
             class_weight = None
-        # Note: In cls_criterion, label < 0 is invalid.
+        # Note: for BCE loss, label < 0 is invalid.
         loss_cls = self.loss_weight * self.cls_criterion(
             cls_score,
             label,

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -109,6 +109,7 @@ def binary_cross_entropy(pred,
             Default: -100.
         avg_non_ignore (bool): The flag decides to whether the loss is
             only averaged over non-ignored targets. Default: False.
+
     Returns:
         torch.Tensor: The calculated loss
     """

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -27,7 +27,7 @@ def cross_entropy(pred,
         class_weight (list[float], optional): The weight for each class.
             Default: None.
         reduction (str, optional): The method used to reduce the loss.
-            Options are "none", "mean" and "sum". Default: 'mean'.
+            Options are 'none', 'mean' and 'sum'. Default: 'mean'.
         avg_factor (int, optional): Average factor that is used to average
             the loss. Default: None.
         ignore_index (int): Specifies a target value that is ignored and
@@ -149,7 +149,7 @@ def mask_cross_entropy(pred,
                        reduction='mean',
                        avg_factor=None,
                        class_weight=None,
-                       ignore_index=-100,
+                       ignore_index=None,
                        **kwargs):
     """Calculate the CrossEntropy loss for masks.
 
@@ -167,7 +167,7 @@ def mask_cross_entropy(pred,
             the loss. Defaults to None.
         class_weight (list[float], optional): The weight for each class.
         ignore_index (None): Placeholder, to be consistent with other loss.
-            Default: -100.
+            Default: None.
 
     Returns:
         torch.Tensor: The calculated loss

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -107,8 +107,7 @@ def binary_cross_entropy(pred,
         avg_factor (int, optional): Average factor that is used to average
             the loss. Defaults to None.
         class_weight (list[float], optional): The weight for each class.
-        ignore_index (int): The label index to be ignored.
-            Default: -100.
+        ignore_index (int): The label index to be ignored. Default: -100.
         avg_non_ignore (bool): The flag decides to whether the loss is
             only averaged over non-ignored targets. Default: False.
             `New in version 0.23.0.`

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -228,6 +228,11 @@ class CrossEntropyLoss(nn.Module):
             self.cls_criterion = cross_entropy
         self._loss_name = loss_name
 
+    def extra_repr(self):
+        """Extra repr."""
+        s = f'avg_non_ignore={self.avg_non_ignore}'
+        return s
+
     def forward(self,
                 cls_score,
                 label,

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -131,7 +131,7 @@ def binary_cross_entropy(pred,
         else:
             weight = valid_mask
     # average loss over non-ignored elements
-    if reduction == 'mean' and avg_factor is None:
+    if reduction == 'mean' and avg_factor is None and avg_non_ignore:
         avg_factor = valid_mask.sum().item()
 
     loss = F.binary_cross_entropy_with_logits(

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -106,7 +106,7 @@ def binary_cross_entropy(pred,
         avg_factor (int, optional): Average factor that is used to average
             the loss. Defaults to None.
         class_weight (list[float], optional): The weight for each class.
-        ignore_index (int | None): The label index to be ignored.
+        ignore_index (int): The label index to be ignored.
             Default: -100.
         avg_non_ignore (bool): The flag decides to whether the loss is
             only averaged over non-ignored targets. Default: False.

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -17,7 +17,7 @@ def cross_entropy(pred,
                   avg_factor=None,
                   ignore_index=-100,
                   avg_non_ignore=False):
-    """cross_entropy.
+    """cross_entropy. The wrapper function for :func:`F.cross_entropy`
 
     Args:
         pred (torch.Tensor): The prediction with shape (N, 1).
@@ -38,7 +38,7 @@ def cross_entropy(pred,
         avg_non_ignore (bool): The flag decides to whether the loss is
             only averaged over non-ignored targets. Default: False.
     """
-    """The wrapper function for :func:`F.cross_entropy`"""
+
     # class_weight is a manual rescaling weight given to each class.
     # If given, has to be a Tensor of size C element-wise losses
     loss = F.cross_entropy(
@@ -115,6 +115,8 @@ def binary_cross_entropy(pred,
                 pred.dim() == 4 and label.dim() == 3), \
             'Only pred shape [N, C], label shape [N] or pred shape [N, C, ' \
             'H, W], label shape [N, H, W] are supported'
+        # `weight` returned from `_expand_onehot_labels`
+        # has been treated for valid (non-ignore) pixels
         label, weight = _expand_onehot_labels(label, weight, pred.shape,
                                               ignore_index)
     else:

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import warnings
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -13,7 +15,29 @@ def cross_entropy(pred,
                   class_weight=None,
                   reduction='mean',
                   avg_factor=None,
-                  ignore_index=-100):
+                  ignore_index=-100,
+                  avg_non_ignore=False):
+    """cross_entropy.
+
+    Args:
+        pred (torch.Tensor): The prediction with shape (N, 1).
+        label (torch.Tensor): The learning label of the prediction.
+        weight (torch.Tensor, optional): Sample-wise loss weight.
+            Default: None.
+        class_weight (list[float], optional): The weight for each class.
+            Default: None.
+        reduction (str, optional): The method used to reduce the loss.
+            Options are "none", "mean" and "sum". Default: 'mean'.
+        avg_factor (int, optional): Average factor that is used to average
+            the loss. Default: None.
+        ignore_index (int): Specifies a target value that is ignored and
+            does not contribute to the input gradients. When
+            ``avg_non_ignore `` is ``True``, and the ``reduction`` is
+            ``''mean''``, the loss is averaged over non-ignored targets.
+            Defaults: -100.
+        avg_non_ignore (bool): The flag decides to whether the loss is
+            only averaged over non-ignored targets. Default: False.
+    """
     """The wrapper function for :func:`F.cross_entropy`"""
     # class_weight is a manual rescaling weight given to each class.
     # If given, has to be a Tensor of size C element-wise losses
@@ -25,6 +49,11 @@ def cross_entropy(pred,
         ignore_index=ignore_index)
 
     # apply weights and do the reduction
+    # average loss over non-ignored elements
+    # pytorch's official cross_entropy average loss over non-ignored elements
+    # refer to https://github.com/pytorch/pytorch/blob/56b43f4fec1f76953f15a627694d4bba34588969/torch/nn/functional.py#L2660  # noqa
+    if (avg_factor is None) and avg_non_ignore:
+        avg_factor = label.numel() - (label == ignore_index).sum().item()
     if weight is not None:
         weight = weight.float()
     loss = weight_reduce_loss(
@@ -61,7 +90,9 @@ def binary_cross_entropy(pred,
                          reduction='mean',
                          avg_factor=None,
                          class_weight=None,
-                         ignore_index=255):
+                         ignore_index=255,
+                         avg_non_ignore=False,
+                         **kwargs):
     """Calculate the binary CrossEntropy loss.
 
     Args:
@@ -73,8 +104,9 @@ def binary_cross_entropy(pred,
         avg_factor (int, optional): Average factor that is used to average
             the loss. Defaults to None.
         class_weight (list[float], optional): The weight for each class.
-        ignore_index (int | None): The label index to be ignored. Default: 255
-
+        ignore_index (int | None): The label index to be ignored. Default: 255.
+        avg_non_ignore (bool): The flag decides to whether the loss is
+            only averaged over non-ignored targets. Default: False.
     Returns:
         torch.Tensor: The calculated loss
     """
@@ -85,10 +117,17 @@ def binary_cross_entropy(pred,
             'H, W], label shape [N, H, W] are supported'
         label, weight = _expand_onehot_labels(label, weight, pred.shape,
                                               ignore_index)
+    else:
+        # should mask out the ignored elements
+        valid_mask = ((label >= 0) & (label != ignore_index)).float()
+        if weight is not None:
+            weight *= valid_mask
+        else:
+            weight = valid_mask
+    # average loss over non-ignored elements
+    if avg_factor is None:
+        avg_factor = label.numel() - (label == ignore_index).sum().item()
 
-    # weighted element-wise losses
-    if weight is not None:
-        weight = weight.float()
     loss = F.binary_cross_entropy_with_logits(
         pred, label.float(), pos_weight=class_weight, reduction='none')
     # do the reduction for the weighted loss
@@ -104,7 +143,8 @@ def mask_cross_entropy(pred,
                        reduction='mean',
                        avg_factor=None,
                        class_weight=None,
-                       ignore_index=None):
+                       ignore_index=None,
+                       **kwargs):
     """Calculate the CrossEntropy loss for masks.
 
     Args:
@@ -153,6 +193,8 @@ class CrossEntropyLoss(nn.Module):
         loss_name (str, optional): Name of the loss item. If you want this loss
             item to be included into the backward graph, `loss_` must be the
             prefix of the name. Defaults to 'loss_ce'.
+        avg_non_ignore (bool): The flag decides to whether the loss is
+            only averaged over non-ignored targets. Default: False.
     """
 
     def __init__(self,
@@ -161,7 +203,8 @@ class CrossEntropyLoss(nn.Module):
                  reduction='mean',
                  class_weight=None,
                  loss_weight=1.0,
-                 loss_name='loss_ce'):
+                 loss_name='loss_ce',
+                 avg_non_ignore=False):
         super(CrossEntropyLoss, self).__init__()
         assert (use_sigmoid is False) or (use_mask is False)
         self.use_sigmoid = use_sigmoid
@@ -169,6 +212,13 @@ class CrossEntropyLoss(nn.Module):
         self.reduction = reduction
         self.loss_weight = loss_weight
         self.class_weight = get_class_weight(class_weight)
+        self.avg_non_ignore = avg_non_ignore
+        if not self.avg_non_ignore and self.reduction == 'mean':
+            warnings.warn(
+                'Default ``avg_non_ignore`` is False, if you would like to '
+                'ignore certain label and average loss over non-ignore label, '
+                'set ``avg_non_ignore=True``, and the loss will be '
+                'slightly larger.')
 
         if self.use_sigmoid:
             self.cls_criterion = binary_cross_entropy
@@ -200,6 +250,7 @@ class CrossEntropyLoss(nn.Module):
             class_weight=class_weight,
             reduction=reduction,
             avg_factor=avg_factor,
+            avg_non_ignore=self.avg_non_ignore,
             **kwargs)
         return loss_cls
 

--- a/mmseg/models/losses/utils.py
+++ b/mmseg/models/losses/utils.py
@@ -3,6 +3,7 @@ import functools
 
 import mmcv
 import numpy as np
+import torch
 import torch.nn.functional as F
 
 
@@ -69,7 +70,10 @@ def weight_reduce_loss(loss, weight=None, reduction='mean', avg_factor=None):
     else:
         # if reduction is mean, then average the loss by avg_factor
         if reduction == 'mean':
-            loss = loss.sum() / avg_factor
+            # Avoid causing ZeroDivisionError when avg_factor is 0.0,
+            # i.e., all labels of an image belong to ignore index.
+            eps = torch.finfo(torch.float32).eps
+            loss = loss.sum() / (avg_factor + eps)
         # if reduction is 'none', then do nothing, otherwise raise an error
         elif reduction != 'none':
             raise ValueError('avg_factor can not be used with reduction="sum"')

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -86,4 +86,85 @@ def test_ce_loss():
         loss_name='loss_ce')
     loss_cls = build_loss(loss_cls_cfg)
     assert loss_cls.loss_name == 'loss_ce'
+
+    # test ce loss with ignore index
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
+    fake_label[1, [0, 5, 8, 9]] = 10
+    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, ignore_index=10, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    # test ignore index and class_weight
+    class_weight = torch.rand(5)
+    class_weight /= class_weight.sum()
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=class_weight,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred,
+        fake_label,
+        ignore_index=10,
+        reduction='sum',
+        weight=class_weight) / 12.0
+    assert torch.allclose(loss, torch_loss)
+
+    # test bce loss
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 10).float()
+    fake_label = torch.rand(2, 10).float()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    fake_label[0, [1, 2, 5, 7]] = -1  # set ignore_index
+    fake_label[1, [0, 5, 8, 9]] = -1
+    loss = loss_cls(fake_pred, fake_label, ignore_index=-1)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred[fake_label != -1],
+        fake_label[fake_label != -1],
+        reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    # test ignore index and weight
+    weight = torch.rand(2, 10)
+    loss = loss_cls(fake_pred, fake_label, weight=weight, ignore_index=-1)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred[fake_label != -1],
+        fake_label[fake_label != -1],
+        reduction='mean',
+        weight=weight[fake_label != -1])
+    assert torch.allclose(loss, torch_loss)
+
     # TODO test use_mask

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -3,7 +3,10 @@ import pytest
 import torch
 
 
-def test_ce_loss():
+@pytest.mark.parametrize('use_sigmoid', [True, False])
+@pytest.mark.parametrize('reduction', ('mean', 'sum', 'none'))
+@pytest.mark.parametrize('avg_non_ignore', [True, False])
+def test_ce_loss(use_sigmoid, reduction, avg_non_ignore):
     from mmseg.models import build_loss
 
     # use_mask and use_sigmoid cannot be true at the same time
@@ -15,20 +18,58 @@ def test_ce_loss():
             loss_weight=1.0)
         build_loss(loss_cfg)
 
-    # test loss with class weights
+    # test loss with simple case for ce/bce
     loss_cls_cfg = dict(
         type='CrossEntropyLoss',
-        use_sigmoid=False,
-        class_weight=[0.8, 0.2],
+        use_sigmoid=use_sigmoid,
         loss_weight=1.0,
+        avg_non_ignore=avg_non_ignore,
         loss_name='loss_ce')
     loss_cls = build_loss(loss_cls_cfg)
-    assert loss_cls.extra_repr() == 'avg_non_ignore=False'
+
     fake_pred = torch.Tensor([[100, -100]])
     fake_label = torch.Tensor([1]).long()
-    assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(40.))
+    if use_sigmoid:
+        assert torch.allclose(
+            loss_cls(fake_pred, fake_label), torch.tensor(100.))
+    else:
+        assert torch.allclose(
+            loss_cls(fake_pred, fake_label), torch.tensor(200.))
+
+    fake_pred = torch.full(size=(2, 21, 8, 8), fill_value=0.5)
+    fake_label = torch.ones(2, 8, 8).long()
+    fake_label[:, 0, 0] = 255
+
+    # test loss with complicated case for ce/bce
+    # when avg_non_ignore is False, `avg_factor` would not be calculated
+    if use_sigmoid:
+        if avg_non_ignore:
+            assert torch.allclose(
+                loss_cls(fake_pred, fake_label, ignore_index=255),
+                torch.tensor(0.9503),
+                atol=1e-4)
+        else:
+            loss_cls = build_loss(loss_cls_cfg)
+            assert torch.allclose(
+                loss_cls(fake_pred, fake_label, ignore_index=255),
+                torch.tensor(0.9354),
+                atol=1e-4)
+    else:
+        if avg_non_ignore:
+            assert torch.allclose(
+                loss_cls(fake_pred, fake_label, ignore_index=255),
+                torch.tensor(3.0445),
+                atol=1e-4)
+        else:
+            loss_cls = build_loss(loss_cls_cfg)
+            assert torch.allclose(
+                loss_cls(fake_pred, fake_label, ignore_index=255),
+                torch.tensor(2.9970),
+                atol=1e-4)
 
     # test loss with class weights from file
+    fake_pred = torch.Tensor([[100, -100]])
+    fake_label = torch.Tensor([1]).long()
     import os
     import tempfile
 
@@ -64,369 +105,89 @@ def test_ce_loss():
     loss_cls = build_loss(loss_cls_cfg)
     assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(200.))
 
+    # test `avg_non_ignore` would not affect ce/bce loss
+    # when reduction='sum'/'none'/'mean'
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=use_sigmoid,
+        reduction=reduction,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=use_sigmoid,
+        reduction=reduction,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+    assert torch.allclose(
+        loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        atol=1e-4)
+
+    # test ce/bce loss with ignore index and class weight
+    # in 5-way classification
+    if use_sigmoid:
+        fake_pred = torch.randn(2, 10).float()
+        fake_label = torch.rand(2, 10).float()
+        class_weight = torch.rand(2, 10)
+        torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+            fake_pred, fake_label, reduction='mean', pos_weight=class_weight)
+    else:
+        fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+        fake_label = torch.randint(0, 5, (2, 10)).long()
+        class_weight = torch.rand(5)
+        class_weight /= class_weight.sum()
+        torch_loss = torch.nn.functional.cross_entropy(
+            fake_pred, fake_label, reduction='sum',
+            weight=class_weight) / fake_label.numel()
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=use_sigmoid,
+        reduction='mean',
+        class_weight=class_weight,
+        loss_weight=1.0,
+        avg_non_ignore=avg_non_ignore)
+    loss_cls = build_loss(loss_cls_cfg)
+
     # test cross entropy loss has name `loss_ce`
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        loss_weight=1.0,
-        loss_name='loss_ce')
-    loss_cls = build_loss(loss_cls_cfg)
     assert loss_cls.loss_name == 'loss_ce'
+    # test avg_non_ignore is in extra_repr
+    assert loss_cls.extra_repr() == f'avg_non_ignore={avg_non_ignore}'
 
-    # test avg_non_ignore would not affect ce
-    # when reduction='sum'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='sum',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='sum',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        atol=1e-4)
-
-    # test avg_non_ignore would not affect ce
-    # when reduction='none'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='none',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='none',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        atol=1e-4)
-
-    # test avg_non_ignore would not affect ce
-    # when reduction='mean'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        atol=1e-4)
-
-    # test ce loss with ignore index in 5-way classification
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss1 = loss_cls1(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss1, torch_loss)
-    loss2 = loss_cls2(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss2, torch_loss)
-
-    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
-    fake_label[1, [0, 5, 8, 9]] = 10
-    loss1 = loss_cls1(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, ignore_index=10, reduction='mean')
-    assert torch.allclose(loss1, torch_loss)
-    # when `avg_non_ignore=False`, and `ignore_index=10`
-    loss2 = loss_cls2(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, ignore_index=10,
-        reduction='sum') / fake_label.numel()
-    assert torch.allclose(loss2, torch_loss)
-
-    # test test ce loss
-    # with ignore index and class_weight
-    class_weight = torch.rand(5)
-    class_weight /= class_weight.sum()
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=class_weight,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=class_weight,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    loss1 = loss_cls1(fake_pred, fake_label, ignore_index=10)
-    loss2 = loss_cls2(fake_pred, fake_label, ignore_index=10)
-
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred,
-        fake_label,
-        ignore_index=10,
-        reduction='sum',
-        weight=class_weight) / 12.0
-    assert torch.allclose(loss1, torch_loss)
-
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred,
-        fake_label,
-        ignore_index=10,
-        reduction='sum',
-        weight=class_weight) / fake_label.numel()
-    assert torch.allclose(loss2, torch_loss)
-
-    # test ce loss
-    # without ignore index and avg_non_ignore
-    # doesn't affect the results
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
     loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='mean')
     assert torch.allclose(loss, torch_loss)
 
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='sum') / fake_label.numel()
-    assert torch.allclose(loss, torch_loss)
-
-    # test ce loss with ignore index and reduction='none'
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='none',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='none')
-    assert torch.allclose(loss, torch_loss)
-
-    # test ce loss with ignore index and reduction='sum'
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='sum',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='sum')
-    assert torch.allclose(loss, torch_loss)
-    # TODO test use_mask
-
-
-def test_bce_loss():
-    from mmseg.models import build_loss
-    fake_pred = torch.Tensor([[100, -100]])
-    fake_label = torch.Tensor([1]).long()
-
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0)
-    loss_cls = build_loss(loss_cls_cfg)
-    assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(100.))
-
-    # test results in different situation
-    # such as `avg_non_ignore`, `reduction` in bce loss.
-    fake_pred = torch.full(size=(2, 21, 8, 8), fill_value=0.5)
-    fake_label = torch.ones(2, 8, 8).long()
-    assert torch.allclose(
-        loss_cls(fake_pred, fake_label), torch.tensor(0.9503), atol=1e-4)
-
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-    fake_label[:, 0, 0] = 255
-    assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255),
-        torch.tensor(0.9503),
-        atol=1e-4)
-
-    # test avg_non_ignore=False for bce
-    # in this case, `avg_factor` would not be calculated
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
-    assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255),
-        torch.tensor(0.9354),
-        atol=1e-4)
-
-    # test avg_non_ignore would not affect bce
-    # when reduction='sum'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='sum',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='sum',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        atol=1e-4)
-
-    # test avg_non_ignore would not affect bce
-    # when reduction='none'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='none',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='none',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        atol=1e-4)
-
-    # test avg_non_ignore would not affect bce
-    # when reduction='mean'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='mean',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='mean',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        atol=1e-4)
-
-    # test bce loss
-    # without ignore index and avg_non_ignore
-    # doesn't affect the results
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 10).float()
-    fake_label = torch.rand(2, 10).float()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss, torch_loss)
-
-    # test bce loss
-    # with ignore index and avg_non_ignore=False
-    # doesn't affect the results
     fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
     fake_label[1, [0, 5, 8, 9]] = 10
     loss = loss_cls(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred[fake_label != 10],
-        fake_label[fake_label != 10],
-        reduction='sum') / fake_label.numel()
-    assert torch.allclose(loss, torch_loss)
-
-    # test bce
-    # with ignore index and weight and avg_non_ignore=False
-    fake_pred = torch.randn(2, 10).float()
-    fake_label = torch.rand(2, 10).float()
-    weight = torch.rand(2, 10)
-    loss = loss_cls(fake_pred, fake_label, weight=weight, ignore_index=10)
-    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred[fake_label != 10],
-        fake_label[fake_label != 10],
-        reduction='mean',
-        weight=weight[fake_label != 10])
+    if use_sigmoid:
+        if not avg_non_ignore:
+            torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+                fake_pred[fake_label != 10],
+                fake_label[fake_label != 10],
+                pos_weight=class_weight[fake_label != 10],
+                reduction='sum') / fake_label.numel()
+        else:
+            torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+                fake_pred[fake_label != 10],
+                fake_label[fake_label != 10],
+                pos_weight=class_weight[fake_label != 10],
+                reduction='mean')
+    else:
+        if avg_non_ignore:
+            torch_loss = torch.nn.functional.cross_entropy(
+                fake_pred,
+                fake_label,
+                ignore_index=10,
+                reduction='sum',
+                weight=class_weight) / fake_label[fake_label != 10].numel()
+        else:
+            torch_loss = torch.nn.functional.cross_entropy(
+                fake_pred,
+                fake_label,
+                ignore_index=10,
+                reduction='sum',
+                weight=class_weight) / fake_label.numel()
     assert torch.allclose(loss, torch_loss)

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -28,34 +28,6 @@ def test_ce_loss():
     fake_label = torch.Tensor([1]).long()
     assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(40.))
 
-    # test loss with class weights, reduction='none'
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        class_weight=[0.8, 0.2],
-        loss_weight=1.0,
-        reduction='none',
-        loss_name='loss_ce')
-    loss_cls = build_loss(loss_cls_cfg)
-    loss_cls.extra_repr()
-    fake_pred = torch.Tensor([[100, -100]])
-    fake_label = torch.Tensor([1]).long()
-    assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(40.))
-
-    # test loss with class weights, reduction='sum'
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        class_weight=[0.8, 0.2],
-        loss_weight=1.0,
-        reduction='sum',
-        loss_name='loss_ce')
-    loss_cls = build_loss(loss_cls_cfg)
-    loss_cls.extra_repr()
-    fake_pred = torch.Tensor([[100, -100]])
-    fake_label = torch.Tensor([1]).long()
-    assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(40.))
-
     # test loss with class weights from file
     import os
     import tempfile
@@ -92,13 +64,232 @@ def test_ce_loss():
     loss_cls = build_loss(loss_cls_cfg)
     assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(200.))
 
+    # test cross entropy loss has name `loss_ce`
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        loss_weight=1.0,
+        loss_name='loss_ce')
+    loss_cls = build_loss(loss_cls_cfg)
+    assert loss_cls.loss_name == 'loss_ce'
+
+    # test avg_non_ignore would not affect ce
+    # when reduction='sum'
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='sum',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='sum',
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+    assert torch.allclose(
+        loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        atol=1e-4)
+
+    # test avg_non_ignore would not affect ce
+    # when reduction='none'
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='none',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='none',
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+    assert torch.allclose(
+        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        atol=1e-4)
+
+    # test avg_non_ignore would not affect ce
+    # when reduction='mean'
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+    assert torch.allclose(
+        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        atol=1e-4)
+
+    # test ce loss with ignore index in 5-way classification
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss1 = loss_cls1(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss1, torch_loss)
+    loss2 = loss_cls2(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss2, torch_loss)
+
+    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
+    fake_label[1, [0, 5, 8, 9]] = 10
+    loss1 = loss_cls1(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, ignore_index=10, reduction='mean')
+    assert torch.allclose(loss1, torch_loss)
+    # when `avg_non_ignore=False`, and `ignore_index=10`
+    loss2 = loss_cls2(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, ignore_index=10,
+        reduction='sum') / fake_label.numel()
+    assert torch.allclose(loss2, torch_loss)
+
+    # test test ce loss
+    # with ignore index and class_weight
+    class_weight = torch.rand(5)
+    class_weight /= class_weight.sum()
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=class_weight,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=class_weight,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+    loss1 = loss_cls1(fake_pred, fake_label, ignore_index=10)
+    loss2 = loss_cls2(fake_pred, fake_label, ignore_index=10)
+
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred,
+        fake_label,
+        ignore_index=10,
+        reduction='sum',
+        weight=class_weight) / 12.0
+    assert torch.allclose(loss1, torch_loss)
+
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred,
+        fake_label,
+        ignore_index=10,
+        reduction='sum',
+        weight=class_weight) / fake_label.numel()
+    assert torch.allclose(loss2, torch_loss)
+
+    # test ce loss
+    # without ignore index and avg_non_ignore
+    # doesn't affect the results
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='sum') / fake_label.numel()
+    assert torch.allclose(loss, torch_loss)
+
+    # test ce loss with ignore index and reduction='none'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='none',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='none')
+    assert torch.allclose(loss, torch_loss)
+
+    # test ce loss with ignore index and reduction='sum'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='sum',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='sum')
+    assert torch.allclose(loss, torch_loss)
+    # TODO test use_mask
+
+
+def test_bce_loss():
+    from mmseg.models import build_loss
+    fake_pred = torch.Tensor([[100, -100]])
+    fake_label = torch.Tensor([1]).long()
+
     loss_cls_cfg = dict(
         type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0)
     loss_cls = build_loss(loss_cls_cfg)
     assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(100.))
 
     # test results in different situation
-    # such as `avg_non_ignore`, `reduction` in ce and bce loss.
+    # such as `avg_non_ignore`, `reduction` in bce loss.
     fake_pred = torch.full(size=(2, 21, 8, 8), fill_value=0.5)
     fake_label = torch.ones(2, 8, 8).long()
     assert torch.allclose(
@@ -124,18 +315,11 @@ def test_ce_loss():
         loss_weight=1.0,
         avg_non_ignore=False)
     loss_cls = build_loss(loss_cls_cfg)
-    fake_label[:, 0, 0] = 255
     assert torch.allclose(
         loss_cls(fake_pred, fake_label, ignore_index=255),
         torch.tensor(0.9354),
         atol=1e-4)
 
-    # test avg_non_ignore would not affect bce/ce
-    # when reduction='sum'/'mean'/'none'
-    fake_pred = torch.full(size=(2, 21, 8, 8), fill_value=0.5)
-    fake_label = torch.ones(2, 8, 8).long()
-    fake_label[:, 0, 0] = 255
-
     # test avg_non_ignore would not affect bce
     # when reduction='sum'
     loss_cls_cfg1 = dict(
@@ -202,222 +386,6 @@ def test_ce_loss():
         loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
         fake_pred.numel(),
         atol=1e-4)
-
-    # test avg_non_ignore would not affect ce
-    # when reduction='sum'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='sum',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='sum',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        atol=1e-4)
-
-    # test avg_non_ignore would not affect ce
-    # when reduction='none'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='none',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='none',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        atol=1e-4)
-
-    # test avg_non_ignore would not affect ce
-    # when reduction='mean'
-    loss_cls_cfg1 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls1 = build_loss(loss_cls_cfg1)
-    loss_cls_cfg2 = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls2 = build_loss(loss_cls_cfg2)
-    assert torch.allclose(
-        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        atol=1e-4)
-
-    # test cross entropy loss has name `loss_ce`
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        loss_weight=1.0,
-        loss_name='loss_ce')
-    loss_cls = build_loss(loss_cls_cfg)
-    assert loss_cls.loss_name == 'loss_ce'
-
-    # test ce loss with ignore index
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss, torch_loss)
-
-    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
-    fake_label[1, [0, 5, 8, 9]] = 10
-    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, ignore_index=10, reduction='mean')
-    assert torch.allclose(loss, torch_loss)
-
-    # test ce loss with ignore index
-    # avg_non_ignore=False
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss, torch_loss)
-
-    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
-    fake_label[1, [0, 5, 8, 9]] = 10
-    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, ignore_index=10,
-        reduction='sum') / fake_label.numel()
-    assert torch.allclose(loss, torch_loss)
-
-    # test ignore index and class_weight
-    class_weight = torch.rand(5)
-    class_weight /= class_weight.sum()
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=class_weight,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred,
-        fake_label,
-        ignore_index=10,
-        reduction='sum',
-        weight=class_weight) / 12.0
-    assert torch.allclose(loss, torch_loss)
-
-    # test ignore index and class_weight
-    # avg_non_ignore=False
-    class_weight = torch.rand(5)
-    class_weight /= class_weight.sum()
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=class_weight,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
-    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred,
-        fake_label,
-        ignore_index=10,
-        reduction='sum',
-        weight=class_weight) / fake_label.numel()
-    assert torch.allclose(loss, torch_loss)
-
-    # test ce loss
-    # without ignore index and avg_non_ignore
-    # doesn't affect the results
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss, torch_loss)
-
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='sum') / fake_label.numel()
-    assert torch.allclose(loss, torch_loss)
-
-    # test bce loss
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=True,
-        reduction='mean',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 10).float()
-    fake_label = torch.rand(2, 10).float()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss, torch_loss)
-
-    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
-    fake_label[1, [0, 5, 8, 9]] = 10
-    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
-    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred[fake_label != 10],
-        fake_label[fake_label != 10],
-        reduction='mean')
-    assert torch.allclose(loss, torch_loss)
 
     # test bce loss
     # without ignore index and avg_non_ignore
@@ -450,15 +418,10 @@ def test_ce_loss():
         reduction='sum') / fake_label.numel()
     assert torch.allclose(loss, torch_loss)
 
-    fake_pred = torch.randn(2, 10).float()
-    fake_label = torch.rand(2, 10).float()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred, fake_label, reduction='mean')
-    assert torch.allclose(loss, torch_loss)
-
     # test bce
     # with ignore index and weight and avg_non_ignore=False
+    fake_pred = torch.randn(2, 10).float()
+    fake_label = torch.rand(2, 10).float()
     weight = torch.rand(2, 10)
     loss = loss_cls(fake_pred, fake_label, weight=weight, ignore_index=10)
     torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
@@ -467,56 +430,3 @@ def test_ce_loss():
         reduction='mean',
         weight=weight[fake_label != 10])
     assert torch.allclose(loss, torch_loss)
-
-    # test ce loss with ignore index and reduction='none'
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='none',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='none')
-    assert torch.allclose(loss, torch_loss)
-
-    # test ce loss with ignore index and reduction='sum'
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='sum',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='sum')
-    assert torch.allclose(loss, torch_loss)
-
-    # test ce loss with ignore index and reduction='none'
-    loss_cls_cfg = dict(
-        type='CrossEntropyLoss',
-        use_sigmoid=False,
-        reduction='none',
-        class_weight=None,
-        loss_weight=1.0,
-        avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-
-    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
-    fake_label = torch.randint(0, 5, (2, 10)).long()
-    loss = loss_cls(fake_pred, fake_label)
-    torch_loss = torch.nn.functional.cross_entropy(
-        fake_pred, fake_label, reduction='none')
-    assert torch.allclose(loss, torch_loss)
-
-    # TODO test use_mask

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -114,6 +114,82 @@ def test_ce_loss():
         torch.tensor(0.9503),
         atol=1e-4)
 
+    # test avg_non_ignore=False for bce
+    # in this case, `avg_factor` would not be calculated
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls = build_loss(loss_cls_cfg)
+    fake_label[:, 0, 0] = 255
+    assert torch.allclose(
+        loss_cls(fake_pred, fake_label, ignore_index=255),
+        torch.tensor(0.9354),
+        atol=1e-4)
+
+    # test avg_non_ignore=True would not affect bce
+    # when reduction='sum'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='sum',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+    fake_label[:, 0, 0] = 255
+    assert torch.allclose(
+        loss_cls(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        torch.tensor(0.9354),
+        atol=1e-4)
+
+    # test avg_non_ignore=True would not affect bce
+    # when reduction='none'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='none',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+    fake_label[:, 0, 0] = 255
+    assert torch.allclose(
+        loss_cls(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        torch.tensor(0.9354),
+        atol=1e-4)
+
+    # test avg_non_ignore=True would not affect ce
+    # when reduction='sum'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='sum',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+    fake_label[:, 0, 0] = 255
+    assert torch.allclose(
+        loss_cls(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        torch.tensor(0.1427),
+        atol=1e-4)
+
+    # test avg_non_ignore=True would not affect ce
+    # when reduction='none'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='none',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+    fake_label[:, 0, 0] = 255
+    assert torch.allclose(
+        loss_cls(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        torch.tensor(0.1427),
+        atol=1e-4)
+
     # test cross entropy loss has name `loss_ce`
     loss_cls_cfg = dict(
         type='CrossEntropyLoss',

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -149,23 +149,23 @@ def test_ce_loss():
         fake_pred, fake_label, reduction='mean')
     assert torch.allclose(loss, torch_loss)
 
-    fake_label[0, [1, 2, 5, 7]] = -1  # set ignore_index
-    fake_label[1, [0, 5, 8, 9]] = -1
-    loss = loss_cls(fake_pred, fake_label, ignore_index=-1)
+    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
+    fake_label[1, [0, 5, 8, 9]] = 10
+    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
     torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred[fake_label != -1],
-        fake_label[fake_label != -1],
+        fake_pred[fake_label != 10],
+        fake_label[fake_label != 10],
         reduction='mean')
     assert torch.allclose(loss, torch_loss)
 
     # test ignore index and weight
     weight = torch.rand(2, 10)
-    loss = loss_cls(fake_pred, fake_label, weight=weight, ignore_index=-1)
+    loss = loss_cls(fake_pred, fake_label, weight=weight, ignore_index=10)
     torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
-        fake_pred[fake_label != -1],
-        fake_label[fake_label != -1],
+        fake_pred[fake_label != 10],
+        fake_label[fake_label != 10],
         reduction='mean',
-        weight=weight[fake_label != -1])
+        weight=weight[fake_label != 10])
     assert torch.allclose(loss, torch_loss)
 
     # TODO test use_mask

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -23,7 +23,7 @@ def test_ce_loss():
         loss_weight=1.0,
         loss_name='loss_ce')
     loss_cls = build_loss(loss_cls_cfg)
-    loss_cls.extra_repr
+    loss_cls.extra_repr()
     fake_pred = torch.Tensor([[100, -100]])
     fake_label = torch.Tensor([1]).long()
     assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(40.))
@@ -166,6 +166,40 @@ def test_ce_loss():
         fake_label[fake_label != 10],
         reduction='mean',
         weight=weight[fake_label != 10])
+    assert torch.allclose(loss, torch_loss)
+
+    # test ce loss with ignore index and reduction='none'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='none',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='none')
+    assert torch.allclose(loss, torch_loss)
+
+    # test ce loss with ignore index and reduction='sum'
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='sum',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='sum')
     assert torch.allclose(loss, torch_loss)
 
     # TODO test use_mask

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -231,7 +231,6 @@ def test_ce_loss():
     assert loss_cls.loss_name == 'loss_ce'
 
     # test ce loss with ignore index
-    # avg_non_ignore=True
     loss_cls_cfg = dict(
         type='CrossEntropyLoss',
         use_sigmoid=False,
@@ -255,6 +254,32 @@ def test_ce_loss():
         fake_pred, fake_label, ignore_index=10, reduction='mean')
     assert torch.allclose(loss, torch_loss)
 
+    # test ce loss with ignore index
+    # avg_non_ignore=False
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
+    fake_label[1, [0, 5, 8, 9]] = 10
+    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, ignore_index=10,
+        reduction='sum') / fake_label.numel()
+    assert torch.allclose(loss, torch_loss)
+
     # test ignore index and class_weight
     class_weight = torch.rand(5)
     class_weight /= class_weight.sum()
@@ -273,6 +298,50 @@ def test_ce_loss():
         ignore_index=10,
         reduction='sum',
         weight=class_weight) / 12.0
+    assert torch.allclose(loss, torch_loss)
+
+    # test ignore index and class_weight
+    # avg_non_ignore=False
+    class_weight = torch.rand(5)
+    class_weight /= class_weight.sum()
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=class_weight,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls = build_loss(loss_cls_cfg)
+    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred,
+        fake_label,
+        ignore_index=10,
+        reduction='sum',
+        weight=class_weight) / fake_label.numel()
+    assert torch.allclose(loss, torch_loss)
+
+    # test ce loss
+    # without ignore index and avg_non_ignore
+    # doesn't affect the results
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 5, 10).float()  # 5-way classification
+    fake_label = torch.randint(0, 5, (2, 10)).long()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    torch_loss = torch.nn.functional.cross_entropy(
+        fake_pred, fake_label, reduction='sum') / fake_label.numel()
     assert torch.allclose(loss, torch_loss)
 
     # test bce loss
@@ -301,7 +370,46 @@ def test_ce_loss():
         reduction='mean')
     assert torch.allclose(loss, torch_loss)
 
-    # test ignore index and weight
+    # test bce loss
+    # without ignore index and avg_non_ignore
+    # doesn't affect the results
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        class_weight=None,
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls = build_loss(loss_cls_cfg)
+
+    fake_pred = torch.randn(2, 10).float()
+    fake_label = torch.rand(2, 10).float()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    # test bce loss
+    # with ignore index and avg_non_ignore=False
+    # doesn't affect the results
+    fake_label[0, [1, 2, 5, 7]] = 10  # set ignore_index
+    fake_label[1, [0, 5, 8, 9]] = 10
+    loss = loss_cls(fake_pred, fake_label, ignore_index=10)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred[fake_label != 10],
+        fake_label[fake_label != 10],
+        reduction='sum') / fake_label.numel()
+    assert torch.allclose(loss, torch_loss)
+
+    fake_pred = torch.randn(2, 10).float()
+    fake_label = torch.rand(2, 10).float()
+    loss = loss_cls(fake_pred, fake_label)
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred, fake_label, reduction='mean')
+    assert torch.allclose(loss, torch_loss)
+
+    # test bce
+    # with ignore index and weight and avg_non_ignore=False
     weight = torch.rand(2, 10)
     loss = loss_cls(fake_pred, fake_label, weight=weight, ignore_index=10)
     torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -130,95 +130,98 @@ def test_ce_loss():
         torch.tensor(0.9354),
         atol=1e-4)
 
-    # test avg_non_ignore=True would not affect bce
+    # test avg_non_ignore would not affect bce
     # when reduction='sum'
-    loss_cls_cfg = dict(
+    loss_cls_cfg1 = dict(
         type='CrossEntropyLoss',
         use_sigmoid=True,
         reduction='sum',
         loss_weight=1.0,
         avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-    fake_label[:, 0, 0] = 255
-    assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        torch.tensor(0.9354),
-        atol=1e-4)
-
-    # test the result when `avg_non_ignore=True`
-    # is equal to the results when `avg_non_ignore=Flase`
-    loss_cls_cfg = dict(
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
         type='CrossEntropyLoss',
         use_sigmoid=True,
         reduction='sum',
         loss_weight=1.0,
         avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+
+    fake_label[:, 0, 0] = 255
     assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        torch.tensor(0.9354),
+        loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
         atol=1e-4)
 
-    # test avg_non_ignore=True would not affect bce
+    # test avg_non_ignore would not affect bce
     # when reduction='none'
-    loss_cls_cfg = dict(
+    loss_cls_cfg1 = dict(
         type='CrossEntropyLoss',
         use_sigmoid=True,
         reduction='none',
         loss_weight=1.0,
         avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
-    fake_label[:, 0, 0] = 255
-    assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255).sum() /
-        fake_pred.numel(),
-        torch.tensor(0.9354),
-        atol=1e-4)
-
-    # test the result when `avg_non_ignore=True`
-    # is equal to the results when `avg_non_ignore=Flase`
-    loss_cls_cfg = dict(
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
         type='CrossEntropyLoss',
         use_sigmoid=True,
         reduction='none',
         loss_weight=1.0,
         avg_non_ignore=False)
-    loss_cls = build_loss(loss_cls_cfg)
+    loss_cls2 = build_loss(loss_cls_cfg2)
+
+    fake_label[:, 0, 0] = 255
     assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255).sum() /
+        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
         fake_pred.numel(),
-        torch.tensor(0.9354),
+        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
         atol=1e-4)
 
-    # test avg_non_ignore=True would not affect ce
+    # test avg_non_ignore would not affect ce
     # when reduction='sum'
-    loss_cls_cfg = dict(
+    loss_cls_cfg1 = dict(
         type='CrossEntropyLoss',
         use_sigmoid=False,
         reduction='sum',
         loss_weight=1.0,
         avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='sum',
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
     fake_label[:, 0, 0] = 255
     assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
-        torch.tensor(0.1427),
+        loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
         atol=1e-4)
 
-    # test avg_non_ignore=True would not affect ce
+    # test avg_non_ignore would not affect ce
     # when reduction='none'
-    loss_cls_cfg = dict(
+    loss_cls_cfg1 = dict(
         type='CrossEntropyLoss',
         use_sigmoid=False,
         reduction='none',
         loss_weight=1.0,
         avg_non_ignore=True)
-    loss_cls = build_loss(loss_cls_cfg)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='none',
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
     fake_label[:, 0, 0] = 255
     assert torch.allclose(
-        loss_cls(fake_pred, fake_label, ignore_index=255).sum() /
+        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
         fake_pred.numel(),
-        torch.tensor(0.1427),
+        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
         atol=1e-4)
 
     # test cross entropy loss has name `loss_ce`

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -130,6 +130,12 @@ def test_ce_loss():
         torch.tensor(0.9354),
         atol=1e-4)
 
+    # test avg_non_ignore would not affect bce/ce
+    # when reduction='sum'/'mean'/'none'
+    fake_pred = torch.full(size=(2, 21, 8, 8), fill_value=0.5)
+    fake_label = torch.ones(2, 8, 8).long()
+    fake_label[:, 0, 0] = 255
+
     # test avg_non_ignore would not affect bce
     # when reduction='sum'
     loss_cls_cfg1 = dict(
@@ -146,8 +152,6 @@ def test_ce_loss():
         loss_weight=1.0,
         avg_non_ignore=False)
     loss_cls2 = build_loss(loss_cls_cfg2)
-
-    fake_label[:, 0, 0] = 255
     assert torch.allclose(
         loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
         loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
@@ -169,8 +173,29 @@ def test_ce_loss():
         loss_weight=1.0,
         avg_non_ignore=False)
     loss_cls2 = build_loss(loss_cls_cfg2)
+    assert torch.allclose(
+        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        atol=1e-4)
 
-    fake_label[:, 0, 0] = 255
+    # test avg_non_ignore would not affect bce
+    # when reduction='mean'
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
     assert torch.allclose(
         loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
         fake_pred.numel(),
@@ -194,7 +219,6 @@ def test_ce_loss():
         loss_weight=1.0,
         avg_non_ignore=False)
     loss_cls2 = build_loss(loss_cls_cfg2)
-    fake_label[:, 0, 0] = 255
     assert torch.allclose(
         loss_cls1(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
         loss_cls2(fake_pred, fake_label, ignore_index=255) / fake_pred.numel(),
@@ -216,7 +240,29 @@ def test_ce_loss():
         loss_weight=1.0,
         avg_non_ignore=False)
     loss_cls2 = build_loss(loss_cls_cfg2)
-    fake_label[:, 0, 0] = 255
+    assert torch.allclose(
+        loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        loss_cls2(fake_pred, fake_label, ignore_index=255).sum() /
+        fake_pred.numel(),
+        atol=1e-4)
+
+    # test avg_non_ignore would not affect ce
+    # when reduction='mean'
+    loss_cls_cfg1 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls1 = build_loss(loss_cls_cfg1)
+    loss_cls_cfg2 = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=False,
+        reduction='mean',
+        loss_weight=1.0,
+        avg_non_ignore=False)
+    loss_cls2 = build_loss(loss_cls_cfg2)
     assert torch.allclose(
         loss_cls1(fake_pred, fake_label, ignore_index=255).sum() /
         fake_pred.numel(),

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -101,6 +101,13 @@ def test_ce_loss():
     fake_label = torch.ones(2, 8, 8).long()
     assert torch.allclose(
         loss_cls(fake_pred, fake_label), torch.tensor(0.9503), atol=1e-4)
+
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        loss_weight=1.0,
+        avg_non_ignore=True)
+    loss_cls = build_loss(loss_cls_cfg)
     fake_label[:, 0, 0] = 255
     assert torch.allclose(
         loss_cls(fake_pred, fake_label, ignore_index=255),

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -23,6 +23,7 @@ def test_ce_loss():
         loss_weight=1.0,
         loss_name='loss_ce')
     loss_cls = build_loss(loss_cls_cfg)
+    loss_cls.extra_repr
     fake_pred = torch.Tensor([[100, -100]])
     fake_label = torch.Tensor([1]).long()
     assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(40.))


### PR DESCRIPTION
## Motivation
Right now, MMSegmentation do not support `ignore_index` in loss average over non-ignored elements in CE loss.

fix https://github.com/open-mmlab/mmsegmentation/pull/578.

old pr: https://github.com/open-mmlab/mmsegmentation/pull/1388.

In old PR: https://github.com/open-mmlab/mmsegmentation/pull/578, the author fixed it while it left a bug if all labels in one image is `ignore_index`, `avg_factor` would be zero and ZeroDivisionError would be rasied in `weight_reduce_loss` function.

## Usage
Just take [fcn_unet_s5-d16_128x128_40k_chase_db1.py](https://github.com/open-mmlab/mmsegmentation/blob/master/configs/unet/fcn_unet_s5-d16_128x128_40k_chase_db1.py), its [base config](https://github.com/open-mmlab/mmsegmentation/blob/master/configs/_base_/models/fcn_unet_s5-d16.py) for example:

original config:
```python
# model settings
...
        loss_decode=dict(
            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
...
```
![image](https://user-images.githubusercontent.com/24582831/158775319-fdd77eb0-244b-42d5-a427-2f4efe72eb9e.png)


Just add `ignore_index` in decoder head or auxiliary head and add `avg_non_ignore=True`:
```python
# model settings
...
        loss_decode=dict(
            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0, avg_non_ignore=True),
...
```

![image](https://user-images.githubusercontent.com/24582831/158775607-35759e39-1c97-4c70-b31a-af5976f2fdf5.png)


|  cfg   | original  |  `avg_non_ignore=True`  |  `avg_non_ignore=False`  |
|  ----  | ----  | ----  | ----  |
| deeplabv3_r18-d8_512x1024_80k_cityscapes  | 76.70 78.27(ms+flip) | 77.07 78.82(ms+flip) | - |
| deeplabv3_r50-d8_512x512_80k_ade20k | 42.42 43.28(ms+flip) | 43.08 44.31(ms+flip) | 42.40 43.65(ms+flip) |