### PR TITLE
[Feature] Support Phi Loss

### DIFF
--- a/mmseg/models/losses/__init__.py
+++ b/mmseg/models/losses/__init__.py
@@ -5,8 +5,8 @@ from .cross_entropy_loss import (CrossEntropyLoss, binary_cross_entropy,
 from .dice_loss import DiceLoss
 from .focal_loss import FocalLoss
 from .lovasz_loss import LovaszLoss
+from .phi_loss import PhiLoss
 from .tversky_loss import TverskyLoss
-from .phi_loss import (PhiLoss, phi_loss)
 from .utils import reduce_loss, weight_reduce_loss, weighted_loss
 
 __all__ = [

--- a/mmseg/models/losses/__init__.py
+++ b/mmseg/models/losses/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
     'accuracy', 'Accuracy', 'cross_entropy', 'binary_cross_entropy',
     'mask_cross_entropy', 'CrossEntropyLoss', 'reduce_loss',
     'weight_reduce_loss', 'weighted_loss', 'LovaszLoss', 'DiceLoss',
-    'FocalLoss', 'TverskyLoss', 'PhiLoss', 'phi_loss'
+    'FocalLoss', 'TverskyLoss', 'PhiLoss'
 ]

--- a/mmseg/models/losses/__init__.py
+++ b/mmseg/models/losses/__init__.py
@@ -6,11 +6,12 @@ from .dice_loss import DiceLoss
 from .focal_loss import FocalLoss
 from .lovasz_loss import LovaszLoss
 from .tversky_loss import TverskyLoss
+from .phi_loss import (PhiLoss, phi_loss)
 from .utils import reduce_loss, weight_reduce_loss, weighted_loss
 
 __all__ = [
     'accuracy', 'Accuracy', 'cross_entropy', 'binary_cross_entropy',
     'mask_cross_entropy', 'CrossEntropyLoss', 'reduce_loss',
     'weight_reduce_loss', 'weighted_loss', 'LovaszLoss', 'DiceLoss',
-    'FocalLoss', 'TverskyLoss'
+    'FocalLoss', 'TverskyLoss', 'PhiLoss', 'phi_loss'
 ]

--- a/mmseg/models/losses/phi_loss.py
+++ b/mmseg/models/losses/phi_loss.py
@@ -31,11 +31,16 @@ def phi_loss(inputs, targets, gamma, smooth, weight=None, reduction='mean'):
 @LOSSES.register_module()
 class PhiLoss(nn.Module):
     """PhiLoss.
+    
+    This loss is proposed in `Novel Focal Phi Loss for Power Line
+    Segmentation with Auxiliary Classifier U-Net <https://doi.org/10.3390/s21082803>`_.
 
     Args:
-        reduction (str, optional): . Defaults to 'mean'.
-            Options are "none", "mean" and "sum".
-        smooth (float, optional): Smoothing factor. Defaults to 1.0.
+        reduction (str, optional): The method used to reduce the loss. Options
+            are "none", "mean" and "sum". This parameter only works when
+            per_image is True. Default: 'mean'.
+        smooth (float, optional):  A float number to smooth loss, and avoid NaN error.
+            Default: 1.0
         loss_weight (float, optional): Weight of the loss. Defaults to 1.0.
     """
 

--- a/mmseg/models/losses/phi_loss.py
+++ b/mmseg/models/losses/phi_loss.py
@@ -3,12 +3,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ..builder import LOSSES
-from .utils import weight_reduce_loss, reduce_loss
+from .utils import reduce_loss
 from .cross_entropy_loss import _expand_onehot_labels
 
 
-def phi_loss(inputs, targets, gamma, smooth, weight=None, reduction='mean',
-                  avg_factor=None):
+def phi_loss(inputs, targets, gamma, smooth, weight=None, reduction='mean'):
     
     inputs = inputs.sigmoid()
     targets= targets.type_as(inputs)
@@ -17,13 +16,6 @@ def phi_loss(inputs, targets, gamma, smooth, weight=None, reduction='mean',
     inputs = inputs.reshape(inputs.size(0), -1)
     targets = targets.reshape(targets.size(0), -1)
     weight = weight.reshape(weight.size(0), -1)
-    
-    #removing .sum() to keep the tensor dimensions to [2,2,256,256] compatible with weight dimensions
-    # to use .sum with TP,FP and FN, weights must also be summed using .sum() in weighted reduction loss
-  
-    # print(gamma)
-    # print(inputs)
-    # print(targets)
     
     TP = (inputs * targets).sum()
     FP = ((1 - targets) * inputs).sum()
@@ -65,14 +57,11 @@ class PhiLoss(nn.Module):
                 targets,
                 weight=None,
                 reduction_override=None,
-                avg_factor=None,
                 ignore_index=255):
         """Forward function."""
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)
-        # print(inputs.shape) #[2,2,256,256] => [N,C,H,W]
-        # print(targets.shape) #[2,256,256] => [N,H,W]
 
         if inputs.dim() != targets.dim():
             assert (inputs.dim() == 2 and targets.dim() == 1) or (
@@ -80,13 +69,10 @@ class PhiLoss(nn.Module):
             'Only pred shape [N, C], label shape [N] or pred shape [N, C, ' \
             'H, W], label shape [N, H, W] are supported'
             label, weight, _ = _expand_onehot_labels(targets, weight, inputs.shape,
-                                                ignore_index) #use imported version from cross_entropy_loss
+                                                ignore_index) 
         phi_loss_val= phi_loss(inputs, label, self.gamma, self.smooth,
-                               weight, reduction= reduction, avg_factor=avg_factor 
-                              )
-        # print(phi_loss_val)
+                               weight, reduction= reduction)
         loss = self.loss_weight * phi_loss_val
