### PR TITLE
[Fix] Fix decode head forward_train error.

### DIFF
--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -200,7 +200,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
         Returns:
             dict[str, Tensor]: a dictionary of loss components
         """
-        seg_logits = self.forward(inputs)
+        seg_logits = self(inputs)
         losses = self.losses(seg_logits, gt_semantic_seg)
         return losses
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation of this PR is to change the `self.forward(inputs)` to `self(inputs)` to solve the problem of not being able to call the pytorch hook.

## Modification

- BaseDecodeHead

Replace the `self.forward(inputs)` with `self(inputs)`.


## BC-breaking (Optional)

NO.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
