### PR TITLE
Avoid converting label ids twice by label map during evaluation

### DIFF
--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -286,9 +286,13 @@ class CustomDataset(Dataset):
         for pred, index in zip(preds, indices):
             seg_map = self.get_gt_seg_map_by_idx(index)
             pre_eval_results.append(
-                intersect_and_union(pred, seg_map, len(self.CLASSES),
-                                    self.ignore_index, self.label_map,
-                                    self.reduce_zero_label))
+                intersect_and_union(
+                    pred,
+                    seg_map,
+                    len(self.CLASSES),
+                    self.ignore_index,
+                    label_map=dict(),
+                    reduce_zero_label=self.reduce_zero_label))
 
         return pre_eval_results
 
@@ -405,7 +409,7 @@ class CustomDataset(Dataset):
                 num_classes,
                 self.ignore_index,
                 metric,
-                label_map=self.label_map,
+                label_map=dict(),
                 reduce_zero_label=self.reduce_zero_label)
         # test a list of pre_eval_results
         else:

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -293,8 +293,9 @@ class CustomDataset(Dataset):
                     self.ignore_index,
                     # as the labels has been converted when dataset initialized
                     # in `get_palette_for_custom_classes ` this `label_map`
-                    # should be `dict()`, see https://github.com/open-mmlab/mmsegmentation/issues/1415
-                    # for more ditails 
+                    # should be `dict()`, see
+                    # https://github.com/open-mmlab/mmsegmentation/issues/1415
+                    # for more ditails
                     label_map=dict(),
                     reduce_zero_label=self.reduce_zero_label))
 

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -291,6 +291,10 @@ class CustomDataset(Dataset):
                     seg_map,
                     len(self.CLASSES),
                     self.ignore_index,
+                    # as the labels has been converted when dataset initialized
+                    # in `get_palette_for_custom_classes ` this `label_map`
+                    # should be `dict()`, see https://github.com/open-mmlab/mmsegmentation/issues/1415
+                    # for more ditails 
                     label_map=dict(),
                     reduce_zero_label=self.reduce_zero_label))
 


### PR DESCRIPTION
`seg_map` or `gt_seg_maps` are already converted by the `label_map` during `self.get_gt_seg_map_by_idx` or `self.get_gt_seg_maps`, pass the `self.label_map` to `intersect_and_union` or `eval_metrics` will do the conversion again.

https://github.com/open-mmlab/mmsegmentation/issues/1415