-        # print(loss)
         return loss
 
     @property

--- a/mmseg/models/losses/phi_loss.py
+++ b/mmseg/models/losses/phi_loss.py
@@ -60,9 +60,9 @@ class PhiLoss(nn.Module):
     def forward(self,
                 inputs,
                 targets,
-                weight=None,
+                label_weights=None,
                 reduction_override=None,
-                ignore_index=255):
+                ignore_index=-100):
         """Forward function."""
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
@@ -73,10 +73,12 @@ class PhiLoss(nn.Module):
                 inputs.dim() == 4 and targets.dim() == 3), \
             'Only pred shape [N, C], label shape [N] or pred shape [N, C, ' \
             'H, W], label shape [N, H, W] are supported'
-            label, weight, _ = _expand_onehot_labels(targets, weight, inputs.shape,
+            # `weight` returned from `_expand_onehot_labels`
+            # has been treated for valid (non-ignore) pixels
+            label, label_weights, _ = _expand_onehot_labels(targets, label_weights, inputs.shape,
                                                 ignore_index) 
         phi_loss_val= phi_loss(inputs, label, self.gamma, self.smooth,
-                               weight, reduction= reduction)
+                               weight, reduction= self.reduction)
         loss = self.loss_weight * phi_loss_val
         return loss
 

