### PR TITLE
[Refactor]Resume do not specify ckpt

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -19,6 +19,7 @@ def parse_args():
     parser.add_argument(
         '--resume',
         action='store_true',
+        default=False,
         help='resume from the latest checkpoint in the work_dir automatically')
     parser.add_argument(
         '--amp',

--- a/tools/train.py
+++ b/tools/train.py
@@ -18,12 +18,8 @@ def parse_args():
     parser.add_argument('--work-dir', help='the dir to save logs and models')
     parser.add_argument(
         '--resume',
-        nargs='?',
-        type=str,
-        const='auto',
-        help='If specify checkpoint path, resume from it, while if not '
-        'specify, try to auto resume from the latest checkpoint '
-        'in the work directory.')
+        action='store_true',
+        help='resume from the latest checkpoint in the work_dir automatically')
     parser.add_argument(
         '--amp',
         action='store_true',
@@ -90,12 +86,7 @@ def main():
             cfg.optim_wrapper.loss_scale = 'dynamic'
 
     # resume training
-    if args.resume == 'auto':
-        cfg.resume = True
-        cfg.load_from = None
-    elif args.resume is not None:
-        cfg.resume = True
-        cfg.load_from = args.resume
+    cfg.resume = args.resume
 
     # build the runner from config
     if 'runner_type' not in cfg:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`resume` is only used to specify whether launch resume training from the latest checkpoint and `load-from` is used to load specific checkpoints.

`resume` in CLI has the same function of `resume` in `Runner`. https://github.com/open-mmlab/mmengine/blob/ca0364bbc3a6ac9132f5d499de190f7e733383ca/mmengine/runner/runner.py#L151-L154
## Modification

1. Add action of `resume`.
2. Remove the load ckpt from `resume`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
5. The documentation has been modified accordingly, like docstring or example tutorials.
