### PR TITLE
[Fix] Revise high workers_per_gpus

### DIFF
--- a/configs/bisenetv1/bisenetv1_r18-d32_in1k-pre_4x8_1024x1024_160k_cityscapes.py
+++ b/configs/bisenetv1/bisenetv1_r18-d32_in1k-pre_4x8_1024x1024_160k_cityscapes.py
@@ -1,5 +1,5 @@
 _base_ = './bisenetv1_r18-d32_in1k-pre_4x4_1024x1024_160k_cityscapes.py'
 data = dict(
     samples_per_gpu=8,
-    workers_per_gpu=8,
+    workers_per_gpu=4,
 )

--- a/configs/bisenetv2/bisenetv2_fcn_4x8_1024x1024_160k_cityscapes.py
+++ b/configs/bisenetv2/bisenetv2_fcn_4x8_1024x1024_160k_cityscapes.py
@@ -7,5 +7,5 @@ lr_config = dict(warmup='linear', warmup_iters=1000)
 optimizer = dict(lr=0.05)
 data = dict(
     samples_per_gpu=8,
-    workers_per_gpu=8,
+    workers_per_gpu=4,
 )

--- a/configs/cgnet/cgnet_512x1024_60k_cityscapes.py
+++ b/configs/cgnet/cgnet_512x1024_60k_cityscapes.py
@@ -45,7 +45,7 @@ test_pipeline = [
 ]
 data = dict(
     samples_per_gpu=8,
-    workers_per_gpu=8,
+    workers_per_gpu=4,
     train=dict(
         type=dataset_type,
         data_root=data_root,

--- a/configs/cgnet/cgnet_680x680_60k_cityscapes.py
+++ b/configs/cgnet/cgnet_680x680_60k_cityscapes.py
@@ -44,7 +44,7 @@ test_pipeline = [
 ]
 data = dict(
     samples_per_gpu=8,
-    workers_per_gpu=8,
+    workers_per_gpu=4,
     train=dict(pipeline=train_pipeline),
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When workers of dataloader are too many, it might affect CPU efficiency and speed.

## Modification

1. revise`workers_per_gpu=8` to ` workers_per_gpu=4`