--- a/mmseg/models/losses/phi_loss.py
+++ b/mmseg/models/losses/phi_loss.py
@@ -1,0 +1,104 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ..builder import LOSSES
+from .utils import weight_reduce_loss, reduce_loss
+from .cross_entropy_loss import _expand_onehot_labels
+
+
+def phi_loss(inputs, targets, gamma, smooth, weight=None, reduction='mean',
+                  avg_factor=None):
+    
+    inputs = inputs.sigmoid()
+    targets= targets.type_as(inputs)
+    
+    # flatten label and prediction tensors
+    inputs = inputs.reshape(inputs.size(0), -1)
+    targets = targets.reshape(targets.size(0), -1)
+    weight = weight.reshape(weight.size(0), -1)
+    
+    #removing .sum() to keep the tensor dimensions to [2,2,256,256] compatible with weight dimensions
+    # to use .sum with TP,FP and FN, weights must also be summed using .sum() in weighted reduction loss
+  
+    # print(gamma)
+    # print(inputs)
+    # print(targets)
+    
+    TP = (inputs * targets).sum()
+    FP = ((1 - targets) * inputs).sum()
+    FN = (targets * (1 - inputs)).sum()
+    TN= inputs[targets==0.].sum()
+    
+    phi = ((TP * TN - FP * FN) + smooth) / torch.sqrt((TP + FP) * (TP + FN) * (TN + FP) * (TN + FN) + smooth) 
+    loss= (1. - phi) ** gamma #focal_phi_loss
+    loss= reduce_loss(loss,reduction=reduction)
+    return loss
+
+
+@LOSSES.register_module()
+class PhiLoss(nn.Module):
+    """PhiLoss.
+
+    Args:
+        reduction (str, optional): . Defaults to 'mean'.
+            Options are "none", "mean" and "sum".
+        smooth (float, optional): Smoothing factor. Defaults to 1.0.
+        loss_weight (float, optional): Weight of the loss. Defaults to 1.0.
+    """
+
+    def __init__(self,
+    			 gamma= 1.0,
+                 reduction='mean',
+                 smooth=1,
+                 loss_weight=1.0,
+                 loss_name='phi_loss'):
+        super(PhiLoss, self).__init__()
+        self.gamma = gamma
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+        self.smooth = smooth
+        self._loss_name = loss_name
+
+    def forward(self,
+                inputs,
+                targets,
+                weight=None,
+                reduction_override=None,
+                avg_factor=None,
+                ignore_index=255):
+        """Forward function."""
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
+        # print(inputs.shape) #[2,2,256,256] => [N,C,H,W]
+        # print(targets.shape) #[2,256,256] => [N,H,W]
+
+        if inputs.dim() != targets.dim():
+            assert (inputs.dim() == 2 and targets.dim() == 1) or (
+                inputs.dim() == 4 and targets.dim() == 3), \
+            'Only pred shape [N, C], label shape [N] or pred shape [N, C, ' \
+            'H, W], label shape [N, H, W] are supported'
+            label, weight, _ = _expand_onehot_labels(targets, weight, inputs.shape,
+                                                ignore_index) #use imported version from cross_entropy_loss
+        phi_loss_val= phi_loss(inputs, label, self.gamma, self.smooth,
+                               weight, reduction= reduction, avg_factor=avg_factor 
+                              )
+        # print(phi_loss_val)
+        loss = self.loss_weight * phi_loss_val
+        # print(loss)
+        return loss
+
+    @property
+    def loss_name(self):
+        """Loss Name.
+
+        This function must be implemented and will return the name of this
+        loss function. This name will be used to combine different loss items
+        by simple sum operation. In addition, if you want this loss item to be
+        included into the backward graph, `loss_` must be the prefix of the
+        name.
+        Returns:
+            str: The name of this loss item.
+        """
+        return self._loss_name

--- a/mmseg/models/losses/phi_loss.py
+++ b/mmseg/models/losses/phi_loss.py
@@ -1,51 +1,54 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 from ..builder import LOSSES
-from .utils import reduce_loss
 from .cross_entropy_loss import _expand_onehot_labels
+from .utils import reduce_loss
 
 
 def phi_loss(inputs, targets, gamma, smooth, weight=None, reduction='mean'):
-    
+
     inputs = inputs.sigmoid()
-    targets= targets.type_as(inputs)
-    
+    targets = targets.type_as(inputs)
+
     # flatten label and prediction tensors
     inputs = inputs.reshape(inputs.size(0), -1)
     targets = targets.reshape(targets.size(0), -1)
     weight = weight.reshape(weight.size(0), -1)
-    
+
     TP = (inputs * targets).sum()
     FP = ((1 - targets) * inputs).sum()
     FN = (targets * (1 - inputs)).sum()
