### PR TITLE
[Enhancement] Support padding in testing

### DIFF
--- a/mmseg/models/data_preprocessor.py
+++ b/mmseg/models/data_preprocessor.py
@@ -139,7 +139,6 @@ class SegDataPreProcessor(BaseDataPreprocessor):
             if self.test_cfg:
                 inputs, data_samples = stack_batch(
                     inputs=inputs,
-                    data_samples=data_samples,
                     size=self.test_cfg.get('size', None),
                     size_divisor=self.test_cfg.get('size_divisor', None),
                     pad_val=self.pad_val,

--- a/mmseg/models/data_preprocessor.py
+++ b/mmseg/models/data_preprocessor.py
@@ -137,7 +137,7 @@ class SegDataPreProcessor(BaseDataPreprocessor):
                 'as the image size might be different in a batch')
             # pad images when testing
             if self.test_cfg:
-                inputs, data_samples = stack_batch(
+                inputs, _ = stack_batch(
                     inputs=inputs,
                     size=self.test_cfg.get('size', None),
                     size_divisor=self.test_cfg.get('size_divisor', None),

--- a/mmseg/models/data_preprocessor.py
+++ b/mmseg/models/data_preprocessor.py
@@ -48,18 +48,28 @@ class SegDataPreProcessor(BaseDataPreprocessor):
         rgb_to_bgr (bool): whether to convert image from RGB to RGB.
             Defaults to False.
         batch_augments (list[dict], optional): Batch-level augmentations
+        train_cfg (dict, optional): The padding size config in training, if
+            not specify, will use `size` and `size_divisor` params as default.
+            Defaults to None, only supports keys `size` or `size_divisor`.
+        test_cfg (dict, optional): The padding size config in testing, if not
+            specify, will use `size` and `size_divisor` params as default.
+            Defaults to None, only supports keys `size` or `size_divisor`.
     """
 
-    def __init__(self,
-                 mean: Sequence[Number] = None,
-                 std: Sequence[Number] = None,
-                 size: Optional[tuple] = None,
-                 size_divisor: Optional[int] = None,
-                 pad_val: Number = 0,
-                 seg_pad_val: Number = 255,
-                 bgr_to_rgb: bool = False,
-                 rgb_to_bgr: bool = False,
-                 batch_augments: Optional[List[dict]] = None):
+    def __init__(
+        self,
+        mean: Sequence[Number] = None,
+        std: Sequence[Number] = None,
+        size: Optional[tuple] = None,
+        size_divisor: Optional[int] = None,
+        pad_val: Number = 0,
+        seg_pad_val: Number = 255,
+        bgr_to_rgb: bool = False,
+        rgb_to_bgr: bool = False,
+        batch_augments: Optional[List[dict]] = None,
+        train_cfg: dict = None,
+        test_cfg: dict = None,
+    ):
         super().__init__()
         self.size = size
         self.size_divisor = size_divisor
@@ -86,6 +96,11 @@ class SegDataPreProcessor(BaseDataPreprocessor):
         # TODO: support batch augmentations.
         self.batch_augments = batch_augments
 
+        # Support different padding methods in training and testing
+        default_size_cfg = dict(size=size, size_divisor=size_divisor)
+        self.train_cfg = train_cfg if train_cfg else default_size_cfg
+        self.test_cfg = test_cfg if test_cfg else default_size_cfg
+
     def forward(self, data: dict, training: bool = False) -> Dict[str, Any]:
         """Perform normalization、padding and bgr2rgb conversion based on
         ``BaseDataPreprocessor``.
@@ -111,21 +126,24 @@ class SegDataPreProcessor(BaseDataPreprocessor):
         if training:
             assert data_samples is not None, ('During training, ',
                                               '`data_samples` must be define.')
-            inputs, data_samples = stack_batch(
-                inputs=inputs,
-                data_samples=data_samples,
-                size=self.size,
-                size_divisor=self.size_divisor,
-                pad_val=self.pad_val,
-                seg_pad_val=self.seg_pad_val)
-
-            if self.batch_augments is not None:
-                inputs, data_samples = self.batch_augments(
-                    inputs, data_samples)
-            return dict(inputs=inputs, data_samples=data_samples)
         else:
             assert len(inputs) == 1, (
                 'Batch inference is not support currently, '
                 'as the image size might be different in a batch')
-            return dict(
-                inputs=torch.stack(inputs, dim=0), data_samples=data_samples)
+
+        size_cfg = self.train_cfg if training else self.test_cfg
+        size = size_cfg.get('size', None)
+        size_divisor = size_cfg.get('size_divisor', None)
+
+        inputs, data_samples = stack_batch(
+            inputs=inputs,
+            data_samples=data_samples,
+            size=size,
+            size_divisor=size_divisor,
+            pad_val=self.pad_val,
+            seg_pad_val=self.seg_pad_val)
+
+        if self.batch_augments is not None:
+            inputs, data_samples = self.batch_augments(inputs, data_samples)
+
+        return dict(inputs=inputs, data_samples=data_samples)

--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -165,6 +165,11 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
                 i_seg_logits = seg_logits[i:i + 1, :,
                                           padding_top:H - padding_bottom,
                                           padding_left:W - padding_right]
+                i_gt_sem_seg = data_samples[i].gt_sem_seg[:, padding_top:H -
+                                                          padding_bottom,
+                                                          padding_left:W -
+                                                          padding_right]
+
                 # resize as original shape
                 i_seg_logits = resize(
                     i_seg_logits,
@@ -184,7 +189,9 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
                 'seg_logits':
                 PixelData(**{'data': i_seg_logits}),
                 'pred_sem_seg':
-                PixelData(**{'data': i_seg_pred})
+                PixelData(**{'data': i_seg_pred}),
+                'gt_sem_seg':
+                PixelData(**{'data': i_gt_sem_seg})
             })
 
         return data_samples

--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -192,7 +192,8 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
                 'pred_sem_seg':
                 PixelData(**{'data': i_seg_pred}),
                 'gt_sem_seg':
-                PixelData(**{'data': i_gt_sem_seg})
+                PixelData() if only_prediction else PixelData(
+                    **{'data': i_gt_sem_seg})
             })
 
         return data_samples

