### PR TITLE
[Fix] Use MMEngine BaseModule

### DIFF
--- a/mmseg/models/backbones/beit.py
+++ b/mmseg/models/backbones/beit.py
@@ -9,7 +9,8 @@ from mmcv.cnn import build_norm_layer
 from mmcv.cnn.bricks.drop import build_dropout
 from mmcv.cnn.utils.weight_init import (constant_init, kaiming_init,
                                         trunc_normal_)
-from mmcv.runner import BaseModule, ModuleList, _load_checkpoint
+from mmengine.model import BaseModule, ModuleList
+from mmengine.runner.checkpoint import _load_checkpoint
 from torch.nn.modules.batchnorm import _BatchNorm
 from torch.nn.modules.utils import _pair as to_2tuple
 

--- a/mmseg/models/backbones/bisenetv1.py
+++ b/mmseg/models/backbones/bisenetv1.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS

--- a/mmseg/models/backbones/bisenetv2.py
+++ b/mmseg/models/backbones/bisenetv2.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn as nn
 from mmcv.cnn import (ConvModule, DepthwiseSeparableConvModule,
                       build_activation_layer, build_norm_layer)
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS

--- a/mmseg/models/backbones/cgnet.py
+++ b/mmseg/models/backbones/cgnet.py
@@ -5,8 +5,8 @@ import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
 from mmcv.cnn import ConvModule, build_conv_layer, build_norm_layer
-from mmcv.runner import BaseModule
 from mmcv.utils.parrots_wrapper import _BatchNorm
+from mmengine.model import BaseModule
 
 from mmseg.registry import MODELS
 

--- a/mmseg/models/backbones/erfnet.py
+++ b/mmseg/models/backbones/erfnet.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 from mmcv.cnn import build_activation_layer, build_conv_layer, build_norm_layer
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS

--- a/mmseg/models/backbones/fast_scnn.py
+++ b/mmseg/models/backbones/fast_scnn.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.models.decode_heads.psp_head import PPM
 from mmseg.ops import resize

--- a/mmseg/models/backbones/hrnet.py
+++ b/mmseg/models/backbones/hrnet.py
@@ -3,8 +3,8 @@ import warnings
 
 import torch.nn as nn
 from mmcv.cnn import build_conv_layer, build_norm_layer
-from mmcv.runner import BaseModule, ModuleList, Sequential
 from mmcv.utils.parrots_wrapper import _BatchNorm
+from mmengine.model import BaseModule, ModuleList, Sequential
 
 from mmseg.ops import Upsample, resize
 from mmseg.registry import MODELS

--- a/mmseg/models/backbones/icnet.py
+++ b/mmseg/models/backbones/icnet.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS

--- a/mmseg/models/backbones/mit.py
+++ b/mmseg/models/backbones/mit.py
@@ -10,7 +10,7 @@ from mmcv.cnn.bricks.drop import build_dropout
 from mmcv.cnn.bricks.transformer import MultiheadAttention
 from mmcv.cnn.utils.weight_init import (constant_init, normal_init,
                                         trunc_normal_init)
-from mmcv.runner import BaseModule, ModuleList, Sequential
+from mmengine.model import BaseModule, ModuleList, Sequential
 
 from mmseg.registry import MODELS
 from ..utils import PatchEmbed, nchw_to_nlc, nlc_to_nchw

--- a/mmseg/models/backbones/mobilenet_v2.py
+++ b/mmseg/models/backbones/mobilenet_v2.py
@@ -3,7 +3,7 @@ import warnings
 
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 from torch.nn.modules.batchnorm import _BatchNorm
 
 from mmseg.registry import MODELS

--- a/mmseg/models/backbones/mobilenet_v3.py
+++ b/mmseg/models/backbones/mobilenet_v3.py
@@ -4,7 +4,7 @@ import warnings
 import mmcv
 from mmcv.cnn import ConvModule
 from mmcv.cnn.bricks import Conv2dAdaptivePadding
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 from torch.nn.modules.batchnorm import _BatchNorm
 
 from mmseg.registry import MODELS

--- a/mmseg/models/backbones/resnet.py
+++ b/mmseg/models/backbones/resnet.py
@@ -4,8 +4,8 @@ import warnings
 import torch.nn as nn
 import torch.utils.checkpoint as cp
 from mmcv.cnn import build_conv_layer, build_norm_layer, build_plugin_layer
-from mmcv.runner import BaseModule
 from mmcv.utils.parrots_wrapper import _BatchNorm
+from mmengine.model import BaseModule
 
 from mmseg.registry import MODELS
 from ..utils import ResLayer

--- a/mmseg/models/backbones/timm_backbone.py
+++ b/mmseg/models/backbones/timm_backbone.py
@@ -5,7 +5,7 @@ except ImportError:
     timm = None
 
 from mmcv.cnn.bricks.registry import NORM_LAYERS
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.registry import MODELS
 

--- a/mmseg/models/backbones/twins.py
+++ b/mmseg/models/backbones/twins.py
@@ -10,7 +10,7 @@ from mmcv.cnn.bricks.drop import build_dropout
 from mmcv.cnn.bricks.transformer import FFN
 from mmcv.cnn.utils.weight_init import (constant_init, normal_init,
                                         trunc_normal_init)
-from mmcv.runner import BaseModule, ModuleList
+from mmengine.model import BaseModule, ModuleList
 from torch.nn.modules.batchnorm import _BatchNorm
 
 from mmseg.models.backbones.mit import EfficientMultiheadAttention

--- a/mmseg/models/backbones/unet.py
+++ b/mmseg/models/backbones/unet.py
@@ -5,8 +5,8 @@ import torch.nn as nn
 import torch.utils.checkpoint as cp
 from mmcv.cnn import (UPSAMPLE_LAYERS, ConvModule, build_activation_layer,
                       build_norm_layer)
-from mmcv.runner import BaseModule
 from mmcv.utils.parrots_wrapper import _BatchNorm
+from mmengine.model import BaseModule
 
 from mmseg.ops import Upsample
 from mmseg.registry import MODELS

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 import torch
 import torch.nn as nn
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 from torch import Tensor
 
 from mmseg.data import build_pixel_sampler

--- a/mmseg/models/decode_heads/dpt_head.py
+++ b/mmseg/models/decode_heads/dpt_head.py
@@ -4,7 +4,7 @@ import math
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule, Linear, build_activation_layer
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS

--- a/mmseg/models/necks/fpn.py
+++ b/mmseg/models/necks/fpn.py
@@ -2,7 +2,6 @@
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
-from mmcv.runner import auto_fp16
 from mmengine.model import BaseModule
 
 from mmseg.ops import resize
@@ -160,7 +159,6 @@ class FPN(BaseModule):
                     inplace=False)
                 self.fpn_convs.append(extra_fpn_conv)
 
-    @auto_fp16()
     def forward(self, inputs):
         assert len(inputs) == len(self.in_channels)
 

--- a/mmseg/models/necks/fpn.py
+++ b/mmseg/models/necks/fpn.py
@@ -2,7 +2,8 @@
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
-from mmcv.runner import BaseModule, auto_fp16
+from mmcv.runner import auto_fp16
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS

--- a/mmseg/models/necks/ic_neck.py
+++ b/mmseg/models/necks/ic_neck.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS

--- a/mmseg/models/necks/jpu.py
+++ b/mmseg/models/necks/jpu.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
-from mmcv.runner import BaseModule
+from mmengine.model import BaseModule
 
 from mmseg.ops import resize
 from mmseg.registry import MODELS


### PR DESCRIPTION
## Motivation

Import `BaseModule` from MMEngine rather than MMCV.

