### PR TITLE
[Fix] Fix ConvNeXt optimizer constructor

### DIFF
--- a/mmseg/core/optimizers/layer_decay_optimizer_constructor.py
+++ b/mmseg/core/optimizers/layer_decay_optimizer_constructor.py
@@ -21,10 +21,7 @@ def get_layer_id_for_convnext(var_name, max_layer_id):
         ``LearningRateDecayOptimizerConstructor``.
     """
 
-    if var_name in ('backbone.cls_token', 'backbone.mask_token',
-                    'backbone.pos_embed'):
-        return 0
-    elif var_name.startswith('backbone.downsample_layers'):
+    if var_name.startswith('backbone.downsample_layers'):
         stage_id = int(var_name.split('.')[2])
         if stage_id == 0:
             layer_id = 0
@@ -64,10 +61,7 @@ def get_stage_id_for_convnext(var_name, max_stage_id):
         ``LearningRateDecayOptimizerConstructor``.
     """
 
-    if var_name in ('backbone.cls_token', 'backbone.mask_token',
-                    'backbone.pos_embed'):
-        return 0
-    elif var_name.startswith('backbone.downsample_layers'):
+    if var_name.startswith('backbone.downsample_layers'):
         return 0
     elif var_name.startswith('backbone.stages'):
         stage_id = int(var_name.split('.')[2])

--- a/tests/test_core/test_layer_decay_optimizer_constructor.py
+++ b/tests/test_core/test_layer_decay_optimizer_constructor.py
@@ -129,9 +129,6 @@ class ToyConvNeXt(nn.Module):
         self.norm0 = nn.BatchNorm2d(2)
 
         # add some variables to meet unit test coverate rate
-        self.cls_token = nn.Parameter(torch.ones(1))
-        self.mask_token = nn.Parameter(torch.ones(1))
-        self.pos_embed = nn.Parameter(torch.ones(1))
         self.stem_norm = nn.Parameter(torch.ones(1))
         self.downsample_norm0 = nn.BatchNorm2d(2)
         self.downsample_norm1 = nn.BatchNorm2d(2)


### PR DESCRIPTION
## Motivation
Delete unnecessary lines of ConvNeXt optimizer constructor, i.e., ConvNeXt in our codebase does not have `backbone.cls_token`, `backbone.mask_token` and `backbone.pos_embed` parameters.

## Example of keys in MMSegmentation ConvNeXt

It does not have those three parameters.

![image](https://user-images.githubusercontent.com/24582831/167086489-9bfb6741-266e-4d4e-a6e1-ba06608a9e12.png)
