### PR TITLE
[Fix] Fix auxiliary_head input

### DIFF
--- a/mmseg/models/segmentors/cascade_encoder_decoder.py
+++ b/mmseg/models/segmentors/cascade_encoder_decoder.py
@@ -51,7 +51,7 @@ class CascadeEncoderDecoder(EncoderDecoder):
     def encode_decode(self, img, img_metas):
         """Encode images with backbone and decode into a semantic segmentation
         map of the same size as input."""
-        x = self.extract_feat(img)
+        x = self.extract_feat(img)[-1]
         out = self.decode_head[0].forward_test(x, img_metas, self.test_cfg)
         for i in range(1, self.num_stages):
             out = self.decode_head[i].forward_test(x, out, img_metas,

--- a/mmseg/models/segmentors/encoder_decoder.py
+++ b/mmseg/models/segmentors/encoder_decoder.py
@@ -62,15 +62,18 @@ class EncoderDecoder(BaseSegmentor):
 
     def extract_feat(self, img):
         """Extract features from images."""
+        output = []
         x = self.backbone(img)
+        output.append(x)
         if self.with_neck:
             x = self.neck(x)
-        return x
+            output.append(x)
+        return tuple(output)
 
     def encode_decode(self, img, img_metas):
         """Encode images with backbone and decode into a semantic segmentation
         map of the same size as input."""
-        x = self.extract_feat(img)
+        x = self.extract_feat(img)[-1]
         out = self._decode_head_forward_test(x, img_metas)
         out = resize(
             input=out,
@@ -140,13 +143,13 @@ class EncoderDecoder(BaseSegmentor):
 
         losses = dict()
 
-        loss_decode = self._decode_head_forward_train(x, img_metas,
+        loss_decode = self._decode_head_forward_train(x[-1], img_metas,
                                                       gt_semantic_seg)
         losses.update(loss_decode)
 
         if self.with_auxiliary_head:
             loss_aux = self._auxiliary_head_forward_train(
-                x, img_metas, gt_semantic_seg)
+                x[0], img_metas, gt_semantic_seg)
             losses.update(loss_aux)
 
         return losses


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The input of auxiliary_head is usually the feature map of a backbone layer. However, when a neck is used, the feature map performs neck first, followed by auxiliary_head.

## Modification

1. Fix extract_feat and encode_decode function in mmseg/models/segmentors/encoder_decoder.py.
2. Fix encode_decode function  in mmseg/models/segmentors/cascade_encoder_decoder.py.

