### PR TITLE
[Enhancement] Improve Dockerfile of mmsegmentation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTORCH="1.11.0"
 ARG CUDA="11.3"
 ARG CUDNN="8"
+ARG MMCV="1.5.0"
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
@@ -40,7 +41,7 @@ SHELL ["/bin/bash", "-c"]
 ARG PYTORCH
 ARG CUDA
 ARG MMCV
-RUN pip install --no-cache-dir mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu${CUDA//./}/torch${PYTORCH}/index.html
+RUN pip install --no-cache-dir mmcv-full==${MMCV} -f https://download.openmmlab.com/mmcv/dist/cu${CUDA//./}/torch${PYTORCH}/index.html
 
 # Install MMSegmentation
 ARG MMSEG_VERISON=master

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ ARG PYTORCH="1.11.0"
 ARG CUDA="11.3"
 ARG CUDNN="8"
 ARG MMCV="1.5.0"
+ARG MMSEG="master"
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
@@ -44,8 +45,8 @@ ARG MMCV
 RUN pip install --no-cache-dir mmcv-full==${MMCV} -f https://download.openmmlab.com/mmcv/dist/cu${CUDA//./}/torch${PYTORCH}/index.html
 
 # Install MMSegmentation
-ARG MMSEG_VERISON=master
-RUN git clone https://github.com/open-mmlab/mmsegmentation.git /home/$USERNAME/mmsegmentation -b ${MMSEG_VERISON}
+ARG MMSEG
+RUN git clone https://github.com/open-mmlab/mmsegmentation.git /home/$USERNAME/mmsegmentation -b ${MMSEG}
 WORKDIR /home/$USERNAME/mmsegmentation
 ENV FORCE_CUDA="1"
 RUN pip install -r requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machi
 ARG GID=1000
 ARG UID=1000
 ENV USERNAME mmseg
-ENV HOME /home/$USERNAME 
+ENV HOME /home/$USERNAME
 RUN groupadd -f -g ${GID} ${USERNAME}
 RUN useradd -m $USERNAME -u ${UID} -g ${GID} && \
     echo "$USERNAME:$USERNAME" | chpasswd && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,21 +12,46 @@ ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
 
-RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx \
+# add new sudo user
+ARG GID=1000
+ARG UID=1000
+ENV USERNAME mmseg
+ENV HOME /home/$USERNAME 
+RUN groupadd -f -g ${GID} ${USERNAME}
+RUN useradd -m $USERNAME -u ${UID} -g ${GID} && \
+    echo "$USERNAME:$USERNAME" | chpasswd && \
+    usermod --shell /bin/bash $USERNAME && \
+    usermod -aG sudo $USERNAME && \
+    mkdir /etc/sudoers.d && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME
+
+RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx sudo curl wget bash-completion \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN conda clean --all
 
+USER $USERNAME
+WORKDIR /home/$USERNAME
+SHELL ["/bin/bash", "-c"]
+
 # Install MMCV
 ARG PYTORCH
 ARG CUDA
 ARG MMCV
-RUN ["/bin/bash", "-c", "pip install --no-cache-dir mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu${CUDA//./}/torch${PYTORCH}/index.html"]
+RUN pip install --no-cache-dir mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu${CUDA//./}/torch${PYTORCH}/index.html
 
 # Install MMSegmentation
-RUN git clone https://github.com/open-mmlab/mmsegmentation.git /mmsegmentation
-WORKDIR /mmsegmentation
+ARG MMSEG_VERISON=master
+RUN git clone https://github.com/open-mmlab/mmsegmentation.git /home/$USERNAME/mmsegmentation -b ${MMSEG_VERISON}
+WORKDIR /home/$USERNAME/mmsegmentation
 ENV FORCE_CUDA="1"
 RUN pip install -r requirements.txt
 RUN pip install --no-cache-dir -e .
+
+# Install package for tools
+RUN pip install seaborn scipy
+
+# Set PATH
+RUN echo "export PATH=$PATH:$HOME/.local/bin" >> ~/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,10 +34,12 @@ If you use mmsegmentation `0.24.1`, please type the following command.
 
 ### with X11
 
+Official [demo scripts](https://github.com/open-mmlab/mmsegmentation/tree/v0.24.1/demo) need X11. So, if you would like to visualize the results, please run the script `launch_container_x11.sh` to enable X11 in docker container.
+
 ```
 ./launch_container_x11.sh <mmseg_version>
 ```
-Official [demo scripts](https://github.com/open-mmlab/mmsegmentation/tree/v0.24.1/demo) need X11. So, if you would like to visualize the results, please run the script `launch_container_x11.sh` to enable X11 in docker container.
+
 If you use mmsegmentation `0.24.1`, please type the following command.
 
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,11 @@
 # Dockerfile for mmsegmentation
 
+## Requirements
+
+- NVIDIA graphics driver
+- docker >=19.03
+- nvidia-docker2
+
 ## Build docker image
 
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+# Dockerfile for mmsegmentation
+
+## Build docker image
+
+```
+./build_image.sh <mmseg_version>
+```
+
+If you use mmsegmentation `0.24.1`, please type the following commnand.
+
+```
+./build_image.sh 0.24.1
+```
+
+## Launch docker container
+
+### without X11
+
+```
+./launch_container.sh <mmseg_version>
+```
+
+If you use mmsegmentation `0.24.1`, please type the following commnand.
+
+```
+./launch_container.sh 0.24.1
+```
+
+### with X11
+
+```
+./launch_container_x11.sh <mmseg_version>
+```
+
+If you use mmsegmentation `0.24.1`, please type the following commnand.
+
+```
+./launch_container_x11.sh 0.24.1
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@
 ./build_image.sh <mmseg_version>
 ```
 
-If you use mmsegmentation `0.24.1`, please type the following commnand.
+If you use mmsegmentation `0.24.1`, please type the following command.
 
 ```
 ./build_image.sh 0.24.1
@@ -20,7 +20,7 @@ If you use mmsegmentation `0.24.1`, please type the following commnand.
 ./launch_container.sh <mmseg_version>
 ```
 
-If you use mmsegmentation `0.24.1`, please type the following commnand.
+If you use mmsegmentation `0.24.1`, please type the following command.
 
 ```
 ./launch_container.sh 0.24.1
@@ -32,7 +32,7 @@ If you use mmsegmentation `0.24.1`, please type the following commnand.
 ./launch_container_x11.sh <mmseg_version>
 ```
 
-If you use mmsegmentation `0.24.1`, please type the following commnand.
+If you use mmsegmentation `0.24.1`, please type the following command.
 
 ```
 ./launch_container_x11.sh 0.24.1

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,7 +37,7 @@ If you use mmsegmentation `0.24.1`, please type the following command.
 ```
 ./launch_container_x11.sh <mmseg_version>
 ```
-
+Official [demo scripts](https://github.com/open-mmlab/mmsegmentation/tree/v0.24.1/demo) need X11. So, if you would like to visualize the results, please run the script `launch_container_x11.sh` to enable X11 in docker container.
 If you use mmsegmentation `0.24.1`, please type the following command.
 
 ```

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ $# != 1 ]; then
+    echo "usage: $0 <mmseg_version>"
+    exit 1
+fi
+
+mmseg_version=$1
+
+docker build -t mmsegmentation:${mmseg_version} \
+             --build-arg GID=$(id -g) \
+             --build-arg UID=$(id -u) \
+             --build-arg MMSEG_VERISON=v${mmseg_version} \
+             .

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -10,5 +10,5 @@ mmseg_version=$1
 docker build -t mmsegmentation:${mmseg_version} \
              --build-arg GID=$(id -g) \
              --build-arg UID=$(id -u) \
-             --build-arg MMSEG_VERISON=v${mmseg_version} \
+             --build-arg MMSEG=v${mmseg_version} \
              .

--- a/docker/launch_container.sh
+++ b/docker/launch_container.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ $# != 1 ]; then
+    echo "usage: $0 <mmseg_version>"
+    exit 1
+fi
+
+mmseg_version=$1
+
+docker run --gpus all -it \
+           --shm-size=4gb \
+           --env=TERM=xterm-256color \
+           --net=host \
+           --name=mmsegmentation-${mmseg_version} \
+           mmsegmentation:${mmseg_version} \
+           bash

--- a/docker/launch_container_x11.sh
+++ b/docker/launch_container_x11.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ $# != 1 ]; then
+    echo "usage: $0 <mmseg_version>"
+    exit 1
+fi
+
+mmseg_version=$1
+
+XSOCK=/tmp/.X11-unix
+XAUTH=/tmp/.docker.xauth
+touch $XAUTH
+xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+
+docker run --gpus all -it \
+           --volume=$XSOCK:$XSOCK:rw \
+           --volume=$XAUTH:$XAUTH:rw \
+           --shm-size=4gb \
+           --env="XAUTHORITY=${XAUTH}" \
+           --env="DISPLAY=${DISPLAY}" \
+           --env=TERM=xterm-256color \
+           --env=QT_X11_NO_MITSHM=1 \
+           --net=host \
+           --name=mmsegmentation-${mmseg_version}-x11 \
+           mmsegmentation:${mmseg_version} \
+           bash


### PR DESCRIPTION
## Motivation

[Current Dockerfile](https://github.com/open-mmlab/mmsegmentation/blob/v0.24.1/docker/Dockerfile) has the following problems.

- There is no README.
- In this docker container, there is no non-root account. So, it may cause permission problems.
- [This Dockerfile](<https://github.com/open-mmlab/mmsegmentation/blob/v0.24.1/docker/Dockerfile#L28>) clone master branch of mmsegmentation.
- Some packages are missing to use mmsegmentation tools.
- In docker container, shared memory size is too small. So, it may cause problems.

## Modification

I changed the following points to resolve mentioned problems.

- I add README to use Dockerfile.
- I changed Dockerfile to create non-root account.
- I changed Dockerfile to specify version of mmsegmentation.
- I changed Dockerfile to install packages for mmsegmentation tools.
  - seaborn : to use `analyze_logs.py`
  - scipy : to use `convert_datasets`
  - sudo : to operate as non-root account
  - curl, wget : to download dataset and pretraind model
  - bash-completion : to enable bash completion in docker container
- I add `--shm-size=4gb` to the option of `docker run`.

## Operation confirmation

## inference

```
mkdir checkpoints
wget https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x1024_40k_cityscapes/pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth -P checkpoints
python demo/image_demo.py demo/demo.png configs/pspnet/pspnet_r50-d8_512x1024_40k_cityscapes.py checkpoints/pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth --device cuda:0 --palette cityscapes
```

## training

```
python tools/train.py configs/pspnet/pspnet_r50-d8_512x512_20k_voc12aug.py
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
