### PR TITLE
[Feature] Support LIP dataset for human parsing

### DIFF
--- a/configs/_base_/datasets/lip.py
+++ b/configs/_base_/datasets/lip.py
@@ -1,0 +1,59 @@
+# dataset settings
+dataset_type = 'LIPDataset'
+data_root = 'data/LIP'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+img_scale = (520, 520)
+crop_size = (473, 473)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations'),
+    dict(
+        type='Resize',
+        img_scale=img_scale,
+        keep_ratio=False,
+        ratio_range=(0.75, 1.25)),
+    dict(type='RandomCrop', crop_size=crop_size, cat_max_ratio=0.75),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='RandomRotate', prob=0.6, degree=30),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size=crop_size, pad_val=0, seg_pad_val=255),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_semantic_seg'])
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=img_scale,
+        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=False),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    samples_per_gpu=4,
+    workers_per_gpu=4,
+    train=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/training',
+        ann_dir='annotations/training',
+        pipeline=train_pipeline),
+    val=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline),
+    test=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline))

--- a/configs/_base_/datasets/lip_321x321.py
+++ b/configs/_base_/datasets/lip_321x321.py
@@ -1,0 +1,59 @@
+# dataset settings
+dataset_type = 'LIPDataset'
+data_root = 'data/LIP'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+img_scale = (520, 520)
+crop_size = (321, 321)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='LoadAnnotations'),
+    dict(
+        type='Resize',
+        img_scale=img_scale,
+        keep_ratio=False,
+        ratio_range=(0.75, 1.25)),
+    dict(type='RandomCrop', crop_size=crop_size, cat_max_ratio=0.75),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='RandomRotate', prob=0.6, degree=30),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size=crop_size, pad_val=0, seg_pad_val=255),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_semantic_seg'])
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=img_scale,
+        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=False),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    samples_per_gpu=4,
+    workers_per_gpu=4,
+    train=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/training',
+        ann_dir='annotations/training',
+        pipeline=train_pipeline),
+    val=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline),
+    test=dict(
+        type=dataset_type,
+        data_root=data_root,
+        img_dir='images/validation',
+        ann_dir='annotations/validation',
+        pipeline=test_pipeline))

