### PR TITLE
[Fix] Input previous results for the last cascade_decode_head

### DIFF
--- a/mmseg/models/segmentors/cascade_encoder_decoder.py
+++ b/mmseg/models/segmentors/cascade_encoder_decoder.py
@@ -76,7 +76,7 @@ class CascadeEncoderDecoder(EncoderDecoder):
         for i in range(1, self.num_stages):
             # forward test again, maybe unnecessary for most methods.
             if i == 1:
-                prev_outputs = self.decode_head[i - 1].forward_test(
+                prev_outputs = self.decode_head[0].forward_test(
                     x, img_metas, self.test_cfg)
             else:
                 prev_outputs = self.decode_head[i - 1].forward_test(

--- a/mmseg/models/segmentors/cascade_encoder_decoder.py
+++ b/mmseg/models/segmentors/cascade_encoder_decoder.py
@@ -75,8 +75,12 @@ class CascadeEncoderDecoder(EncoderDecoder):
 
         for i in range(1, self.num_stages):
             # forward test again, maybe unnecessary for most methods.
-            prev_outputs = self.decode_head[i - 1].forward_test(
-                x, img_metas, self.test_cfg)
+            if i == 1:
+                prev_outputs = self.decode_head[i - 1].forward_test(
+                    x, img_metas, self.test_cfg)
+            else:
+                prev_outputs = self.decode_head[i - 1].forward_test(
+                    x, prev_outputs, img_metas, self.test_cfg)
             loss_decode = self.decode_head[i].forward_train(
                 x, prev_outputs, img_metas, gt_semantic_seg, self.train_cfg)
             losses.update(add_prefix(loss_decode, f'decode_{i}'))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

fix # https://github.com/open-mmlab/mmsegmentation/issues/1353

## Modification

- Input `prev_outputs` to `forward_test` for the latter `cascade_decode_head`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
