### PR TITLE
[Doc] Add more clearly statement of CPU training/inference

### DIFF
--- a/docs/en/inference.md
+++ b/docs/en/inference.md
@@ -16,7 +16,8 @@ You can use the following commands to test a dataset.
 # single-gpu testing
 python tools/test.py ${CONFIG_FILE} ${CHECKPOINT_FILE} [--out ${RESULT_FILE}] [--eval ${EVAL_METRICS}] [--show]
 
-# CPU: disable GPUs and run single-gpu testing script
+# CPU: If GPU unavailable, directly running sing-gpu testing command above
+# CPU: If GPU available, disable GPUs and run single-gpu testing script
 export CUDA_VISIBLE_DEVICES=-1
 python tools/test.py ${CONFIG_FILE} ${CHECKPOINT_FILE} [--out ${RESULT_FILE}] [--eval ${EVAL_METRICS}] [--show]
 

--- a/docs/en/train.md
+++ b/docs/en/train.md
@@ -37,7 +37,7 @@ If you want to specify the working directory in the command, you can add an argu
 
 #### Train with CPU
 
-The process of training on the CPU is consistent with single GPU training. We just need to disable GPUs before the training process.
+The process of training on the CPU is consistent with single GPU training if machine does not have GPU. If it has GPUs but not wanting to use it, we just need to disable GPUs before the training process.
 
 ```shell
 export CUDA_VISIBLE_DEVICES=-1

--- a/docs/zh_cn/inference.md
+++ b/docs/zh_cn/inference.md
@@ -15,8 +15,9 @@
 # 单卡 GPU 测试
 python tools/test.py ${配置文件} ${检查点文件} [--out ${结果文件}] [--eval ${评估指标}] [--show]
 
-# CPU: 禁用 GPU 并运行单 GPU 测试脚本
-export CUDA_VISIBLE_DEVICES=-1
+# CPU: 如果机器没有 GPU, 则跟上述单卡 GPU 测试一致
+# CPU: 如果机器有 GPU, 那么先禁用 GPU 再运行单 GPU 测试脚本
+export CUDA_VISIBLE_DEVICES=-1 # 禁用 GPU
 python tools/test.py ${配置文件} ${检查点文件} [--out ${结果文件}] [--eval ${评估指标}] [--show]
 
 # 多卡GPU 测试

--- a/docs/zh_cn/train.md
+++ b/docs/zh_cn/train.md
@@ -27,7 +27,7 @@ python tools/train.py ${CONFIG_FILE} [可选参数]
 
 #### 使用 CPU 训练
 
-使用 CPU 训练的流程和使用单 GPU 训练的流程一致，我们仅需要在训练流程开始前禁用 GPU。
+如果计算机没有 GPU，那么使用 CPU 训练的流程和使用单 GPU 训练的流程一致。如果计算机有 GPU 但是想使用 CPU，我们仅需要在训练流程开始前禁用 GPU。
 
 ```shell
 export CUDA_VISIBLE_DEVICES=-1


### PR DESCRIPTION
## Motivation

Fix: https://github.com/open-mmlab/mmsegmentation/issues/1513

Add more clearly statement of CPU training/inference, i.e., if no GPU, MMSegmentation would use CPU training/testing automatically and set `CUDA_VISIBLE_DEVICES=-1` is unnecessary.

