### PR TITLE
[Fix] Fix several config file errors in 2.0

### DIFF
--- a/configs/bisenetv1/bisenetv1_r101-d32_lr5e-3_4x4_512x512_160k_coco-stuff164k.py
+++ b/configs/bisenetv1/bisenetv1_r101-d32_lr5e-3_4x4_512x512_160k_coco-stuff164k.py
@@ -5,6 +5,7 @@ _base_ = [
 ]
 crop_size = (512, 512)
 data_preprocessor = dict(size=crop_size)
+norm_cfg = dict(type='SyncBN', requires_grad=True)
 model = dict(
     data_preprocessor=data_preprocessor,
     backbone=dict(
@@ -14,8 +15,30 @@ model = dict(
         backbone_cfg=dict(type='ResNet', depth=101)),
     decode_head=dict(in_channels=1024, channels=1024, num_classes=171),
     auxiliary_head=[
-        dict(in_channels=512, channels=256, num_classes=171),
-        dict(in_channels=512, channels=256, num_classes=171),
+        dict(
+            type='FCNHead',
+            in_channels=512,
+            channels=256,
+            num_convs=1,
+            num_classes=171,
+            in_index=1,
+            norm_cfg=norm_cfg,
+            concat_input=False,
+            align_corners=False,
+            loss_decode=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
+        dict(
+            type='FCNHead',
+            in_channels=512,
+            channels=256,
+            num_convs=1,
+            num_classes=171,
+            in_index=2,
+            norm_cfg=norm_cfg,
+            concat_input=False,
+            align_corners=False,
+            loss_decode=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
     ])
 param_scheduler = [
     dict(type='LinearLR', by_epoch=False, start_factor=0.1, begin=0, end=1000),

--- a/configs/bisenetv1/bisenetv1_r18-d32_lr5e-3_4x4_512x512_160k_coco-stuff164k.py
+++ b/configs/bisenetv1/bisenetv1_r18-d32_lr5e-3_4x4_512x512_160k_coco-stuff164k.py
@@ -5,12 +5,35 @@ _base_ = [
 ]
 crop_size = (512, 512)
 data_preprocessor = dict(size=crop_size)
+norm_cfg = dict(type='SyncBN', requires_grad=True)
 model = dict(
     data_preprocessor=data_preprocessor,
     decode_head=dict(num_classes=171),
     auxiliary_head=[
-        dict(num_classes=171),
-        dict(num_classes=171),
+        dict(
+            type='FCNHead',
+            in_channels=128,
+            channels=64,
+            num_convs=1,
+            num_classes=171,
+            in_index=1,
+            norm_cfg=norm_cfg,
+            concat_input=False,
+            align_corners=False,
+            loss_decode=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
+        dict(
+            type='FCNHead',
+            in_channels=128,
+            channels=64,
+            num_convs=1,
+            num_classes=171,
+            in_index=2,
+            norm_cfg=norm_cfg,
+            concat_input=False,
+            align_corners=False,
+            loss_decode=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
     ])
 param_scheduler = [
     dict(type='LinearLR', by_epoch=False, start_factor=0.1, begin=0, end=1000),

--- a/configs/bisenetv1/bisenetv1_r50-d32_lr5e-3_4x4_512x512_160k_coco-stuff164k.py
+++ b/configs/bisenetv1/bisenetv1_r50-d32_lr5e-3_4x4_512x512_160k_coco-stuff164k.py
@@ -5,6 +5,7 @@ _base_ = [
 ]
 crop_size = (512, 512)
 data_preprocessor = dict(size=crop_size)
+norm_cfg = dict(type='SyncBN', requires_grad=True)
 model = dict(
     data_preprocessor=data_preprocessor,
     backbone=dict(
@@ -14,8 +15,30 @@ model = dict(
         backbone_cfg=dict(type='ResNet', depth=50)),
     decode_head=dict(in_channels=1024, channels=1024, num_classes=171),
     auxiliary_head=[
-        dict(in_channels=512, channels=256, num_classes=171),
-        dict(in_channels=512, channels=256, num_classes=171),
+        dict(
+            type='FCNHead',
+            in_channels=512,
+            channels=256,
+            num_convs=1,
+            num_classes=171,
+            in_index=1,
+            norm_cfg=norm_cfg,
+            concat_input=False,
+            align_corners=False,
+            loss_decode=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
+        dict(
+            type='FCNHead',
+            in_channels=512,
+            channels=256,
+            num_convs=1,
+            num_classes=171,
+            in_index=2,
+            norm_cfg=norm_cfg,
+            concat_input=False,
+            align_corners=False,
+            loss_decode=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0)),
     ])
 param_scheduler = [
     dict(type='LinearLR', by_epoch=False, start_factor=0.1, begin=0, end=1000),

--- a/configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_80k_loveda.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r101-d8_512x512_80k_loveda.py
@@ -1,6 +1,2 @@
 _base_ = './deeplabv3plus_r50-d8_512x512_80k_loveda.py'
-model = dict(
-    backbone=dict(
-        depth=101,
-        init_cfg=dict(
-            type='Pretrained', checkpoint='open-mmlab://resnet101_v1c')))
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/deeplabv3plus/deeplabv3plus_r18-d8_512x512_80k_loveda.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r18-d8_512x512_80k_loveda.py
@@ -1,9 +1,7 @@
 _base_ = './deeplabv3plus_r50-d8_512x512_80k_loveda.py'
 model = dict(
-    backbone=dict(
-        depth=18,
-        init_cfg=dict(
-            type='Pretrained', checkpoint='open-mmlab://resnet18_v1c')),
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
     decode_head=dict(
         c1_in_channels=64,
         c1_channels=12,

--- a/configs/hrnet/fcn_hr18s_512x512_80k_loveda.py
+++ b/configs/hrnet/fcn_hr18s_512x512_80k_loveda.py
@@ -1,9 +1,7 @@
 _base_ = './fcn_hr18_512x512_80k_loveda.py'
 model = dict(
+    pretrained='open-mmlab://msra/hrnetv2_w18_small',
     backbone=dict(
-        init_cfg=dict(
-            type='Pretrained',
-            checkpoint='open-mmlab://msra/hrnetv2_w18_small'),
         extra=dict(
             stage1=dict(num_blocks=(2, )),
             stage2=dict(num_blocks=(2, 2)),

--- a/configs/hrnet/fcn_hr48_512x512_80k_loveda.py
+++ b/configs/hrnet/fcn_hr48_512x512_80k_loveda.py
@@ -1,8 +1,7 @@
 _base_ = './fcn_hr18_512x512_80k_loveda.py'
 model = dict(
+    pretrained='open-mmlab://msra/hrnetv2_w48',
     backbone=dict(
-        init_cfg=dict(
-            type='Pretrained', checkpoint='open-mmlab://msra/hrnetv2_w48'),
         extra=dict(
             stage2=dict(num_channels=(48, 96)),
             stage3=dict(num_channels=(48, 96, 192)),

--- a/configs/pspnet/pspnet_r101-d8_512x512_80k_loveda.py
+++ b/configs/pspnet/pspnet_r101-d8_512x512_80k_loveda.py
@@ -1,6 +1,2 @@
 _base_ = './pspnet_r50-d8_512x512_80k_loveda.py'
-model = dict(
-    backbone=dict(
-        depth=101,
-        init_cfg=dict(
-            type='Pretrained', checkpoint='open-mmlab://resnet101_v1c')))
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/pspnet/pspnet_r18-d8_512x512_80k_loveda.py
+++ b/configs/pspnet/pspnet_r18-d8_512x512_80k_loveda.py
@@ -1,9 +1,7 @@
 _base_ = './pspnet_r50-d8_512x512_80k_loveda.py'
 model = dict(
-    backbone=dict(
-        depth=18,
-        init_cfg=dict(
-            type='Pretrained', checkpoint='open-mmlab://resnet18_v1c')),
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
     decode_head=dict(
         in_channels=512,
         channels=128,

--- a/configs/swin/upernet_swin_large_patch4_window12_512x512_pretrain_384x384_22K_160k_ade20k.py
+++ b/configs/swin/upernet_swin_large_patch4_window12_512x512_pretrain_384x384_22K_160k_ade20k.py
@@ -1,0 +1,10 @@
+_base_ = [
+    'upernet_swin_large_patch4_window7_512x512_'
+    'pretrain_224x224_22K_160k_ade20k.py'
+]
+checkpoint_file = 'https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/swin/swin_large_patch4_window12_384_22k_20220412-6580f57d.pth'  # noqa
+model = dict(
+    backbone=dict(
+        init_cfg=dict(type='Pretrained', checkpoint=checkpoint_file),
+        pretrain_img_size=384,
+        window_size=12))

--- a/configs/swin/upernet_swin_large_patch4_window7_512x512_pretrain_224x224_22K_160k_ade20k.py
+++ b/configs/swin/upernet_swin_large_patch4_window7_512x512_pretrain_224x224_22K_160k_ade20k.py
@@ -1,0 +1,15 @@
+_base_ = [
+    'upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_'
+    'pretrain_224x224_1K.py'
+]
+checkpoint_file = 'https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/swin/swin_large_patch4_window7_224_22k_20220412-aeecf2aa.pth'  # noqa
+model = dict(
+    backbone=dict(
+        init_cfg=dict(type='Pretrained', checkpoint=checkpoint_file),
+        pretrain_img_size=224,
+        embed_dims=192,
+        depths=[2, 2, 18, 2],
+        num_heads=[6, 12, 24, 48],
+        window_size=7),
+    decode_head=dict(in_channels=[192, 384, 768, 1536], num_classes=150),
+    auxiliary_head=dict(in_channels=768, num_classes=150))

--- a/configs/upernet/upernet_r18_512x1024_40k_cityscapes.py
+++ b/configs/upernet/upernet_r18_512x1024_40k_cityscapes.py
@@ -1,0 +1,6 @@
+_base_ = './upernet_r50_512x1024_40k_cityscapes.py'
+model = dict(
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
+    decode_head=dict(in_channels=[64, 128, 256, 512]),
+    auxiliary_head=dict(in_channels=256))

--- a/configs/upernet/upernet_r18_512x1024_80k_cityscapes.py
+++ b/configs/upernet/upernet_r18_512x1024_80k_cityscapes.py
@@ -1,0 +1,6 @@
+_base_ = './upernet_r50_512x1024_80k_cityscapes.py'
+model = dict(
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
+    decode_head=dict(in_channels=[64, 128, 256, 512]),
+    auxiliary_head=dict(in_channels=256))

--- a/configs/upernet/upernet_r18_512x512_160k_ade20k.py
+++ b/configs/upernet/upernet_r18_512x512_160k_ade20k.py
@@ -1,0 +1,9 @@
+_base_ = [
+    '../_base_/models/upernet_r50.py', '../_base_/datasets/ade20k.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
+    decode_head=dict(in_channels=[64, 128, 256, 512], num_classes=150),
+    auxiliary_head=dict(in_channels=256, num_classes=150))

--- a/configs/upernet/upernet_r18_512x512_20k_voc12aug.py
+++ b/configs/upernet/upernet_r18_512x512_20k_voc12aug.py
@@ -1,0 +1,10 @@
+_base_ = [
+    '../_base_/models/upernet_r50.py',
+    '../_base_/datasets/pascal_voc12_aug.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_20k.py'
+]
+model = dict(
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
+    decode_head=dict(in_channels=[64, 128, 256, 512], num_classes=21),
+    auxiliary_head=dict(in_channels=256, num_classes=21))

--- a/configs/upernet/upernet_r18_512x512_40k_voc12aug.py
+++ b/configs/upernet/upernet_r18_512x512_40k_voc12aug.py
@@ -1,0 +1,10 @@
+_base_ = [
+    '../_base_/models/upernet_r50.py',
+    '../_base_/datasets/pascal_voc12_aug.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_40k.py'
+]
+model = dict(
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
+    decode_head=dict(in_channels=[64, 128, 256, 512], num_classes=21),
+    auxiliary_head=dict(in_channels=256, num_classes=21))

--- a/configs/upernet/upernet_r18_512x512_80k_ade20k.py
+++ b/configs/upernet/upernet_r18_512x512_80k_ade20k.py
@@ -1,0 +1,9 @@
+_base_ = [
+    '../_base_/models/upernet_r50.py', '../_base_/datasets/ade20k.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    pretrained='open-mmlab://resnet18_v1c',
+    backbone=dict(depth=18),
+    decode_head=dict(in_channels=[64, 128, 256, 512], num_classes=150),
+    auxiliary_head=dict(in_channels=256, num_classes=150))


### PR DESCRIPTION
## Motivation
(1) Fix several wrong config files in 2.0.
### Some errors
- Use `init_cfg` and `pretrained` at the same time.
- In config file, `[]` can not be parsed like `{}` so the content in `[]` should be all set.  

(2) Add several config files which are not included at the first time, such as UperNet-R18 and Swin-Large.

## Notification

Those config files are all checked locally.