### PR TITLE
[Feature] Support CIHP dataset

### DIFF
--- a/configs/_base_/datasets/cihp.py
+++ b/configs/_base_/datasets/cihp.py
@@ -1,0 +1,55 @@
+# dataset settings
+dataset_type = 'LIPDataset'
+data_root = 'data/LIP'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+img_scale = (520, 520)
+crop_size = (473, 473)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations', reduce_zero_label=True),
+    dict(type='Resize', img_scale=img_scale, ratio_range=(0.5, 2.0)),
+    dict(type='RandomCrop', crop_size=crop_size, cat_max_ratio=0.75),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size=crop_size, pad_val=0, seg_pad_val=255),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_semantic_seg']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=img_scale,
+        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    samples_per_gpu=4,
+    workers_per_gpu=4,
+    train=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/training',
+        ann_dir='annotations/training',
+        pipeline=train_pipeline),
+    val=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline),
+    test=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline))

--- a/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_160k_CIHP.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_160k_CIHP.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/deeplabv3plus_r50-d8.py', '../_base_/datasets/cihp.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_80k_CIHP.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_80k_CIHP.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/deeplabv3plus_r50-d8.py', '../_base_/datasets/cihp.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/pspnet/pspnet_r101-d8_473x473_160k_CIHP.py
+++ b/configs/pspnet/pspnet_r101-d8_473x473_160k_CIHP.py
@@ -1,0 +1,2 @@
+_base_ = './pspnet_r50-d8_473x473_160k_CIHP.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/pspnet/pspnet_r101-d8_473x473_80k_CIHP.py
+++ b/configs/pspnet/pspnet_r101-d8_473x473_80k_CIHP.py
@@ -1,0 +1,2 @@
+_base_ = './pspnet_r50-d8_473x473_80k_CIHP.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/pspnet/pspnet_r50-d8_473x473_160k_CIHP.py
+++ b/configs/pspnet/pspnet_r50-d8_473x473_160k_CIHP.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/pspnet_r50-d8.py', '../_base_/datasets/cihp.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/pspnet/pspnet_r50-d8_473x473_80k_CIHP.py
+++ b/configs/pspnet/pspnet_r50-d8_473x473_80k_CIHP.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/pspnet_r50-d8.py', '../_base_/datasets/cihp.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/mmseg/datasets/__init__.py
+++ b/mmseg/datasets/__init__.py
@@ -2,6 +2,7 @@
 from .ade import ADE20KDataset
 from .builder import DATASETS, PIPELINES, build_dataloader, build_dataset
 from .chase_db1 import ChaseDB1Dataset
+from .cihp import CIHPDataset
 from .cityscapes import CityscapesDataset
 from .coco_stuff import COCOStuffDataset
 from .custom import CustomDataset
@@ -26,5 +27,5 @@ __all__ = [
     'PascalContextDataset59', 'ChaseDB1Dataset', 'DRIVEDataset', 'HRFDataset',
     'STAREDataset', 'DarkZurichDataset', 'NightDrivingDataset',
     'COCOStuffDataset', 'LoveDADataset', 'MultiImageMixDataset',
-    'iSAIDDataset', 'ISPRSDataset', 'PotsdamDataset'
+    'iSAIDDataset', 'ISPRSDataset', 'PotsdamDataset', 'CIHPDataset'
 ]

--- a/mmseg/datasets/cihp.py
+++ b/mmseg/datasets/cihp.py
@@ -1,0 +1,32 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from .builder import DATASETS
+from .custom import CustomDataset
+
+
+@DATASETS.register_module()
+class CIHPDataset(CustomDataset):
+    """CIHP dataset.
+
+    In segmentation map annotation for CIHP, 0 stands for background,
+    which is included in 20 categories. ``reduce_zero_label`` is fixed to
+    False. The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
+    fixed to '.png'.
+    """
+    CLASSES = ('background', 'hat', 'hair', 'glove', 'sunglasses', 'upperclothes',
+        'dress', 'coat', 'socks', 'pants', 'torsoSkin', 'scarf', 'skirt', 'face', 
+        'leftArm', 'rightArm', 'leftLeg', 'rightLeg', 'leftShoe', 'rightShoe')
+
+    PALETTE = [[0, 0, 0], [128, 0, 0], [255, 0, 0], [0, 85, 0],
+               [170, 0, 51], [255, 85, 0], [0, 0, 85], [0, 119, 221], 
+               [85, 85, 0], [0, 85, 85], [85, 51, 0], [52, 86, 128], 
+               [0, 128, 0], [0, 0, 255], [51, 170, 221], [0, 255, 255], 
+               [85, 255, 170], [170, 255, 85], [255, 255, 0], [255, 170, 0]]
+
+    def __init__(self, **kwargs):
+        super(CIHPDataset, self).__init__(
+            img_suffix='.jpg',
+            seg_map_suffix='.png',
+            reduce_zero_label=False,
+            **kwargs)
+


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

[CIHP](https://openaccess.thecvf.com/content_ECCV_2018/papers/Ke_Gong_Instance-level_Human_Parsing_ECCV_2018_paper.pdf) is tasked for Multiple human parsing. There are 19 semantic classes and 1 background class. The dataset is divided into 28K/5K/5K images for training, validation and testing.

## Modification

1. Add mmseg/datasets/cihp.py to get the images and labels.
2. Add CIHPDataset in mmseg/datasets/__init__.py.
3. Add configs/_base_/datasets/cihp.py for CIHP dataset.
4. Add deeplabv3plus and pspnet config files of CIHP dataset. 
