### PR TITLE
[Fix] Fix ResizeToMultiple transform in MMSeg 1.x

### DIFF
--- a/configs/segformer/README.md
+++ b/configs/segformer/README.md
@@ -77,20 +77,13 @@ using `AlignedResize`, you can change the dataset pipeline like this:
 ```python
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(
-        type='MultiScaleFlipAug',
-        img_scale=(2048, 512),
-        # img_ratios=[0.5, 0.75, 1.0, 1.25, 1.5, 1.75],
-        flip=False,
-        transforms=[
-            dict(type='Resize', keep_ratio=True),
-            # resize image to multiple of 32, improve SegFormer by 0.5-1.0 mIoU.
-            dict(type='ResizeToMultiple', size_divisor=32),
-            dict(type='RandomFlip'),
-            dict(type='Normalize', **img_norm_cfg),
-            dict(type='ImageToTensor', keys=['img']),
-            dict(type='Collect', keys=['img']),
-        ])
+    dict(type='Resize', scale=(2048, 512), keep_ratio=True),
+    # resize image to multiple of 32, improve SegFormer by 0.5-1.0 mIoU.
+    dict(type='ResizeToMultiple', size_divisor=32),
+    # add loading annotation after ``Resize`` because ground truth
+    # does not need to do resize data transform
+    dict(type='LoadAnnotations', reduce_zero_label=True),
+    dict(type='PackSegInputs')
 ]
 ```
 

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -59,8 +59,8 @@ class ResizeToMultiple(BaseTransform):
             if self.interpolation else 'bilinear')
 
         results['img'] = img
-        results['img_shape'] = img.shape
-        results['pad_shape'] = img.shape
+        results['img_shape'] = img.shape[:2]
+        results['pad_shape'] = img.shape[:2]
 
         # Align segmentation map to multiple of size divisor.
         for key in results.get('seg_fields', []):

--- a/tests/test_datasets/test_transform.py
+++ b/tests/test_datasets/test_transform.py
@@ -678,4 +678,4 @@ def test_resize_to_multiple():
     results = transform(results)
     assert results['img'].shape == (224, 256, 3)
     assert results['gt_semantic_seg'].shape == (224, 256)
-    assert results['img_shape'] == (224, 256, 3)
+    assert results['img_shape'] == (224, 256)


### PR DESCRIPTION
## Motivation 
Fix ResizeToMultiple transform in MMSeg 1.x.

## Description
In current  `ResizeToMultiple`, it has:
```python
        results['img'] = img
        results['img_shape'] = img.shape
        results['pad_shape'] = img.shape
```

If `dict(type='ResizeToMultiple', size_divisor=32),` is added, because in https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/mmseg/models/utils/wrappers.py#L27, the `input` and  `size` should have same dimension, but currently it is 2 and 3, respectively. And it would cause error `ValueError: size shape must match input shape. Input is 2D, size is 3`:

![image](https://user-images.githubusercontent.com/24582831/195577793-cdd4ea28-6b21-4c41-8695-5b9a7325b422.png)


## Solution
Just modify `ResizeToMultiple`:
```python
        results['img'] = img
        results['img_shape'] = img.shape[:2]
        results['pad_shape'] = img.shape[:2]
```
![image](https://user-images.githubusercontent.com/24582831/195577718-36a69f18-a8ed-46b2-bd40-17337c84ce22.png)





