### PR TITLE
[Fix] MMSegmentation Tutorial running on colab error fix

### DIFF
--- a/demo/MMSegmentation_Tutorial.ipynb
+++ b/demo/MMSegmentation_Tutorial.ipynb
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "# Install PyTorch\n",
-    "!conda install pytorch=1.6.0 torchvision cudatoolkit=10.1 -c pytorch\n",
+    "!conda install pytorch=1.10.0 torchvision cudatoolkit=11.1 -c pytorch\n",
     "# Install MMCV\n",
     "!pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6/index.html"
    ]

--- a/demo/MMSegmentation_Tutorial.ipynb
+++ b/demo/MMSegmentation_Tutorial.ipynb
@@ -33,7 +33,7 @@
     "## Install MMSegmentation\n",
     "This step may take several minutes. \n",
     "\n",
-    "We use PyTorch 1.6 and CUDA 10.1 for this tutorial. You may install other versions by change the version number in pip install command. "
+    "We use PyTorch 1.10 and CUDA 11.1 for this tutorial. You may install other versions by change the version number in pip install command. "
    ]
   },
   {


### PR DESCRIPTION
## Motivation

As the colab's versions of cudatoolkit has changed, the installed version in the tutorial needs to be changed as well.

## Modification

The cudatoolkit is chenged to 11.1 to match Colab. Pytorch is changed to version 1.10.0 to match the cudatoolkit.

The whole tutorial file runs well after the fix.