### PR TITLE
[Fix] Fix `UnicodeDecodeError` in `md2yml.py`

### DIFF
--- a/.dev/md2yml.py
+++ b/.dev/md2yml.py
@@ -88,7 +88,7 @@ def parse_md(md_file):
     # should be set with head or neck of this config file.
     is_backbone = None
 
-    with open(md_file, 'r') as md:
+    with open(md_file, 'r', encoding='UTF-8') as md:
         lines = md.readlines()
         i = 0
         current_dataset = ''


### PR DESCRIPTION
## Motivation

Currently, `md2yml.py` is usually used in MMSegmentation for generating metafile of each algorithm automatically.

However,  `UnicodeDecodeError` would be raised if not specified encoding format of each markdown file.

![image](https://user-images.githubusercontent.com/24582831/166892993-04c9d2e9-f99b-4e75-9b9f-767666e6e1d1.png)

Error above would be solved only needs to add `encoding='UTF-8'`:

![image](https://user-images.githubusercontent.com/24582831/166893765-69cacf71-c522-4083-9224-356c3f489c12.png)
