### PR TITLE
[Fix] Fix the bug in binary_cross_entropy

### DIFF
--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -118,7 +118,7 @@ def binary_cross_entropy(pred,
     if pred.size(1) == 1:
         # For binary class segmentation, the shape of pred is
         # [N, 1, H, W] and that of label is [N, H, W].
-        assert label.max() <= 1, \
+        assert label[label != ignore_index].max() <= 1, \
             'For pred with shape [N, 1, H, W], its label must have at ' \
             'most 2 classes'
         pred = pred.squeeze()


### PR DESCRIPTION
## Motivation

 Fix the bug in binary_cross_entropy
[' label.max() <= 1'](https://github.com/open-mmlab/mmsegmentation/blob/master/mmseg/models/losses/cross_entropy_loss.py#L121) should mask out ignore_index, since the ignore_index often set as 255.
Related Issuse [#1525](https://github.com/open-mmlab/mmsegmentation/issues/1525)

## Modification

Add a mask.

```python
if pred.size(1) == 1:
        # For binary class segmentation, the shape of pred is
        # [N, 1, H, W] and that of label is [N, H, W].
        assert label[label != ignore_index].max() <= 1, \
            'For pred with shape [N, 1, H, W], its label must have at ' \
            'most 2 classes'
        pred = pred.squeeze()
```