### PR TITLE
[Fix] Fix DATASETS not imported error

### DIFF
--- a/tests/test_datasets/test_dataset.py
+++ b/tests/test_datasets/test_dataset.py
@@ -6,10 +6,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mmseg.datasets import (ADE20KDataset, BaseSegDataset,
-                            CityscapesDataset, COCOStuffDataset, ISPRSDataset,
-                            LoveDADataset, PascalVOCDataset, PotsdamDataset,
-                            iSAIDDataset)
+from mmseg.datasets import (ADE20KDataset, BaseSegDataset, CityscapesDataset,
+                            COCOStuffDataset, ISPRSDataset, LoveDADataset,
+                            PascalVOCDataset, PotsdamDataset, iSAIDDataset)
+from mmseg.registry import DATASETS
 from mmseg.utils import get_classes, get_palette
 
 


### PR DESCRIPTION
## Motivation
Fix bug produced by https://github.com/open-mmlab/mmsegmentation/pull/1791

## Solution
Just add 
```python
from mmseg.registry import DATASETS
```