### PR TITLE
[Enchance] support infererence with padding

### DIFF
--- a/mmseg/datasets/pipelines/test_time_aug.py
+++ b/mmseg/datasets/pipelines/test_time_aug.py
@@ -57,6 +57,14 @@ class MultiScaleFlipAug(object):
                  img_ratios=None,
                  flip=False,
                  flip_direction='horizontal'):
+        if flip:
+            trans_index = {
+                key['type']: index
+                for index, key in enumerate(transforms)
+            }
+            if 'RandomFlip' in trans_index and 'Pad' in trans_index:
+                assert trans_index['RandomFlip'] < trans_index['Pad'], \
+                    'Pad must be executed after RandomFlip when flip is True'
         self.transforms = Compose(transforms)
         if img_ratios is not None:
             img_ratios = img_ratios if isinstance(img_ratios,

--- a/mmseg/models/segmentors/encoder_decoder.py
+++ b/mmseg/models/segmentors/encoder_decoder.py
@@ -189,6 +189,9 @@ class EncoderDecoder(BaseSegmentor):
                 count_mat.cpu().detach().numpy()).to(device=img.device)
         preds = preds / count_mat
         if rescale:
+            # remove padding area
+            resize_shape = img_meta[0]['img_shape'][:2]
+            preds = preds[:, :, :resize_shape[0], :resize_shape[1]]
             preds = resize(
                 preds,
                 size=img_meta[0]['ori_shape'][:2],
@@ -206,6 +209,9 @@ class EncoderDecoder(BaseSegmentor):
             if torch.onnx.is_in_onnx_export():
                 size = img.shape[2:]
             else:
+                # remove padding area
+                resize_shape = img_meta[0]['img_shape'][:2]
+                seg_logit = seg_logit[:, :, :resize_shape[0], :resize_shape[1]]
                 size = img_meta[0]['ori_shape'][:2]
             seg_logit = resize(
                 seg_logit,


### PR DESCRIPTION
- Before padding
![飞书20220522-190911](https://user-images.githubusercontent.com/13444198/169692249-9559ff16-b711-4e16-865b-dc9a5f337506.jpg)
-  After padding
![飞书20220522-190917](https://user-images.githubusercontent.com/13444198/169692261-73528fa2-a62f-447e-9843-7a944bb2a7f1.jpg)


## Motivation

I use mmseg to train my model and found the mask has a left offset to the image. Finally I found that it is caused by inference input without padding. For example, A input with origin shape (1920, 1080) and `img_scale=(2048, 512)` will be resized to `(910 , 512)`.   When infer it with resnet50-d8，the final feature map is 114 * 64 and then resize it to 910*512. Attention that 114x8=912. So it is same with pad the input to (912, 512) and resize feature to (910, 512). With 2-pixel left offset

## BC-breaking (Optional)
Attention that when `dict(type='Pad', size_divisor=32),` is add, the model performance will intend to be improved, I have test several mIoU rise
- `configs/deeplabv3plus/deeplabv3plus_r50-d8_512x512_80k_ade20k.py`
from 42.72 to 42.78
- `configs/ocrnet/ocrnet_hr18s_512x512_80k_ade20k.py`
from 35.06 to 35.53
- `configs/knet/knet_s3_upernet_swin-l_8x2_512x512_adamw_80k_ade20k.py`
from 52.05 to 52.61

## Use cases (Optional)
Add `Pad` when inference to make sure that input can be divide to model stride.
[Update]
Attention that `Pad` must behinde `RandomFlip` when flip is True

```
test_pipeline = [
    dict(type='LoadImageFromFile'),
    dict(
        type='MultiScaleFlipAug',
        img_scale=(2048, 512),
        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
        flip=False,
        transforms=[
            dict(type='Resize', keep_ratio=True),
            dict(type='RandomFlip'),
            dict(type='Pad', size_divisor=32),
            dict(type='Normalize', **img_norm_cfg),
            dict(type='ImageToTensor', keys=['img']),
            dict(type='Collect', keys=['img']),
        ])
]
```
