### PR TITLE
[Fix] inconsistent dtype of `seg_label` in stdc decode

### DIFF
--- a/mmseg/models/decode_heads/stdc_head.py
+++ b/mmseg/models/decode_heads/stdc_head.py
@@ -37,7 +37,7 @@ class STDCHead(FCNHead):
         # parameters. However, it is a constant in original repo and other
         # codebase because it would not be added into computation graph
         # after threshold operation.
-        seg_label = seg_label.float()
+        seg_label = seg_label.to(self.laplacian_kernel)
         boundary_targets = F.conv2d(
             seg_label, self.laplacian_kernel, padding=1)
         boundary_targets = boundary_targets.clamp(min=0)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

fix #1462

## Modification

- revise `seg_label.float`  to `seg_label.to(self.laplacian_kernel)` in mmseg/models/decode_heads/stdc_head.py

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
