### PR TITLE
[Fix] Fix save best checkpoint bug when separate_eval is True

### DIFF
--- a/mmseg/datasets/dataset_wrappers.py
+++ b/mmseg/datasets/dataset_wrappers.py
@@ -34,6 +34,8 @@ class ConcatDataset(_ConcatDataset):
         assert separate_eval in [True, False], \
             f'separate_eval can only be True or False,' \
             f'but get {separate_eval}'
+        self.have_same_type = \
+            len(set([type(ds) for ds in self.datasets])) == 1
         if any([isinstance(ds, CityscapesDataset) for ds in datasets]):
             raise NotImplementedError(
                 'Evaluating ConcatDataset containing CityscapesDataset'
@@ -66,6 +68,7 @@ class ConcatDataset(_ConcatDataset):
         if self.separate_eval:
             dataset_idx = -1
             total_eval_results = dict()
+            metrics = set()
             for size, dataset in zip(self.cumulative_sizes, self.datasets):
                 start_idx = 0 if dataset_idx == -1 else \
                     self.cumulative_sizes[dataset_idx]
@@ -82,10 +85,20 @@ class ConcatDataset(_ConcatDataset):
                 dataset_idx += 1
                 for k, v in eval_results_per_dataset.items():
                     total_eval_results.update({f'{dataset_idx}_{k}': v})
+                    metrics.add(k)
 
+            # calculate the average metric of datasets
+            # if they have same dataset type
+            # e.g. results['mIoU'] = mean(results['0_mIoU], results['1_mIoU]..)
+            if self.have_same_type:
+                for m in metrics:
+                    total_eval_results[m] = np.mean([
+                        total_eval_results[k] for k in total_eval_results
+                        if k.endswith(m)
+                    ])
             return total_eval_results
 
-        if len(set([type(ds) for ds in self.datasets])) != 1:
+        if not self.have_same_type:
             raise NotImplementedError(
                 'All the datasets should have same types when '
                 'self.separate_eval=False')

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -430,25 +430,29 @@ def test_eval_concat_custom_dataset(separate_eval):
     dataset2 = build_dataset(cfg2)
     assert isinstance(dataset2, ConcatDataset)
     assert len(dataset2) == 10
+    assert dataset2.have_same_type is True
 
     eval_results2 = dataset2.evaluate(
         pseudo_results * 2, metric=['mIoU', 'mDice', 'mFscore'])
 
     if separate_eval:
         assert eval_results1['mIoU'] == eval_results2[
-            '0_mIoU'] == eval_results2['1_mIoU']
+            '0_mIoU'] == eval_results2['1_mIoU'] == eval_results2['mIoU']
         assert eval_results1['mDice'] == eval_results2[
-            '0_mDice'] == eval_results2['1_mDice']
+            '0_mDice'] == eval_results2['1_mDice'] == eval_results2['mDice']
         assert eval_results1['mAcc'] == eval_results2[
-            '0_mAcc'] == eval_results2['1_mAcc']
+            '0_mAcc'] == eval_results2['1_mAcc'] == eval_results2['mAcc']
         assert eval_results1['aAcc'] == eval_results2[
-            '0_aAcc'] == eval_results2['1_aAcc']
+            '0_aAcc'] == eval_results2['1_aAcc'] == eval_results2['aAcc']
         assert eval_results1['mFscore'] == eval_results2[
-            '0_mFscore'] == eval_results2['1_mFscore']
+            '0_mFscore'] == eval_results2['1_mFscore'] == eval_results2[
+                'mFscore']
         assert eval_results1['mPrecision'] == eval_results2[
-            '0_mPrecision'] == eval_results2['1_mPrecision']
+            '0_mPrecision'] == eval_results2['1_mPrecision'] == eval_results2[
+                'mPrecision']
         assert eval_results1['mRecall'] == eval_results2[
-            '0_mRecall'] == eval_results2['1_mRecall']
+            '0_mRecall'] == eval_results2['1_mRecall'] == eval_results2[
+                'mRecall']
     else:
         assert eval_results1['mIoU'] == eval_results2['mIoU']
         assert eval_results1['mDice'] == eval_results2['mDice']
