### PR TITLE
Alternative implementation to #1812 for multiple RandomFlip operations

### DIFF
--- a/mmseg/datasets/pipelines/transforms.py
+++ b/mmseg/datasets/pipelines/transforms.py
@@ -354,23 +354,35 @@ class RandomFlip(object):
             dict: Flipped results, 'flip', 'flip_direction' keys are added into
                 result dict.
         """
-
+        flip = True if np.random.rand() < self.prob else False
         if 'flip' not in results:
-            flip = True if np.random.rand() < self.prob else False
             results['flip'] = flip
+        else:
+            results['flip'] = self._ensure_list(results['flip'])
+            results['flip'].append(flip)
         if 'flip_direction' not in results:
             results['flip_direction'] = self.direction
-        if results['flip']:
+        else:
+            results['flip_direction'] = self._ensure_list(
+                results['flip_direction'])
+            results['flip_direction'].append(self.direction)
+        if flip:
             # flip image
             results['img'] = mmcv.imflip(
-                results['img'], direction=results['flip_direction'])
+                results['img'], direction=self.direction)
 
             # flip segs
             for key in results.get('seg_fields', []):
                 # use copy() to make numpy stride positive
                 results[key] = mmcv.imflip(
-                    results[key], direction=results['flip_direction']).copy()
+                    results[key], direction=self.direction).copy()
         return results
+
+    @staticmethod
+    def _ensure_list(entity):
+        if not isinstance(entity, list):
+            entity = [entity]
+        return entity
 
     def __repr__(self):
         return self.__class__.__name__ + f'(prob={self.prob})'


### PR DESCRIPTION
## Motivation

This PR addresses #1781 by adding support for multiple `RandomFlip` operations in the `training_pipeline`. It is an alternative implementation to #1812.

## Modification

With this PR it is possible to define multiple random flip operations by adding something like
```
dict(type='RandomFlip', prob=0.5, direction="vertical")
dict(type='RandomFlip', prob=0.5, direction="horizontal")
```
to the `training_pipeline`, e.g.
```
train_pipeline = [
    dict(type='LoadImageFromFile'),
    dict(type='LoadAnnotations', reduce_zero_label=True),
    ...
    dict(type='RandomFlip', prob=0.5, direction="vertical")
    dict(type='RandomFlip', prob=0.5, direction="horizontal")
    ...
    dict(type='DefaultFormatBundle'),
    dict(type='Collect', keys=['img', 'gt_semantic_seg']),
]
```

## Use cases (Optional)

For specific image domains it is reasonable to flip the data in both directions.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues. [Yes]
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness. [There are already unit tests covering the random flip operator. Is it necessary to adjust these?]
