### PR TITLE
fix beit model converter

### DIFF
--- a/tools/model_converters/beit2mmseg.py
+++ b/tools/model_converters/beit2mmseg.py
@@ -20,14 +20,13 @@ def convert_beit(ckpt):
                 new_key = new_key.replace('mlp.fc1', 'ffn.layers.0.0')
             elif 'mlp.fc2' in new_key:
                 new_key = new_key.replace('mlp.fc2', 'ffn.layers.1')
+            new_ckpt[new_key] = v
         elif k.startswith('patch_embed'):
             new_key = k.replace('patch_embed.proj', 'patch_embed.projection')
+            new_ckpt[new_key] = v
         else:
             new_key = k
-        if k.startswith('fc_norm') or k.startswith('head'):
-            continue
-        new_key = 'backbone.' + new_key
-        new_ckpt[new_key] = v
+            new_ckpt[new_key] = v
 
     return new_ckpt
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The script in `tools/model_converters/beit2mmseg.py` doesn't match the key of models between the official repo and MMSegmentation style (e.g. backbone.*). 
The training log shows lots of keys in `missing keys in source state_dict`.
Trainging result after 1500 iteration:
|  aAcc | mIoU | mAcc |
| 39.95 | 1.97 | 3.46 |


## Modification

I modify `tools/model_converters/beit2mmseg.py`.
Now the warnings of missing keys related to 'backbone' disappear.
Trainging result after 1500 iteration:
| aAcc | mIoU | mAcc |
| 60.4 | 6.21 | 9.4  |

## BC-breaking (Optional)

## Use cases (Optional)

## Checklist
