### PR TITLE
Delegate logger to setup_multi_processes in train.py

### DIFF
--- a/mmseg/utils/set_env.py
+++ b/mmseg/utils/set_env.py
@@ -8,9 +8,10 @@ import torch.multiprocessing as mp
 from ..utils import get_root_logger
 
 
-def setup_multi_processes(cfg):
+def setup_multi_processes(cfg, logger=None):
     """Setup multi-processing environment variables."""
-    logger = get_root_logger()
+    if logger is None:
+        logger = get_root_logger()
 
     # set multi-process start method
     if platform.system() != 'Windows':

--- a/tools/train.py
+++ b/tools/train.py
@@ -166,7 +166,7 @@ def main():
     logger = get_root_logger(log_file=log_file, log_level=cfg.log_level)
 
     # set multi-process settings
-    setup_multi_processes(cfg)
+    setup_multi_processes(cfg, logger)
 
     # init the meta dict to record some important information such as
     # environment info and seed, which will be logged


### PR DESCRIPTION
Adresses #1611 by delegating the logger object in `tools/train.py` to `setup_multi_processes()`
