### PR TITLE
[Fix] Fix the error of BCE loss when batch size is 1.

### DIFF
--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -124,7 +124,7 @@ def binary_cross_entropy(pred,
         assert label[label != ignore_index].max() <= 1, \
             'For pred with shape [N, 1, H, W], its label must have at ' \
             'most 2 classes'
-        pred = pred.squeeze()
+        pred = pred.squeeze(1)
     if pred.dim() != label.dim():
         assert (pred.dim() == 2 and label.dim() == 1) or (
                 pred.dim() == 4 and label.dim() == 3), \


### PR DESCRIPTION
## Motivation

The motivation of this PR is to fix the error of `binary_cross_entropy` when the batch size is 1.

## Modification

- binary_cross_entropy  
Modify the `pred.squeeze()` to `pred.squeeze(1)` to avoid the error caused by squeeze dimension 0 when batch size is 1.

## BC-breaking (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