--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -165,10 +165,11 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
                 i_seg_logits = seg_logits[i:i + 1, :,
                                           padding_top:H - padding_bottom,
                                           padding_left:W - padding_right]
-                i_gt_sem_seg = data_samples[i].gt_sem_seg[:, padding_top:H -
-                                                          padding_bottom,
-                                                          padding_left:W -
-                                                          padding_right]
+                i_gt_sem_seg = data_samples[i].gt_sem_seg.data[:,
+                                                               padding_top:H -
+                                                               padding_bottom,
+                                                               padding_left:W -
+                                                               padding_right]
 
                 # resize as original shape
                 i_seg_logits = resize(

--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -165,11 +165,6 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
                 i_seg_logits = seg_logits[i:i + 1, :,
                                           padding_top:H - padding_bottom,
                                           padding_left:W - padding_right]
-                i_gt_sem_seg = data_samples[i].gt_sem_seg.data[:,
-                                                               padding_top:H -
-                                                               padding_bottom,
-                                                               padding_left:W -
-                                                               padding_right]
 
                 # resize as original shape
                 i_seg_logits = resize(
@@ -190,10 +185,7 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
                 'seg_logits':
                 PixelData(**{'data': i_seg_logits}),
                 'pred_sem_seg':
-                PixelData(**{'data': i_seg_pred}),
-                'gt_sem_seg':
-                PixelData() if only_prediction else PixelData(
-                    **{'data': i_gt_sem_seg})
+                PixelData(**{'data': i_seg_pred})
             })
 
         return data_samples

--- a/tests/test_models/test_data_preprocessor.py
+++ b/tests/test_models/test_data_preprocessor.py
@@ -46,3 +46,19 @@ class TestSegDataPreProcessor(TestCase):
         out = processor(data, training=True)
         self.assertEqual(out['inputs'].shape, (2, 3, 20, 20))
         self.assertEqual(len(out['data_samples']), 2)
+
+        # test predict with padding
+        processor = SegDataPreProcessor(
+            mean=[0, 0, 0],
+            std=[1, 1, 1],
+            size=(20, 20),
+            test_cfg=dict(size_divisor=15))
+        data = {
+            'inputs': [
+                torch.randint(0, 256, (3, 11, 10)),
+            ],
+            'data_samples': [data_sample]
+        }
+        out = processor(data, training=False)
+        self.assertEqual(out['inputs'].shape[2] % 15, 0)
+        self.assertEqual(out['inputs'].shape[3] % 15, 0)


### PR DESCRIPTION
## Motivation

- Fix removing gt_sem_seg padding at postprocess_result
- Support  different padding methods in testing

## Modification

- Add removing gt_sem_seg padding at postprocess_result method in mmseg/models/segmentors/base.py.
- Add test_cfg` params to SegDataPreprocessor, supporting different padding methods.

## BC-breaking (Optional)

None

## Use cases

In a case that uses `size` in training and using `size_divisor` in testing, we might set the `test_cfg` param to data_preprocessor.

```python
data_preprocessor = dict(
    type='SegDataPreProcessor',
    mean=[123.675, 116.28, 103.53],
    std=[58.395, 57.12, 57.375],
    bgr_to_rgb=True,
    pad_val=0,
    seg_pad_val=255,
    size=(512, 512),
    test_cfg=dict(size_divisor=32))
```

