### PR TITLE
Fix validation loss logging

### DIFF
--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -155,9 +155,14 @@ class BaseSegmentor(BaseModule, metaclass=ABCMeta):
         losses = self(**data_batch)
         loss, log_vars = self._parse_losses(losses)
 
+        log_vars_ = dict()
+        for loss_name, loss_value in log_vars.items():
+            k = loss_name + '_val'
+            log_vars_[k] = loss_value
+
         outputs = dict(
             loss=loss,
-            log_vars=log_vars,
+            log_vars=log_vars_,
             num_samples=len(data_batch['img_metas']))
 
         return outputs


### PR DESCRIPTION
## Motivation

The validation loss is currently not logged in the setting of both train and val workflow modes.

The problem is described in this issue:
https://github.com/open-mmlab/mmsegmentation/issues/1396

> Iteration runner calls the model's val_step here
https://github.com/open-mmlab/mmcv/blob/44edcdd91f8940a58c9680c609febc757a50a040/mmcv/runner/iter_based_runner.py#L77

> The model's val_step returns the loss under the same key as in the training mode, which gets lost in all output logs later on.

### The training log in master

```
2022-04-19 19:32:16,444 - mmseg - INFO - workflow: [('train', 1), ('val', 1)], max: 60000 iters
2022-04-19 19:32:16,444 - mmseg - INFO - Checkpoints will be saved to /home/SENSETIME/zhengmiao/openmmlab/mmsegmentation/work_dir/test_val by HardDiskBackend.
2022-04-19 19:32:28,897 - mmseg - INFO - Iter [50/60000]        lr: 9.993e-04, eta: 1:42:42, time: 0.103, data_time: 0.031, memory: 1826, decode.loss_ce: 8.7741, decode.acc_seg: 46.9911, loss: 8.7741
2022-04-19 19:32:38,829 - mmseg - INFO - Iter [100/60000]       lr: 9.987e-04, eta: 1:39:56, time: 0.097, data_time: 0.025, memory: 1826, decode.loss_ce: 7.8357, decode.acc_seg: 55.5759, loss: 7.8357
2022-04-19 19:32:48,881 - mmseg - INFO - Iter [150/60000]       lr: 9.980e-04, eta: 1:40:39, time: 0.103, data_time: 0.031, memory: 1826, decode.loss_ce: 6.8078, decode.acc_seg: 55.5736, loss: 6.8078
2022-04-19 19:32:58,964 - mmseg - INFO - Iter [200/60000]       lr: 9.973e-04, eta: 1:39:12, time: 0.095, data_time: 0.024, memory: 1826, decode.loss_ce: 7.4038, decode.acc_seg: 55.5497, loss: 7.4038
2022-04-19 19:33:10,215 - mmseg - INFO - Iter [250/60000]       lr: 9.966e-04, eta: 1:41:36, time: 0.112, data_time: 0.040, memory: 1826, decode.loss_ce: 7.9811, decode.acc_seg: 50.0213, loss: 7.9811
2022-04-19 19:33:21,737 - mmseg - INFO - Iter [300/60000]       lr: 9.960e-04, eta: 1:44:22, time: 0.119, data_time: 0.047, memory: 1826, decode.loss_ce: 7.5471, decode.acc_seg: 56.7233, loss: 7.5471

```

### The training log in this pr

```
2022-04-19 19:38:37,786 - mmseg - INFO - workflow: [('train', 1), ('val', 1)], max: 60000 iters
2022-04-19 19:38:37,786 - mmseg - INFO - Checkpoints will be saved to /home/SENSETIME/zhengmiao/openmmlab/mmsegmentation/work_dir/test_val by HardDiskBackend.
2022-04-19 19:38:48,518 - mmseg - INFO - Iter [50/60000]        lr: 9.993e-04, eta: 1:24:30, time: 0.085, data_time: 0.007, memory: 1826, decode.loss_ce: 8.6380, decode.acc_seg: 47.9639, loss: 8.6380, decode.loss_ce_val: 9.4497, decode.acc_seg_val: 42.7901, loss_val: 9.4497
2022-04-19 19:38:56,737 - mmseg - INFO - Iter [100/60000]       lr: 9.987e-04, eta: 1:22:30, time: 0.081, data_time: 0.005, memory: 1826, decode.loss_ce: 8.6980, decode.acc_seg: 50.3345, loss: 8.6980, decode.loss_ce_val: 7.5011, decode.acc_seg_val: 52.2022, loss_val: 7.5011
2022-04-19 19:39:05,216 - mmseg - INFO - Iter [150/60000]       lr: 9.980e-04, eta: 1:22:42, time: 0.083, data_time: 0.010, memory: 1826, decode.loss_ce: 8.0604, decode.acc_seg: 50.3131, loss: 8.0604, decode.loss_ce_val: 9.1770, decode.acc_seg_val: 45.5095, loss_val: 9.1770
2022-04-19 19:39:14,397 - mmseg - INFO - Iter [200/60000]       lr: 9.973e-04, eta: 1:25:00, time: 0.092, data_time: 0.021, memory: 1826, decode.loss_ce: 8.1406, decode.acc_seg: 50.2319, loss: 8.1406, decode.loss_ce_val: 8.5317, decode.acc_seg_val: 50.3491, loss_val: 8.5317
2022-04-19 19:39:23,989 - mmseg - INFO - Iter [250/60000]       lr: 9.966e-04, eta: 1:26:10, time: 0.092, data_time: 0.021, memory: 1826, decode.loss_ce: 7.0185, decode.acc_seg: 61.1673, loss: 7.0185, decode.loss_ce_val: 6.7485, decode.acc_seg_val: 65.5584, loss_val: 6.7485
2022-04-19 19:39:34,398 - mmseg - INFO - Iter [300/60000]       lr: 9.960e-04, eta: 1:29:11, time: 0.105, data_time: 0.033, memory: 1826, decode.loss_ce: 7.7831, decode.acc_seg: 52.2874, loss: 7.7831, decode.loss_ce_val: 8.1309, decode.acc_seg_val: 52.5872, loss_val: 8.1309

```

## Modification

`val_step` is modified to add `_val` suffix to all validation losses, to distinguish those losses from those in the training step. This enables both training and validation loss logging.
