### PR TITLE
[Fix] Fix typo in customize_models.md

### DIFF
--- a/docs/en/tutorials/customize_models.md
+++ b/docs/en/tutorials/customize_models.md
@@ -85,7 +85,7 @@ Here we show how to develop new components with an example of MobileNet.
 ```python
 import torch.nn as nn
 
-from ..registry import BACKBONES
+from ..builder import BACKBONES
 
 
 @BACKBONES.register_module

--- a/docs/zh_cn/tutorials/customize_models.md
+++ b/docs/zh_cn/tutorials/customize_models.md
@@ -83,7 +83,7 @@ MMSegmentation 里主要有2种组件：
 ```python
 import torch.nn as nn
 
-from ..registry import BACKBONES
+from ..builder import BACKBONES
 
 
 @BACKBONES.register_module


### PR DESCRIPTION
## Motivation

find a typo in  customize_models.md 

## Modification

Fix a typo in documentation.
```python
# diff
=====
- from ..registry import BACKBONES
+ from ..builder import BACKBONES
=====
```