### PR TITLE
[Enhance] Add extra dataloader settings in configs

### DIFF
--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -83,7 +83,6 @@ def train_segmentor(model,
         # cfg.gpus will be ignored if distributed
         num_gpus=len(cfg.gpu_ids),
         dist=distributed,
-        round_up=True,
         seed=cfg.seed,
         drop_last=True)
     # The overall dataloader settings

--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -148,7 +148,6 @@ def train_segmentor(model,
             **loader_cfg,
             'samples_per_gpu': 1,
             'shuffle': False,  # Not shuffle by default
-            'sampler_cfg': None,  # Not use sampler by default
             **cfg.data.get('val_dataloader', {}),
         }
         val_dataloader = build_dataloader(val_dataset, **val_loader_cfg)

--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -147,6 +147,7 @@ def train_segmentor(model,
         # The specific dataloader settings
         val_loader_cfg = {
             **loader_cfg,
+            'samples_per_gpu': 1,
             'shuffle': False,  # Not shuffle by default
             'sampler_cfg': None,  # Not use sampler by default
             **cfg.data.get('val_dataloader', {}),

--- a/mmseg/apis/train.py
+++ b/mmseg/apis/train.py
@@ -78,17 +78,26 @@ def train_segmentor(model,
 
     # prepare data loaders
     dataset = dataset if isinstance(dataset, (list, tuple)) else [dataset]
-    data_loaders = [
-        build_dataloader(
-            ds,
-            cfg.data.samples_per_gpu,
-            cfg.data.workers_per_gpu,
-            # cfg.gpus will be ignored if distributed
-            len(cfg.gpu_ids),
-            dist=distributed,
-            seed=cfg.seed,
-            drop_last=True) for ds in dataset
-    ]
+    # The default loader config
+    loader_cfg = dict(
+        # cfg.gpus will be ignored if distributed
+        num_gpus=len(cfg.gpu_ids),
+        dist=distributed,
+        round_up=True,
+        seed=cfg.seed,
+        drop_last=True)
+    # The overall dataloader settings
+    loader_cfg.update({
+        k: v
+        for k, v in cfg.data.items() if k not in [
+            'train', 'val', 'test', 'train_dataloader', 'val_dataloader',
+            'test_dataloader'
+        ]
+    })
+
+    # The specific dataloader settings
+    train_loader_cfg = {**loader_cfg, **cfg.data.get('train_dataloader', {})}
+    data_loaders = [build_dataloader(ds, **train_loader_cfg) for ds in dataset]
 
     # put model on gpus
     if distributed:
@@ -135,12 +144,14 @@ def train_segmentor(model,
     # register eval hooks
     if validate:
         val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
-        val_dataloader = build_dataloader(
-            val_dataset,
-            samples_per_gpu=1,
-            workers_per_gpu=cfg.data.workers_per_gpu,
-            dist=distributed,
-            shuffle=False)
+        # The specific dataloader settings
+        val_loader_cfg = {
+            **loader_cfg,
+            'shuffle': False,  # Not shuffle by default
+            'sampler_cfg': None,  # Not use sampler by default
+            **cfg.data.get('val_dataloader', {}),
+        }
+        val_dataloader = build_dataloader(val_dataset, **val_loader_cfg)
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook

--- a/tools/test.py
+++ b/tools/test.py
@@ -209,6 +209,7 @@ def main():
     })
     test_loader_cfg = {
         **loader_cfg,
+        'samples_per_gpu': 1,
         'shuffle': False,  # Not shuffle by default
         'sampler_cfg': None,  # Not use sampler by default
         **cfg.data.get('test_dataloader', {}),

--- a/tools/test.py
+++ b/tools/test.py
@@ -196,8 +196,7 @@ def main():
         # cfg.gpus will be ignored if distributed
         num_gpus=len(cfg.gpu_ids),
         dist=distributed,
-        shuffle=False,
-    )
+        shuffle=False)
     # The overall dataloader settings
     loader_cfg.update({
         k: v
@@ -210,8 +209,7 @@ def main():
         **loader_cfg,
         'samples_per_gpu': 1,
         'shuffle': False,  # Not shuffle by default
-        'sampler_cfg': None,  # Not use sampler by default
-        **cfg.data.get('test_dataloader', {}),
+        **cfg.data.get('test_dataloader', {})
     }
     # build the dataloader
     data_loader = build_dataloader(dataset, **test_loader_cfg)

--- a/tools/test.py
+++ b/tools/test.py
@@ -197,7 +197,6 @@ def main():
         num_gpus=len(cfg.gpu_ids),
         dist=distributed,
         shuffle=False,
-        round_up=True,
     )
     # The overall dataloader settings
     loader_cfg.update({


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

ref: https://github.com/open-mmlab/mmclassification/pull/752
In some situation, we need to use different dataloader settings like samples_per_gpu in train/val/test dataloader.

## Modification

Use train_dataloader, val_dataloader and test_dataloader settings in the data field to specify different arguments.

## Use cases (Optional)

```python
data = dict(
    samples_per_gpu=64,
    workers_per_gpu=4,
    train=dict(type='xxx', ...),
    val=dict(type='xxx', ...),
    test=dict(type='xxx', ...),
    # Use different batch size during inference.
    val_dataloader=dict(samples_per_gpu=8, workers_per_gpu=2),
    test_dataloader=dict(samples_per_gpu=8, workers_per_gpu=2),
)

```
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
