### PR TITLE
[Fix] Fix bug in `tools/analyse_logs.py` caused by wrong plot_iter in some cases.

### DIFF
--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -31,8 +31,9 @@ def plot_curve(log_dicts, args):
             plot_epochs = []
             plot_iters = []
             plot_values = []
-            # In some log files, iters number is not correct, `mode` list
-            # is used to prevent generate wrong lines of validation set.
+            # In some log files, wrong iters number in validation lines
+            # would be kept, `mode` list is used to only kept iter number
+            # in training line.
             for epoch in epochs:
                 epoch_logs = log_dict[epoch]
                 if metric not in epoch_logs.keys():

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -31,9 +31,8 @@ def plot_curve(log_dicts, args):
             plot_epochs = []
             plot_iters = []
             plot_values = []
-            # In some log files, iters number is not correct, `pre_iter` is
-            # used to prevent generate wrong lines.
-            pre_iter = -1
+            # In some log files, iters number is not correct, `mode` list
+            # is used to prevent generate wrong lines of validation set.
             for epoch in epochs:
                 epoch_logs = log_dict[epoch]
                 if metric not in epoch_logs.keys():
@@ -43,11 +42,9 @@ def plot_curve(log_dicts, args):
                     plot_values.append(epoch_logs[metric][0])
                 else:
                     for idx in range(len(epoch_logs[metric])):
-                        if pre_iter > epoch_logs['iter'][idx]:
-                            continue
-                        pre_iter = epoch_logs['iter'][idx]
-                        plot_iters.append(epoch_logs['iter'][idx])
-                        plot_values.append(epoch_logs[metric][idx])
+                        if epoch_logs['mode'][idx] == 'train':
+                            plot_iters.append(epoch_logs['iter'][idx])
+                            plot_values.append(epoch_logs[metric][idx])
             ax = plt.gca()
             label = legend[i * num_metrics + j]
             if metric in ['mIoU', 'mAcc', 'aAcc']:

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -31,9 +31,9 @@ def plot_curve(log_dicts, args):
             plot_epochs = []
             plot_iters = []
             plot_values = []
-            # In some log files, wrong iters number in validation lines
-            # would be kept, `mode` list is used to only kept iter number
-            # in training line.
+            # In some log files exist lines of validation,
+            # `mode` list is used to only collect iter number
+            # of training line.
             for epoch in epochs:
                 epoch_logs = log_dict[epoch]
                 if metric not in epoch_logs.keys():


### PR DESCRIPTION
## Motivation
Fix https://github.com/open-mmlab/mmsegmentation/issues/1426

Current in `tools/analyse_logs.py` we assert whether certain line in `log.json` is validation rather than training set by:
```python
  if pre_iter > epoch_logs['iter'][idx]:
      continue
```
It's OK in many cases like below ` 32000 (pre_iter) > 250 (epoch_logs['iter'][idx]) `.

It is in ConvNeXt, whose validation step is 16000. Of course, 16000, 32000, 48000 and so on those values > 250. 
Note that 250 is related with number of images in validation sets.
![image](https://user-images.githubusercontent.com/24582831/160478055-af2bb4b2-c4cb-456c-96bf-6ac6b0599449.png)

However, in certain cases when (1) valitaion is large and (2) validation step is small, like below:

![image](https://user-images.githubusercontent.com/24582831/160479004-9c6c3b1d-ac15-4f7e-a816-0c3113b89d98.png)
The valition has 1334 images and validation step is 200. So  ` 200 (pre_iter) < 1334 (epoch_logs['iter'][idx]) `. And it would generate many `1334` in `plot_iters` which makes a horizontal line segment in lr figure:

![image](https://user-images.githubusercontent.com/24582831/160479451-3988297e-db81-4bd1-9a69-7fcce1df464c.png)

## Solution
Using paragraph below to assert whther to keep values in training set.
```python
  if epoch_logs['mode'][idx] == 'train':
      plot_iters.append(epoch_logs['iter'][idx])
      plot_values.append(epoch_logs[metric][idx])
```

## Result
Take [logfile.zip](https://github.com/open-mmlab/mmsegmentation/files/8364563/logfile.zip) from https://github.com/open-mmlab/mmsegmentation/issues/1426 for example:

LR before:
![image](https://user-images.githubusercontent.com/24582831/160477101-bf1212c7-9062-44ce-9610-2974deae290a.png)

LR after:
![image](https://user-images.githubusercontent.com/24582831/160476973-962dd154-ff3c-4c46-a118-a0f02414436d.png)

Loss before:
![image](https://user-images.githubusercontent.com/24582831/160477274-b0bfa6a8-1084-410d-be1a-30833dbeb8db.png)

Loss after:
![image](https://user-images.githubusercontent.com/24582831/160477192-19a746f8-e3ed-4123-a69b-bf047d797c54.png)

