### PR TITLE
[Fix] pip up grade when testing windows platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Upgrade pip
-        run: pip install pip --upgrade --user
+        run: python -m pip install pip --upgrade --user
       - name: Install OpenCV
         run: pip install opencv-python>=3
       - name: Install PyTorch


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. CI failed when testing windows platform, it needs fixing the pip up-grading command

## Modification

1. Revise .github/workflows/build.yml

## BC-breaking (Optional)

None