-    TN= inputs[targets==0.].sum()
-    
-    phi = ((TP * TN - FP * FN) + smooth) / torch.sqrt((TP + FP) * (TP + FN) * (TN + FP) * (TN + FN) + smooth) 
-    loss= (1. - phi) ** gamma #focal_phi_loss
-    loss= reduce_loss(loss,reduction=reduction)
+    TN = inputs[targets == 0.].sum()
+
+    phi = ((TP * TN - FP * FN) + smooth) / torch.sqrt((TP + FP) * (TP + FN) *
+                                                      (TN + FP) *
+                                                      (TN + FN) + smooth)
+    loss = (1. - phi)**gamma  # focal_phi_loss
+    loss = reduce_loss(loss, reduction=reduction)
     return loss
 
 
 @LOSSES.register_module()
 class PhiLoss(nn.Module):
     """PhiLoss.
-    
+
     This loss is proposed in `Novel Focal Phi Loss for Power Line
-    Segmentation with Auxiliary Classifier U-Net <https://doi.org/10.3390/s21082803>`_.
+    Segmentation with Auxiliary
+    Classifier U-Net <https://doi.org/10.3390/s21082803>.
 
     Args:
         reduction (str, optional): The method used to reduce the loss. Options
             are "none", "mean" and "sum". This parameter only works when
             per_image is True. Default: 'mean'.
-        smooth (float, optional):  A float number to smooth loss, and avoid NaN error.
+        smooth (float, optional):  A float number to smooth loss.
             Default: 1.0
         loss_weight (float, optional): Weight of the loss. Defaults to 1.0.
     """
 
     def __init__(self,
-    			 gamma= 1.0,
+                 gamma=1.0,
                  reduction='mean',
                  smooth=1,
                  loss_weight=1.0,
@@ -60,25 +63,29 @@ class PhiLoss(nn.Module):
     def forward(self,
                 inputs,
                 targets,
+                weight=None,
                 label_weights=None,
                 reduction_override=None,
                 ignore_index=-100):
         """Forward function."""
         assert reduction_override in (None, 'none', 'mean', 'sum')
-        reduction = (
-            reduction_override if reduction_override else self.reduction)
 
         if inputs.dim() != targets.dim():
             assert (inputs.dim() == 2 and targets.dim() == 1) or (
                 inputs.dim() == 4 and targets.dim() == 3), \
-            'Only pred shape [N, C], label shape [N] or pred shape [N, C, ' \
-            'H, W], label shape [N, H, W] are supported'
+                'Only pred shape [N, C], label shape [N] or pred' \
+                'shape [N, C, H, W], label shape [N, H, W] are supported'
             # `weight` returned from `_expand_onehot_labels`
             # has been treated for valid (non-ignore) pixels
-            label, label_weights, _ = _expand_onehot_labels(targets, label_weights, inputs.shape,
-                                                ignore_index) 
-        phi_loss_val= phi_loss(inputs, label, self.gamma, self.smooth,
-                               weight, reduction= self.reduction)
+            label, label_weights, _ = _expand_onehot_labels(
+                targets, label_weights, inputs.shape, ignore_index)
+        phi_loss_val = phi_loss(
+            inputs,
+            label,
+            self.gamma,
+            self.smooth,
+            weight,
+            reduction=self.reduction)
         loss = self.loss_weight * phi_loss_val
         return loss
 


### PR DESCRIPTION
## Motivation

Support PhiLoss as described in https://doi.org/10.3390/s21082803. The implementation is published by authors of the paper in this [repo](https://github.com/rubeea/focal_phi_loss_mmsegmentation), but the pull request was never created for that. I fixed some parts of the implementation which were outdated for the current version of mmseg and cleaned up commented lines used during development. 

This Loss is particularly useful in case of highly unbalanced datasets.

## Modification

Add PhiLoss class, add the class and function in respective `__init__.py` file. 

## BC-breaking 

None

## Use cases (Optional)

Tested this loss during my own dataset training, helped me to improve the imbalanced dataset issue without manually introducing class weights.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
