### PR TITLE
[CI] Add mmengine in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         name: update-model-index
         description: Collect model information and update model-index.yml
         entry: .dev/md2yml.py
-        additional_dependencies: [mmcv, lxml, opencv-python]
+        additional_dependencies: [mmcv, lxml, opencv-python, mmengine]
         language: python
         files: ^configs/.*\.md$
         require_serial: true


### PR DESCRIPTION
## Motivation
Add `mmengine` in `.pre-commit-config.yaml` which is necessary.

Before:
![image](https://user-images.githubusercontent.com/24582831/188661697-cd6975a0-f791-4c24-a0da-5d00f427d77e.png)

After:
![image](https://user-images.githubusercontent.com/24582831/188661793-61c59d2e-d3c7-42d6-a621-4e8ed80a25ea.png)

Plus, it usually happened in CI:

https://github.com/open-mmlab/mmsegmentation/runs/8150416700?check_suite_focus=true

![image](https://user-images.githubusercontent.com/24582831/188662345-5eaef360-3761-4ab3-aa06-39f5e15176ee.png)


