### PR TITLE
[fix] fix image save path bug in Windows

### DIFF
--- a/tools/convert_datasets/isaid.py
+++ b/tools/convert_datasets/isaid.py
@@ -85,8 +85,7 @@ def slide_crop_image(src_path, out_dir, mode, patch_H, patch_W, overlap):
 
             img_patch = img[y_str:y_end, x_str:x_end, :]
             img_patch = Image.fromarray(img_patch.astype(np.uint8))
-            image = osp.splitext(
-                src_path.split('/')[-1])[0] + '_' + str(y_str) + '_' + str(
+            image = osp.basename(src_path).split('.')[0] + '_' + str(y_str) + '_' + str(
                     y_end) + '_' + str(x_str) + '_' + str(x_end) + '.png'
             # print(image)
             save_path_image = osp.join(out_dir, 'img_dir', mode, str(image))
@@ -135,7 +134,7 @@ def slide_crop_label(src_path, out_dir, mode, patch_H, patch_W, overlap):
             lab_patch = label[y_str:y_end, x_str:x_end]
             lab_patch = Image.fromarray(lab_patch.astype(np.uint8), mode='P')
 
-            image = osp.splitext(src_path.split('/')[-1])[0].split(
+            image = osp.basename(src_path).split('.')[0].split(
                 '_')[0] + '_' + str(y_str) + '_' + str(y_end) + '_' + str(
                     x_str) + '_' + str(x_end) + '_instance_color_RGB' + '.png'
             lab_patch.save(osp.join(out_dir, 'ann_dir', mode, str(image)))

--- a/tools/convert_datasets/isaid.py
+++ b/tools/convert_datasets/isaid.py
@@ -85,8 +85,9 @@ def slide_crop_image(src_path, out_dir, mode, patch_H, patch_W, overlap):
 
             img_patch = img[y_str:y_end, x_str:x_end, :]
             img_patch = Image.fromarray(img_patch.astype(np.uint8))
-            image = osp.basename(src_path).split('.')[0] + '_' + str(y_str) + '_' + str(
-                    y_end) + '_' + str(x_str) + '_' + str(x_end) + '.png'
+            image = osp.basename(src_path).split('.')[0] + '_' + str(
+                y_str) + '_' + str(y_end) + '_' + str(x_str) + '_' + str(
+                    x_end) + '.png'
             # print(image)
             save_path_image = osp.join(out_dir, 'img_dir', mode, str(image))
             img_patch.save(save_path_image)


### PR DESCRIPTION
## Motivation

when run `.\tools\convert_datasets\isaid.py`  in Windows OS,  as the path str has no `/`，there will get wrong image save path.

![image](https://user-images.githubusercontent.com/8895344/160324453-ac808c1a-e8a6-4011-b1c7-52d12b4609fa.png)


## Modification

using `os.path.basename(src_path).split('.')[0]` to get the filename without suffix.