--- a/configs/ccnet/ccnet_r101-d8_473x473_160k_lip.py
+++ b/configs/ccnet/ccnet_r101-d8_473x473_160k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './ccnet_r50-d8_473x473_160k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/ccnet/ccnet_r101-d8_473x473_80k_lip.py
+++ b/configs/ccnet/ccnet_r101-d8_473x473_80k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './ccnet_r50-d8_473x473_80k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/ccnet/ccnet_r50-d8_473x473_160k_lip.py
+++ b/configs/ccnet/ccnet_r50-d8_473x473_160k_lip.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/ccnet_r50-d8.py', '../_base_/datasets/lip.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/ccnet/ccnet_r50-d8_473x473_80k_lip.py
+++ b/configs/ccnet/ccnet_r50-d8_473x473_80k_lip.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/ccnet_r50-d8.py', '../_base_/datasets/lip.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/deeplabv3/deeplabv3_r101-d8_321x321_160k_lip.py
+++ b/configs/deeplabv3/deeplabv3_r101-d8_321x321_160k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './deeplabv3_r50-d8_321x321_160k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/deeplabv3/deeplabv3_r101-d8_321x321_80k_lip.py
+++ b/configs/deeplabv3/deeplabv3_r101-d8_321x321_80k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './deeplabv3_r50-d8_321x321_80k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/deeplabv3/deeplabv3_r50-d8_321x321_160k_lip.py
+++ b/configs/deeplabv3/deeplabv3_r50-d8_321x321_160k_lip.py
@@ -1,0 +1,7 @@
+_base_ = [
+    '../_base_/models/deeplabv3_r50-d8.py',
+    '../_base_/datasets/lip_321x321.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/deeplabv3/deeplabv3_r50-d8_321x321_80k_lip.py
+++ b/configs/deeplabv3/deeplabv3_r50-d8_321x321_80k_lip.py
@@ -1,0 +1,7 @@
+_base_ = [
+    '../_base_/models/deeplabv3_r50-d8.py',
+    '../_base_/datasets/lip_321x321.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/deeplabv3plus/deeplabv3plus_r101-d8_321x321_160k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r101-d8_321x321_160k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './deeplabv3plus_r50-d8_321x321_160k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/deeplabv3plus/deeplabv3plus_r101-d8_321x321_80k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r101-d8_321x321_80k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './deeplabv3plus_r50-d8_321x321_80k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/deeplabv3plus/deeplabv3plus_r101-d8_473x473_160k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r101-d8_473x473_160k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './deeplabv3plus_r50-d8_473x473_160k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/deeplabv3plus/deeplabv3plus_r101-d8_473x473_80k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r101-d8_473x473_80k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './deeplabv3plus_r50-d8_473x473_80k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/deeplabv3plus/deeplabv3plus_r50-d8_321x321_160k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r50-d8_321x321_160k_lip.py
@@ -1,0 +1,7 @@
+_base_ = [
+    '../_base_/models/deeplabv3plus_r50-d8.py',
+    '../_base_/datasets/lip_321x321.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/deeplabv3plus/deeplabv3plus_r50-d8_321x321_80k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r50-d8_321x321_80k_lip.py
@@ -1,0 +1,7 @@
+_base_ = [
+    '../_base_/models/deeplabv3plus_r50-d8.py',
+    '../_base_/datasets/lip_321x321.py', '../_base_/default_runtime.py',
+    '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_160k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_160k_lip.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/deeplabv3plus_r50-d8.py', '../_base_/datasets/lip.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_80k_lip.py
+++ b/configs/deeplabv3plus/deeplabv3plus_r50-d8_473x473_80k_lip.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/deeplabv3plus_r50-d8.py', '../_base_/datasets/lip.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/pspnet/pspnet_r101-d8_473x473_160k_lip.py
+++ b/configs/pspnet/pspnet_r101-d8_473x473_160k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './pspnet_r50-d8_473x473_160k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/pspnet/pspnet_r101-d8_473x473_80k_lip.py
+++ b/configs/pspnet/pspnet_r101-d8_473x473_80k_lip.py
@@ -1,0 +1,2 @@
+_base_ = './pspnet_r50-d8_473x473_80k_lip.py'
+model = dict(pretrained='open-mmlab://resnet101_v1c', backbone=dict(depth=101))

--- a/configs/pspnet/pspnet_r50-d8_473x473_160k_lip.py
+++ b/configs/pspnet/pspnet_r50-d8_473x473_160k_lip.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/pspnet_r50-d8.py', '../_base_/datasets/lip.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/configs/pspnet/pspnet_r50-d8_473x473_80k_lip.py
+++ b/configs/pspnet/pspnet_r50-d8_473x473_80k_lip.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/models/pspnet_r50-d8.py', '../_base_/datasets/lip.py',
+    '../_base_/default_runtime.py', '../_base_/schedules/schedule_80k.py'
+]
+model = dict(
+    decode_head=dict(num_classes=20), auxiliary_head=dict(num_classes=20))

--- a/docs/en/dataset_prepare.md
+++ b/docs/en/dataset_prepare.md
@@ -138,6 +138,13 @@ mmsegmentation
 │   │   ├── ann_dir
 │   │   │   ├── train
 │   │   │   ├── val
+│   ├── LIP
+│   │   ├── annotations
+│   │   │   ├── training
+│   │   │   ├── validation
+│   │   ├── images
+│   │   │   ├── training
+│   │   │   ├── validation
 ```
 
 ### Cityscapes
@@ -376,3 +383,23 @@ python tools/convert_datasets/isaid.py /path/to/iSAID
 ```
 
 In our default setting (`patch_width`=896, `patch_height`=896,　`overlap_area`=384), it will generate 33978 images for training and 11644 images for validation.
+
+### LIP
+
+The data images and annotations could be download from [LIP](https://lip.sysuhcp.com/overview.php) (train/val/test)
+
+LIP is tasked for single human parsing. There are 19 semantic classes and 1 background class. The dataset is divided into 30K/10K/10K images for training, validation and testing.
+
+In particular, it will generate 30462 images for training and 10000 images for validation.
+
+You may need to rename the training set and validation set (images and annotations) and follow the following structure for dataset preparation after downloading LIP dataset.
+
+```
+│   ├── LIP
+│   │   ├── annotations
+│   │   │   ├── training
+│   │   │   ├── validation
+│   │   ├── images
+│   │   │   ├── training
+│   │   │   ├── validation
+```

--- a/docs/zh_cn/dataset_prepare.md
+++ b/docs/zh_cn/dataset_prepare.md
@@ -119,6 +119,13 @@ mmsegmentation
 │   │   ├── ann_dir
 │   │   │   ├── train
 │   │   │   ├── val
+│   ├── LIP
+│   │   ├── annotations
+│   │   │   ├── training
+│   │   │   ├── validation
+│   │   ├── images
+│   │   │   ├── training
+│   │   │   ├── validation
 ```
 
 ### Cityscapes
@@ -317,3 +324,23 @@ python tools/convert_datasets/isaid.py /path/to/iSAID
 ```
 
 使用我们默认的配置 (`patch_width`=896, `patch_height`=896,　`overlap_area`=384)， 将生成 33978 张图片的训练集和 11644 张图片的验证集。
+
+### LIP
+
+LIP 数据集(训练集/验证集/测试集)的图像和注释可以从 [LIP](https://lip.sysuhcp.com/overview.php) 下载.
+
+该数据集是一个单人人体解析数据集，总共19个语义类和一个背景类别。数据集被划分成30K/10K/10K的图像进行训练/验证/测试。
+
+特别说明, 它将生成 30462 张图片的训练集和 10000 张图片的验证集。
+
+下载后，在使用数据集进行训练前，您需要将数据集文件夹中的训练集和验证集（图像和注释）进行重新命名调整成如下格式.
+
+```
+│   ├── LIP
+│   │   ├── annotations
+│   │   │   ├── training
+│   │   │   ├── validation
+│   │   ├── images
+│   │   │   ├── training
+│   │   │   ├── validation
+```

--- a/mmseg/core/evaluation/class_names.py
+++ b/mmseg/core/evaluation/class_names.py
@@ -121,6 +121,16 @@ def isaid_classes():
     ]
 
 
+def lip_classes():
+    """LIP class names for external use."""
+    return [
+        'background', 'hat', 'hair', 'glove', 'sunglasses', 'upperclothes',
+        'dress', 'coat', 'socks', 'pants', 'jumpsuits', 'scarf', 'skirt',
+        'face', 'leftArm', 'rightArm', 'leftLeg', 'rightLeg', 'leftShoe',
+        'rightShoe'
+    ]
+
+
 def stare_classes():
     """stare class names for external use."""
     return ['background', 'vessel']
@@ -260,6 +270,15 @@ def isaid_palette():
             [0, 127, 255], [0, 100, 155]]
 
 
+def lip_palette():
+    """LIP palette for external use."""
+    return [[0, 0, 0], [128, 0, 0], [255, 0, 0], [0, 85, 0], [170, 0, 51],
+            [255, 85, 0], [0, 0, 85], [0, 119, 221], [85, 85, 0], [0, 85, 85],
+            [85, 51, 0], [52, 86, 128], [0, 128, 0], [0, 0, 255],
+            [51, 170, 221], [0, 255, 255], [85, 255, 170], [170, 255, 85],
+            [255, 255, 0], [255, 170, 0]]
+
+
 def stare_palette():
     """STARE palette for external use."""
     return [[120, 120, 120], [6, 230, 230]]
@@ -278,7 +297,8 @@ dataset_aliases = {
         'coco_stuff164k'
     ],
     'isaid': ['isaid', 'iSAID'],
-    'stare': ['stare', 'STARE']
+    'stare': ['stare', 'STARE'],
+    'lip': ['lip']
 }
 
 

--- a/mmseg/datasets/__init__.py
+++ b/mmseg/datasets/__init__.py
@@ -12,6 +12,7 @@ from .drive import DRIVEDataset
 from .hrf import HRFDataset
 from .isaid import iSAIDDataset
 from .isprs import ISPRSDataset
+from .lip import LIPDataset
 from .loveda import LoveDADataset
 from .night_driving import NightDrivingDataset
 from .pascal_context import PascalContextDataset, PascalContextDataset59
@@ -26,5 +27,5 @@ __all__ = [
     'PascalContextDataset59', 'ChaseDB1Dataset', 'DRIVEDataset', 'HRFDataset',
     'STAREDataset', 'DarkZurichDataset', 'NightDrivingDataset',
     'COCOStuffDataset', 'LoveDADataset', 'MultiImageMixDataset',
-    'iSAIDDataset', 'ISPRSDataset', 'PotsdamDataset'
+    'iSAIDDataset', 'ISPRSDataset', 'PotsdamDataset', 'LIPDataset'
 ]

--- a/mmseg/datasets/lip.py
+++ b/mmseg/datasets/lip.py
@@ -1,0 +1,33 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from .builder import DATASETS
+from .custom import CustomDataset
+
+
+@DATASETS.register_module()
+class LIPDataset(CustomDataset):
+    """LIP dataset.
+
+    In segmentation map annotation for LIP, 0 stands for background, which is
+    included in 20 categories. ``reduce_zero_label`` is fixed to False. The
+    ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is fixed to
+    '.png'.
+    """
+    CLASSES = ('background', 'hat', 'hair', 'glove', 'sunglasses',
+               'upperclothes', 'dress', 'coat', 'socks', 'pants', 'jumpsuits',
+               'scarf', 'skirt', 'face', 'leftArm', 'rightArm', 'leftLeg',
+               'rightLeg', 'leftShoe', 'rightShoe')
+
+    PALETTE = [[0, 0, 0], [128, 0, 0], [255, 0, 0], [0, 85, 0], [170, 0, 51],
+               [255, 85, 0], [0, 0, 85], [0, 119, 221], [85, 85,
+                                                         0], [0, 85, 85],
+               [85, 51, 0], [52, 86, 128], [0, 128, 0], [0, 0, 255],
+               [51, 170, 221], [0, 255, 255], [85, 255, 170], [170, 255, 85],
+               [255, 255, 0], [255, 170, 0]]
+
+    def __init__(self, **kwargs):
+        super(LIPDataset, self).__init__(
+            img_suffix='.jpg',
+            seg_map_suffix='.png',
+            reduce_zero_label=False,
+            **kwargs)

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -14,9 +14,10 @@ from PIL import Image
 from mmseg.core.evaluation import get_classes, get_palette
 from mmseg.datasets import (DATASETS, ADE20KDataset, CityscapesDataset,
                             COCOStuffDataset, ConcatDataset, CustomDataset,
-                            ISPRSDataset, LoveDADataset, MultiImageMixDataset,
-                            PascalVOCDataset, PotsdamDataset, RepeatDataset,
-                            build_dataset, iSAIDDataset)
+                            ISPRSDataset, LIPDataset, LoveDADataset,
+                            MultiImageMixDataset, PascalVOCDataset,
+                            PotsdamDataset, RepeatDataset, build_dataset,
+                            iSAIDDataset)
 
 
 def test_classes():
@@ -30,6 +31,7 @@ def test_classes():
     assert list(PotsdamDataset.CLASSES) == get_classes('potsdam')
     assert list(ISPRSDataset.CLASSES) == get_classes('vaihingen')
     assert list(iSAIDDataset.CLASSES) == get_classes('isaid')
+    assert list(LIPDataset.CLASSES) == get_classes('lip')
 
     with pytest.raises(ValueError):
         get_classes('unsupported')
@@ -75,6 +77,7 @@ def test_palette():
     assert PotsdamDataset.PALETTE == get_palette('potsdam')
     assert COCOStuffDataset.PALETTE == get_palette('cocostuff')
     assert iSAIDDataset.PALETTE == get_palette('isaid')
+    assert LIPDataset.PALETTE == get_palette('lip')
 
     with pytest.raises(ValueError):
         get_palette('unsupported')
@@ -751,6 +754,25 @@ def test_isaid():
             osp.dirname(__file__),
             '../data/pseudo_isaid_dataset/splits/train.txt'))
     assert len(isaid_info) == 1
