### PR TITLE
Fix potential bugs in accuracy.py

### DIFF
--- a/mmseg/models/losses/accuracy.py
+++ b/mmseg/models/losses/accuracy.py
@@ -45,14 +45,18 @@ def accuracy(pred, target, topk=1, thresh=None, ignore_index=None):
     if thresh is not None:
         # Only prediction values larger than thresh are counted as correct
         correct = correct & (pred_value > thresh).t()
-    correct = correct[:, target != ignore_index]
+    if ignore_index is not None:
+        correct = correct[:, target != ignore_index]
     res = []
     eps = torch.finfo(torch.float32).eps
     for k in topk:
         # Avoid causing ZeroDivisionError when all pixels
         # of an image are ignored
         correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True) + eps
-        total_num = target[target != ignore_index].numel() + eps
+        if ignore_index is not None:
+            total_num = target[target != ignore_index].numel() + eps
+        else:
+            total_num = target.numel() + eps
         res.append(correct_k.mul_(100.0 / total_num))
     return res[0] if return_single else res
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

There is a potential bug in accuracy.py, and This PR aims to fix this issue. 
In line https://github.com/open-mmlab/mmsegmentation/blob/618d3c3bccdceb45372fb2e9e9228285af63fe4d/mmseg/models/losses/accuracy.py#L48, `correct = correct[:, target != ignore_index]` is used to filter out the ignored targets. However, as the default value of `ignore_index` is None, this line would cause unwanted behavior. For example
```python
>>> target = torch.ones(3)
>>> target != 255
tensor([True,  True, True])
>>> target != None
True
>>> target[target != 255].shape
torch.Size([3])
>>> target[target != None].shape
torch.Size([1, 3])
```
Therefore an unwanted additional dimension is created in the original implementation. Luckily, the `correct ` tensor is finally flattened and the above behavior would not affect the final results. However, this is still a potential bug, and a quick fix would be better.  

## Modification

I used an `if else` condition to cater for the case of `ignored_index is None`. 

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
