### PR TITLE
[Fix] Support single cahnnel `pred` for Binary Cross Entropy Loss

### DIFF
--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -135,7 +135,7 @@ def binary_cross_entropy(pred,
         # should mask out the ignored elements
         valid_mask = ((label >= 0) & (label != ignore_index)).float()
         if weight is not None:
-            weight *= valid_mask
+            weight = weight * valid_mask
         else:
             weight = valid_mask
     # average loss over non-ignored and valid elements

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -115,7 +115,14 @@ def binary_cross_entropy(pred,
     Returns:
         torch.Tensor: The calculated loss
     """
-    if pred.dim() != label.dim() and pred.size(1) != 1:
+    if pred.size(1) == 1:
+        # For binary class segmentation, the shape of pred is
+        # [N, 1, H, W] and that of label is [N, H, W].
+        assert label.max() <= 1, \
+            'For pred with shape [N, 1, H, W], its label must have at ' \
+            'most 2 classes'
+        pred = pred.squeeze()
+    if pred.dim() != label.dim():
         assert (pred.dim() == 2 and label.dim() == 1) or (
                 pred.dim() == 4 and label.dim() == 3), \
             'Only pred shape [N, C], label shape [N] or pred shape [N, C, ' \
@@ -125,13 +132,6 @@ def binary_cross_entropy(pred,
         label, weight, valid_mask = _expand_onehot_labels(
             label, weight, pred.shape, ignore_index)
     else:
-        if pred.dim() != label.dim():
-            # For binary class segmentation, the shape of `pred` is
-            # [N, 1, H, W] and that of `label` is [N, H, W].
-            assert label.max() <= 1, \
-                'For pred with shape [N, 1, H, W], its label must have at ' \
-                'most 2 classes'
-            pred = pred.squeeze()
         # should mask out the ignored elements
         valid_mask = ((label >= 0) & (label != ignore_index)).float()
         if weight is not None:

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -68,6 +68,9 @@ def _expand_onehot_labels(labels, label_weights, target_shape, ignore_index):
     if target_shape[1] == 1:
         # For binary class segmentation, the shape of `pred` is
         # [N, 1, H, W] and that of `label` is [N, H, W].
+        assert labels.max() <= 1, \
+            'For pred with shape [N, 1, H, W], its label must have at ' \
+            'most 2 classes'
         bin_labels = labels.unsqueeze(1)
         valid_mask = ((bin_labels >= 0) & (bin_labels != ignore_index)).float()
         if label_weights is not None:

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -91,7 +91,7 @@ def _expand_onehot_labels(labels, label_weights, target_shape, ignore_index):
             bin_label_weights = valid_mask
         else:
             bin_label_weights = label_weights.unsqueeze(1).expand(target_shape)
-            bin_label_weights *= valid_mask
+            bin_label_weights = bin_label_weights * valid_mask
 
     return bin_labels, bin_label_weights, valid_mask
 

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -65,36 +65,23 @@ def cross_entropy(pred,
 
 def _expand_onehot_labels(labels, label_weights, target_shape, ignore_index):
     """Expand onehot labels to match the size of prediction."""
-    if target_shape[1] == 1:
-        # For binary class segmentation, the shape of `pred` is
-        # [N, 1, H, W] and that of `label` is [N, H, W].
-        assert labels.max() <= 1, \
-            'For pred with shape [N, 1, H, W], its label must have at ' \
-            'most 2 classes'
-        bin_labels = labels.unsqueeze(1)
-        valid_mask = ((bin_labels >= 0) & (bin_labels != ignore_index)).float()
-        if label_weights is not None:
-            bin_label_weights = label_weights.unsqueeze(1).float() * valid_mask
+    bin_labels = labels.new_zeros(target_shape)
+    valid_mask = (labels >= 0) & (labels != ignore_index)
+    inds = torch.nonzero(valid_mask, as_tuple=True)
+
+    if inds[0].numel() > 0:
+        if labels.dim() == 3:
+            bin_labels[inds[0], labels[valid_mask], inds[1], inds[2]] = 1
         else:
-            bin_label_weights = valid_mask
+            bin_labels[inds[0], labels[valid_mask]] = 1
+
+    valid_mask = valid_mask.unsqueeze(1).expand(target_shape).float()
+
+    if label_weights is None:
+        bin_label_weights = valid_mask
     else:
-        bin_labels = labels.new_zeros(target_shape)
-        valid_mask = (labels >= 0) & (labels != ignore_index)
-        inds = torch.nonzero(valid_mask, as_tuple=True)
-
-        if inds[0].numel() > 0:
-            if labels.dim() == 3:
-                bin_labels[inds[0], labels[valid_mask], inds[1], inds[2]] = 1
-            else:
-                bin_labels[inds[0], labels[valid_mask]] = 1
-
-        valid_mask = valid_mask.unsqueeze(1).expand(target_shape).float()
-
-        if label_weights is None:
-            bin_label_weights = valid_mask
-        else:
-            bin_label_weights = label_weights.unsqueeze(1).expand(target_shape)
-            bin_label_weights = bin_label_weights * valid_mask
+        bin_label_weights = label_weights.unsqueeze(1).expand(target_shape)
+        bin_label_weights = bin_label_weights * valid_mask
 
     return bin_labels, bin_label_weights, valid_mask
 
@@ -128,7 +115,7 @@ def binary_cross_entropy(pred,
     Returns:
         torch.Tensor: The calculated loss
     """
-    if pred.dim() != label.dim():
+    if pred.dim() != label.dim() and pred.size(1) != 1:
         assert (pred.dim() == 2 and label.dim() == 1) or (
                 pred.dim() == 4 and label.dim() == 3), \
             'Only pred shape [N, C], label shape [N] or pred shape [N, C, ' \
@@ -138,6 +125,13 @@ def binary_cross_entropy(pred,
         label, weight, valid_mask = _expand_onehot_labels(
             label, weight, pred.shape, ignore_index)
     else:
+        if pred.dim() != label.dim():
+            # For binary class segmentation, the shape of `pred` is
+            # [N, 1, H, W] and that of `label` is [N, H, W].
+            assert label.max() <= 1, \
+                'For pred with shape [N, 1, H, W], its label must have at ' \
+                'most 2 classes'
+            pred = pred.squeeze()
         # should mask out the ignored elements
         valid_mask = ((label >= 0) & (label != ignore_index)).float()
         if weight is not None:

--- a/tests/test_models/test_losses/test_ce_loss.py
+++ b/tests/test_models/test_losses/test_ce_loss.py
@@ -223,3 +223,38 @@ def test_ce_loss(use_sigmoid, reduction, avg_non_ignore, bce_input_same_dim):
                 reduction='sum',
                 weight=class_weight) / fake_label.numel()
     assert torch.allclose(loss, torch_loss)
+
+
+@pytest.mark.parametrize('avg_non_ignore', [True, False])
+def test_binary_class_ce_loss(avg_non_ignore):
+    from mmseg.models import build_loss
+
+    fake_pred = torch.rand(3, 1, 10, 10)
+    fake_label = torch.randint(0, 2, (3, 10, 10))
+    fake_weight = torch.rand(3, 10, 10)
+    valid_mask = ((fake_label >= 0) & (fake_label != 255)).float()
+    weight = valid_mask
+    torch_loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        fake_pred,
+        fake_label.unsqueeze(1).float(),
+        reduction='none',
+        weight=fake_weight.unsqueeze(1).float())
+    if avg_non_ignore:
+        eps = torch.finfo(torch.float32).eps
+        avg_factor = valid_mask.sum().item()
+        torch_loss = (torch_loss * weight.unsqueeze(1)).sum() / (
+            avg_factor + eps)
+    else:
+        torch_loss = (torch_loss * weight.unsqueeze(1)).mean()
+
+    loss_cls_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        loss_weight=1.0,
+        avg_non_ignore=avg_non_ignore,
+        reduction='mean',
+        loss_name='loss_ce')
+    loss_cls = build_loss(loss_cls_cfg)
+    loss = loss_cls(
+        fake_pred, fake_label, weight=fake_weight, ignore_index=255)
+    assert torch.allclose(loss, torch_loss)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix the bug that binary cross entropy loss doesn't support single channel input.
Related Issue: https://github.com/open-mmlab/mmsegmentation/issues/1430

## Modification

1. When the channel of `pred` is one, instead of expanding the lebel to one-hot format, `binary_cross_entropy_loss` only unsqueeze the `label` to match the shape of the `pred`.
2. Add a new test function to cover the new codes.