+
+
+def test_lip():
+    test_dataset = LIPDataset(
+        pipeline=[],
+        img_dir=osp.join(
+            osp.dirname(__file__), '../data/pseudo_lip_dataset/images'),
+        ann_dir=osp.join(
+            osp.dirname(__file__), '../data/pseudo_lip_dataset/annotations'))
+    assert len(test_dataset) == 1
+    lip_info = test_dataset.load_annotations(
+        img_dir=osp.join(
+            osp.dirname(__file__), '../data/pseudo_lip_dataset/images'),
+        img_suffix='.jpg',
+        ann_dir=osp.join(
+            osp.dirname(__file__), '../data/pseudo_lip_dataset/annotations'),
+        seg_map_suffix='.png',
+        split=None)
+    assert len(lip_info) == 1
 
 
 @patch('mmseg.datasets.CustomDataset.load_annotations', MagicMock)


### PR DESCRIPTION
## Motivation

Old PR: https://github.com/open-mmlab/mmsegmentation/pull/1492


[LIP](https://arxiv.org/abs/1703.05446) is tasked for single human parsing. There are 19 semantic classes and 1 background class. The dataset is divided into 30K/10K/10K images for training, validation and testing. **In particular, training set has 30462 images and validation set has 10000 images.**

## Modification

1. Add mmseg/datasets/lip.py to get the images and labels.
2. Add LIPDataset in mmseg/datasets/init.py.
3. Add configs/_base_/datasets/lip.py for LIP dataset.
4. Add deeplabv3plus and pspnet config files of LIP dataset.

## Results

| Config                                   | mIoU img_scale = (520, 520)   | mIoU img_scale = (352, 352) | 
|------------------------------------------|---------| -------| 
| deeplabv3_r50-d8_321x321_80k_lip.py | 38.67 | **39.85** |
| deeplabv3_r50-d8_321x321_160k_lip.py | 39.70 | **39.89** |
| deeplabv3_r101-d8_321x321_80k_lip.py | 40.08 | **40.23** | 
| deeplabv3_r101-d8_321x321_160k_lip.py | **40.82** | 40.6 |
| deeplabv3plus_r50-d8_321x321_80k_lip.py | 40.14 | **41.61** |
| deeplabv3plus_r50-d8_321x321_160k_lip.py  | 40.95 | **41.9** |
| deeplabv3plus_r101-d8_321x321_80k_lip.py | **41.54** | 41.08 |
| deeplabv3plus_r101-d8_321x321_160k_lip.py| 41.77 | **42.31** |

| Config                                   | mIoU    |
|------------------------------------------|---------|
| ccnet_r50-d8_473x473_80k_lip.py | 40.73 |
| ccnet_r50-d8_473x473_160k_lip.py | 40.78 |
| ccnet_r101-d8_473x473_80k_lip.py | 41.76 |
| ccnet_r101-d8_473x473_160k_lip.py | 42.29 |
| deeplabv3plus_r50-d8_473x473_80k_lip.py | 42.02   |
| deeplabv3plus_r50-d8_473x473_160k_lip.py  | 42.86 |
| deeplabv3plus_r101-d8_473x473_80k_lip.py | 43.29 |
| deeplabv3plus_r101-d8_473x473_160k_lip.py| 43.69 |
| pspnet_r50-d8_473x473_80k_lip.py         | 40.85|
| pspnet_r50-d8_473x473_160k_lip.py        | 41.59 |
| pspnet_r101-d8_473x473_80k_lip.py        | 42.24   |
| pspnet_r101-d8_473x473_160k_lip.py       | 42.41 |

## Related reference 1:
https://arxiv.org/pdf/1811.11721.pdf
![image](https://user-images.githubusercontent.com/24582831/188668040-007abd2f-9431-428a-b8cc-23ac276684c3.png)

The crop size is also `(473, 473)`:

![image](https://user-images.githubusercontent.com/24582831/188666273-48ecfbf3-f8f7-493c-b858-689eec020b30.png)

## Related reference 2:
https://arxiv.org/pdf/1804.01984.pdf
![image](https://user-images.githubusercontent.com/24582831/188667857-44cc1e02-b1e3-4b74-8285-9093ad377451.png)

The crop size is also `(384, 384)` for JPPNet, `(321, 321)` for DeepLab and do inference on multi-scale inputs (with scales = 0.75, 0.5, 1.25) and also left-right flipped images. In particular, we compute as the final result the average probabilities from each scaleand flipped images, which is the same for predicting both parsing and pose.

![image](https://user-images.githubusercontent.com/24582831/188668521-b79bd325-ddc9-4b2b-a8f6-aa6c3c4bd7fb.png)

## Next move (2022-09-06)

**with multi-scale inputs (with scales = 0.75, 0.5, 1.25) and also left-right flipped images.**

(1) ccnet_r50-d8_473x473_80k_lip.py
(2) ccnet_r50-d8_473x473_160k_lip.py
(3) ccnet_r101-d8_473x473_80k_lip.py
(4) ccnet_r101-d8_473x473_160k_lip.py

(5) deeplabv3plus_r50-d8_321x321_80k_lip.py
(6) deeplabv3plus_r50-d8_321x321_160k_lip.py
(7) deeplabv3plus_r101-d8_321x321_80k_lip.py
(8) deeplabv3plus_r101-d8_321x321_160k_lip.py
(9) deeplabv3plus_r101-d8_473x473_80k_lip.py
(10) deeplabv3plus_r101-d8_473x473_160k_lip.py

(11) deeplabv3_r50-d8_321x321_80k_lip.py
(12) deeplabv3_r50-d8_321x321_160k_lip.py
(13) deeplabv3_r101-d8_321x321_80k_lip.py
(14) deeplabv3_r101-d8_321x321_160k_lip.py