@@ -515,19 +519,22 @@ def test_eval_concat_custom_dataset(separate_eval):
 
     if separate_eval:
         assert eval_results1['mIoU'] == eval_results2[
-            '0_mIoU'] == eval_results2['1_mIoU']
+            '0_mIoU'] == eval_results2['1_mIoU'] == eval_results2['mIoU']
         assert eval_results1['mDice'] == eval_results2[
-            '0_mDice'] == eval_results2['1_mDice']
+            '0_mDice'] == eval_results2['1_mDice'] == eval_results2['mDice']
         assert eval_results1['mAcc'] == eval_results2[
-            '0_mAcc'] == eval_results2['1_mAcc']
+            '0_mAcc'] == eval_results2['1_mAcc'] == eval_results2['mAcc']
         assert eval_results1['aAcc'] == eval_results2[
-            '0_aAcc'] == eval_results2['1_aAcc']
+            '0_aAcc'] == eval_results2['1_aAcc'] == eval_results2['aAcc']
         assert eval_results1['mFscore'] == eval_results2[
-            '0_mFscore'] == eval_results2['1_mFscore']
+            '0_mFscore'] == eval_results2['1_mFscore'] == eval_results2[
+                'mFscore']
         assert eval_results1['mPrecision'] == eval_results2[
-            '0_mPrecision'] == eval_results2['1_mPrecision']
+            '0_mPrecision'] == eval_results2['1_mPrecision'] == eval_results2[
+                'mPrecision']
         assert eval_results1['mRecall'] == eval_results2[
-            '0_mRecall'] == eval_results2['1_mRecall']
+            '0_mRecall'] == eval_results2['1_mRecall'] == eval_results2[
+                'mRecall']
     else:
         assert eval_results1['mIoU'] == eval_results2['mIoU']
         assert eval_results1['mDice'] == eval_results2['mDice']
@@ -551,19 +558,22 @@ def test_eval_concat_custom_dataset(separate_eval):
 
     if separate_eval:
         assert eval_results1['mIoU'] == eval_results2[
-            '0_mIoU'] == eval_results2['1_mIoU']
+            '0_mIoU'] == eval_results2['1_mIoU'] == eval_results2['mIoU']
         assert eval_results1['mDice'] == eval_results2[
-            '0_mDice'] == eval_results2['1_mDice']
+            '0_mDice'] == eval_results2['1_mDice'] == eval_results2['mDice']
         assert eval_results1['mAcc'] == eval_results2[
-            '0_mAcc'] == eval_results2['1_mAcc']
+            '0_mAcc'] == eval_results2['1_mAcc'] == eval_results2['mAcc']
         assert eval_results1['aAcc'] == eval_results2[
-            '0_aAcc'] == eval_results2['1_aAcc']
+            '0_aAcc'] == eval_results2['1_aAcc'] == eval_results2['aAcc']
         assert eval_results1['mFscore'] == eval_results2[
-            '0_mFscore'] == eval_results2['1_mFscore']
+            '0_mFscore'] == eval_results2['1_mFscore'] == eval_results2[
+                'mFscore']
         assert eval_results1['mPrecision'] == eval_results2[
-            '0_mPrecision'] == eval_results2['1_mPrecision']
+            '0_mPrecision'] == eval_results2['1_mPrecision'] == eval_results2[
+                'mPrecision']
         assert eval_results1['mRecall'] == eval_results2[
-            '0_mRecall'] == eval_results2['1_mRecall']
+            '0_mRecall'] == eval_results2['1_mRecall'] == eval_results2[
+                'mRecall']
     else:
         assert eval_results1['mIoU'] == eval_results2['mIoU']
         assert eval_results1['mDice'] == eval_results2['mDice']


### PR DESCRIPTION
## Motivation

When use `save_best='mIoU'` or other metric in cfg.evaluation, if `separate_eval=True`, the results metric keys will change to `0_mIoU` and `1_mIoU`... Lead to error when save best checkpoint
## Modification
1. calculate the average metric of datasets if test datasets have same dataset type
e.g. results['mIoU'] = mean(results['0_mIoU], results['1_mIoU]..)
2. disable `save_best` if test datasets have different dataset type and raise warning

