### PR TITLE
[Fix] Fix typo in LINCENSES.md

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,7 +1,7 @@
-# Licenses for special operations
+# Licenses for special features
 
 In this file, we list the features with other licenses instead of Apache 2.0. Users should be careful about adopting these features in any commercial matters.
 
-| Operation |                                                                        Files                                                                        |                            License                            |
+|  Feature  |                                                                        Files                                                                        |                            License                            |
 | :-------: | :-------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------: |
 | SegFormer | [mmseg/models/decode_heads/segformer_head.py](https://github.com/open-mmlab/mmsegmentation/blob/master/mmseg/models/decode_heads/segformer_head.py) | [NVIDIA License](https://github.com/NVlabs/SegFormer#license) |


### PR DESCRIPTION
Because of my carelessness, those `features` are wrongly replaced by `operations`. Now they are all modified.

Sorry for my carelessness.