### PR TITLE
Adding missing dependencies to torchserve container

### DIFF
--- a/docker/serve/Dockerfile
+++ b/docker/serve/Dockerfile
@@ -8,6 +8,10 @@ ARG MMSEG="0.28.0"
 
 ENV PYTHONUNBUFFERED TRUE
 
+# NVIDIA APT KEYS
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
@@ -21,7 +25,7 @@ ENV PATH="/opt/conda/bin:$PATH"
 RUN export FORCE_CUDA=1
 
 # TORCHSEVER
-RUN pip install torchserve torch-model-archiver
+RUN pip install torchserve torch-model-archiver nvgpu
 
 # MMLAB
 ARG PYTORCH


### PR DESCRIPTION
## Motivation

While building the torchserve docker container, I noticed some errors due to missing dependencies.

## Modification

I added the Nvidia APT keys to the container before installing packages. I also added nvgpu pip dependency as it was required later on by the server to retrieve GPU usage stats.