### PR TITLE
Replace Arxiv with ICCV bibtex entry

### DIFF
--- a/configs/segmenter/README.md
+++ b/configs/segmenter/README.md
@@ -22,11 +22,13 @@ Image segmentation is often ambiguous at the level of individual image patches a
 </div>
 
 ```bibtex
-@article{strudel2021Segmenter,
-  title={Segmenter: Transformer for Semantic Segmentation},
-  author={Strudel, Robin and Ricardo, Garcia, and Laptev, Ivan and Schmid, Cordelia},
-  journal={arXiv preprint arXiv:2105.05633},
-  year={2021}
+@InProceedings{strudel2021Segmenter,
+  title     = {Segmenter: Transformer for Semantic Segmentation},
+  author    = {Strudel, Robin and Garcia, Ricardo and Laptev, Ivan and Schmid, Cordelia},
+  booktitle = {Proceedings of the IEEE/CVF International Conference on Computer Vision (ICCV)},
+  month     = {October},
+  year      = {2021},
+  pages     = {7262-7272}
 }
 ```
 

--- a/configs/segmenter/README.md
+++ b/configs/segmenter/README.md
@@ -22,13 +22,12 @@ Image segmentation is often ambiguous at the level of individual image patches a
 </div>
 
 ```bibtex
-@InProceedings{strudel2021Segmenter,
-  title     = {Segmenter: Transformer for Semantic Segmentation},
-  author    = {Strudel, Robin and Garcia, Ricardo and Laptev, Ivan and Schmid, Cordelia},
-  booktitle = {Proceedings of the IEEE/CVF International Conference on Computer Vision (ICCV)},
-  month     = {October},
-  year      = {2021},
-  pages     = {7262-7272}
+@inproceedings{strudel2021segmenter,
+  title={Segmenter: Transformer for semantic segmentation},
+  author={Strudel, Robin and Garcia, Ricardo and Laptev, Ivan and Schmid, Cordelia},
+  booktitle={Proceedings of the IEEE/CVF International Conference on Computer Vision},
+  pages={7262--7272},
+  year={2021}
 }
 ```
 


### PR DESCRIPTION
Replace Arxiv with ICCV bibtex entry

Source: https://openaccess.thecvf.com/content/ICCV2021/html/Strudel_Segmenter_Transformer_for_Semantic_Segmentation_ICCV_2021_paper.html

