### PR TITLE
[Enchance] Support random seed for distributed sampler

### DIFF
--- a/mmseg/datasets/builder.py
+++ b/mmseg/datasets/builder.py
@@ -9,7 +9,9 @@ import torch
 from mmcv.parallel import collate
 from mmcv.runner import get_dist_info
 from mmcv.utils import Registry, build_from_cfg, digit_version
-from torch.utils.data import DataLoader, DistributedSampler
+from torch.utils.data import DataLoader
+
+from .samplers import DistributedSampler
 
 if platform.system() != 'Windows':
     # https://github.com/pytorch/pytorch/issues/973
@@ -129,7 +131,7 @@ def build_dataloader(dataset,
     rank, world_size = get_dist_info()
     if dist:
         sampler = DistributedSampler(
-            dataset, world_size, rank, shuffle=shuffle)
+            dataset, world_size, rank, shuffle=shuffle, seed=seed)
         shuffle = False
         batch_size = samples_per_gpu
         num_workers = workers_per_gpu

--- a/mmseg/datasets/samplers/__init__.py
+++ b/mmseg/datasets/samplers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .distributed_sampler import DistributedSampler
+
+__all__ = ['DistributedSampler']

--- a/mmseg/datasets/samplers/distributed_sampler.py
+++ b/mmseg/datasets/samplers/distributed_sampler.py
@@ -1,0 +1,95 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from __future__ import division
+
+import numpy as np
+import torch
+from torch.utils.data import DistributedSampler as _DistributedSampler
+
+from mmseg.utils import sync_random_seed
+
+
+class DistributedSampler(_DistributedSampler):
+    """DistributedSampler inheriting from
+    `torch.utils.data.DistributedSampler`.
+
+    In pytorch of lower versions, there is no `shuffle` argument. This child
+    class will port one to DistributedSampler.
+    """
+
+    def __init__(self,
+                 dataset,
+                 num_replicas=None,
+                 rank=None,
+                 shuffle=True,
+                 samples_per_gpu=1,
+                 seed=None):
+        super().__init__(dataset, num_replicas=num_replicas, rank=rank)
+
+        self.shuffle = shuffle
+        self.samples_per_gpu = samples_per_gpu
+        # fix the bug of the official implementation
+        self.num_samples_per_replica = int(
+            int(
+                np.ceil(
+                    len(self.dataset) * 1.0 / self.num_replicas /
+                    samples_per_gpu)))
+        self.num_samples = self.num_samples_per_replica * self.samples_per_gpu
+        self.total_size = self.num_samples * self.num_replicas
+
+        # to avoid padding bug when meeting too small dataset
+        if len(dataset) < self.num_replicas * samples_per_gpu:
+            raise ValueError(
+                'You may use too small dataset and our distributed '
+                'sampler cannot pad your dataset correctly. We highly '
+                'recommend you to use fewer GPUs to finish your work')
+        # In distributed sampling, different ranks should sample
+        # non-overlapped data in the dataset. Therefore, this function
+        # is used to make sure that each rank shuffles the data indices
+        # in the same order based on the same seed. Then different ranks
+        # could use different indices to select non-overlapped data from the
+        # same data list.
+        self.seed = sync_random_seed(seed)
+
+    def update_sampler(self, dataset, samples_per_gpu=None):
+        self.dataset = dataset
+        if samples_per_gpu is not None:
+            self.samples_per_gpu = samples_per_gpu
+        # fix the bug of the official implementation
+        self.num_samples_per_replica = int(
+            int(
+                np.ceil(
+                    len(self.dataset) * 1.0 / self.num_replicas /
+                    self.samples_per_gpu)))
+        self.num_samples = self.num_samples_per_replica * self.samples_per_gpu
+        self.total_size = self.num_samples * self.num_replicas
+
+        # to avoid padding bug when meeting too small dataset
+        if len(dataset) < self.num_replicas * self.samples_per_gpu:
+            raise ValueError(
+                'You may use too small dataset and our distributed '
+                'sampler cannot pad your dataset correctly. We highly '
+                'recommend you to use fewer GPUs to finish your work')
+
+    def __iter__(self):
+        # default training setting of MMSegmentation is iter-based
+        # deterministically shuffle based on epoch
+        if self.shuffle:
+            g = torch.Generator()
+            # When :attr:`shuffle=True`, this ensures all replicas
+            # use a different random ordering for each epoch.
+            # Otherwise, the next iteration of this sampler will
+            # yield the same ordering.
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(len(self.dataset), generator=g).tolist()
+        else:
+            indices = torch.arange(len(self.dataset)).tolist()
+
+        # add extra samples to make it evenly divisible
+        indices += indices[:(self.total_size - len(indices))]
+        assert len(indices) == self.total_size
+
+        # subsample
+        indices = indices[self.rank:self.total_size:self.num_replicas]
+        assert len(indices) == self.num_samples
+
+        return iter(indices)

--- a/mmseg/utils/__init__.py
+++ b/mmseg/utils/__init__.py
@@ -1,10 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .collect_env import collect_env
+from .dist_util import check_dist_init, sync_random_seed
 from .logger import get_root_logger
 from .misc import find_latest_checkpoint
 from .set_env import setup_multi_processes
 
 __all__ = [
     'get_root_logger', 'collect_env', 'find_latest_checkpoint',
-    'setup_multi_processes'
+    'setup_multi_processes', 'check_dist_init', 'sync_random_seed'
 ]

--- a/mmseg/utils/dist_util.py
+++ b/mmseg/utils/dist_util.py
@@ -1,0 +1,45 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import numpy as np
+import torch
+import torch.distributed as dist
+from mmcv.runner import get_dist_info
+
+
+def check_dist_init():
+    return dist.is_available() and dist.is_initialized()
+
+
+def sync_random_seed(seed=None, device='cuda'):
+    """Make sure different ranks share the same seed.
+
+    All workers must call
+    this function, otherwise it will deadlock. This method is generally used in
+    `DistributedSampler`, because the seed should be identical across all
+    processes in the distributed group.
+    In distributed sampling, different ranks should sample non-overlapped
+    data in the dataset. Therefore, this function is used to make sure that
+    each rank shuffles the data indices in the same order based
+    on the same seed. Then different ranks could use different indices
+    to select non-overlapped data from the same data list.
+    Args:
+        seed (int, Optional): The seed. Default to None.
+        device (str): The device where the seed will be put on.
+            Default to 'cuda'.
+    Returns:
+        int: Seed to be used.
+    """
+    if seed is None:
+        seed = np.random.randint(2**31)
+    assert isinstance(seed, int)
+
+    rank, world_size = get_dist_info()
+
+    if world_size == 1:
+        return seed
+
+    if rank == 0:
+        random_num = torch.tensor(seed, dtype=torch.int32, device=device)
+    else:
+        random_num = torch.tensor(0, dtype=torch.int32, device=device)
+    dist.broadcast(random_num, src=0)
+    return random_num.item()


### PR DESCRIPTION
## Motivation
Modify distributed sampler and keep the manual_seed behavior same with pytorch original version

Refers to https://github.com/open-mmlab/mmdetection/pull/7440/files, https://github.com/open-mmlab/mmdetection/pull/7432/files and https://github.com/open-mmlab/mmediting/pull/815.

## Modification
add seed to distributed sampler and apply `g.manual_seed(self.epoch + self.seed)`
synchronize the seed in init function