### PR TITLE
[Fix] Fix after iter `SegVisualizationHook`

### DIFF
--- a/mmseg/engine/hooks/visualization_hook.py
+++ b/mmseg/engine/hooks/visualization_hook.py
@@ -62,12 +62,12 @@ class SegVisualizationHook(Hook):
                           'effect. The results will NOT be '
                           'visualized or stored.')
 
-    def after_iter(self,
-                   runner: Runner,
-                   batch_idx: int,
-                   data_batch: Sequence[dict],
-                   outputs: Sequence[SegDataSample],
-                   mode: str = 'val') -> None:
+    def _after_iter(self,
+                    runner: Runner,
+                    batch_idx: int,
+                    data_batch: Sequence[dict],
+                    outputs: Sequence[SegDataSample],
+                    mode: str = 'val') -> None:
         """Run after every ``self.interval`` validation iterations.
 
         Args:

--- a/tests/test_engine/test_visualization_hook.py
+++ b/tests/test_engine/test_visualization_hook.py
@@ -59,4 +59,4 @@ class TestVisualizationHook(TestCase):
         runner = Mock()
         runner.iter = 3
         hook = SegVisualizationHook(draw=True, interval=1)
-        hook.after_iter(runner, 1, self.data_batch, self.outputs)
+        hook.after_test_iter(runner, 1, self.data_batch, self.outputs)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. `Hook` call `after_val_iter`  and `after_test_iter` by `_after_iter`
```python
def after_val_iter(self,
                    runner,
                    batch_idx: int,
                    data_batch: DATA_BATCH = None,
                    outputs: Optional[Sequence[BaseDataElement]] = None) -> None:
    self._after_iter(
        runner,
        batch_idx=batch_idx,
        data_batch=data_batch,
        outputs=outputs,
        mode='val')
```

## Modification

1. `after_iter` -> `_after_iter`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
5. The documentation has been modified accordingly, like docstring or example tutorials.
