### PR TITLE
This 3 lines add configs to the wandb instance, which will make the w…

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -157,6 +157,11 @@ def main():
         _, world_size = get_dist_info()
         cfg.gpu_ids = range(world_size)
 
+    # log configs to wandb
+    for hook in cfg.log_config.hooks:
+        if hook['type'] == 'MMSegWandbHook':
+            hook['init_kwargs'].update({'config': cfg._cfg_dict.to_dict()})
+
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))
     # dump config


### PR DESCRIPTION
## Motivation

This PR aims to solve this issue https://github.com/open-mmlab/mmcv/issues/1773 for mmsegmentation. It logs all configs to WandB. 

## Modification

I added three lines in the train.py script as suggested by https://github.com/open-mmlab/mmcv/issues/1773 

As mentioned in the issue, there is no chance to grab the cfg info inside the Logger, so i needed to add in into the train.py file...

## BC-breaking (Optional)

No

## Use cases (Optional)

Researchers want to filter experiments based on configurations. If you want to filter your experiments in WandB, you need to have some configurations and thus I added the lines.  

