### PR TITLE
fix: correct inference_demo.ipynb path

### DIFF
--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -244,7 +244,7 @@ python demo/image_demo.py demo/demo.png configs/pspnet/pspnet_r50-d8_512x1024_40
     checkpoints/pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth --device cuda:0 --palette cityscapes
 ```
 
-A notebook demo can be found in [demo/inference_demo.ipynb](../demo/inference_demo.ipynb).
+A notebook demo can be found in [demo/inference_demo.ipynb](../../demo/inference_demo.ipynb).
 
 Now we also provide a demo script to test a single video.
 

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -244,4 +244,4 @@ python demo/image_demo.py demo/demo.jpg configs/pspnet/pspnet_r50-d8_512x1024_40
     checkpoints/pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth --device cuda:0 --palette cityscapes
 ```
 
-推理的 demo 文档可在此查询：[demo/inference_demo.ipynb](../demo/inference_demo.ipynb) 。
+推理的 demo 文档可在此查询：[demo/inference_demo.ipynb](../../demo/inference_demo.ipynb) 。


### PR DESCRIPTION
## Motivation

I try to see the demo jupyter notebook` inference_demo.ipynb`, but the superlink in `get_started.md` is wrong

## Modification

Correct the `inference_demo.ipynb` superlink in get_started.md

