### PR TITLE
Fixe the bug in the visualization step.

### DIFF
--- a/demo/MMSegmentation_Tutorial.ipynb
+++ b/demo/MMSegmentation_Tutorial.ipynb
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "# Install PyTorch\n",
-    "conda install pytorch==1.12.0 torchvision==0.13.0 torchaudio==0.12.0 cudatoolkit=11.3 - c pytorch\n",
+    "!conda install pytorch==1.12.0 torchvision==0.13.0 torchaudio==0.12.0 cudatoolkit=11.3 - c pytorch\n",
     "# Install mim\n",
     "!pip install -U openmim\n",
     "# Install mmengine\n",

--- a/demo/MMSegmentation_Tutorial.ipynb
+++ b/demo/MMSegmentation_Tutorial.ipynb
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "# Install PyTorch\n",
-    "conda install pytorch == 1.12.0 torchvision == 0.13.0 torchaudio == 0.12.0 cudatoolkit = 11.3 - c pytorch\n",
+    "conda install pytorch==1.12.0 torchvision==0.13.0 torchaudio==0.12.0 cudatoolkit=11.3 - c pytorch\n",
     "# Install mim\n",
     "!pip install -U openmim\n",
     "# Install mmengine\n",

--- a/demo/MMSegmentation_Tutorial.ipynb
+++ b/demo/MMSegmentation_Tutorial.ipynb
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "# Install PyTorch\n",
-    "!conda install pytorch==1.12.0 torchvision==0.13.0 torchaudio==0.12.0 cudatoolkit=11.3 - c pytorch\n",
+    "!conda install pytorch==1.12.0 torchvision==0.13.0 torchaudio==0.12.0 cudatoolkit=11.3 -c pytorch\n",
     "# Install mim\n",
     "!pip install -U openmim\n",
     "# Install mmengine\n",

--- a/demo/MMSegmentation_Tutorial.ipynb
+++ b/demo/MMSegmentation_Tutorial.ipynb
@@ -33,7 +33,7 @@
     "## Install MMSegmentation\n",
     "This step may take several minutes. \n",
     "\n",
-    "We use PyTorch 1.12 and CUDA 11.3 installed in Colab for this tutorial. You may install other versions by change the version number in pip install command. "
+    "We use PyTorch 1.12 and CUDA 11.3 for this tutorial. You may install other versions by change the version number in pip install command. "
    ]
   },
   {
@@ -49,13 +49,9 @@
    "outputs": [],
    "source": [
     "# Check nvcc version\n",
-    "import torch\n",
-    "import torchvision\n",
     "!nvcc -V\n",
     "# Check GCC version\n",
-    "!gcc - -version\n",
-    "# Check Pytorch installation\n",
-    "print(torch.__version__, torch.cuda.is_available())"
+    "!gcc --version"
    ]
   },
   {
@@ -70,12 +66,14 @@
    },
    "outputs": [],
    "source": [
+    "# Install PyTorch\n",
+    "conda install pytorch == 1.12.0 torchvision == 0.13.0 torchaudio == 0.12.0 cudatoolkit = 11.3 - c pytorch\n",
     "# Install mim\n",
     "!pip install -U openmim\n",
     "# Install mmengine\n",
     "!mim install mmengine\n",
     "# Install MMCV\n",
-    "!mim install 'mmcv >= 2.0.0rc1'"
+    "!mim install 'mmcv >= 2.0.0rc1'\n"
    ]
   },
   {
@@ -108,6 +106,10 @@
    },
    "outputs": [],
    "source": [
+    "# Check Pytorch installation\n",
+    "import torch, torchvision\n",
+    "print(torch.__version__, torch.cuda.is_available())\n",
+    "\n",
     "# Check MMSegmentation installation\n",
     "import mmseg\n",
     "print(mmseg.__version__)"
@@ -521,7 +523,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('pt1.12')",
+   "display_name": "Python 3.8.5 ('tensorflow')",
    "language": "python",
    "name": "python3"
   },
@@ -535,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.5"
   },
   "pycharm": {
    "stem_cell": {
@@ -548,7 +550,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "ffdb7915c29738c259ec7ee5d0d1b9253c264f1fd267d45dd77f1a420396c120"
+    "hash": "20d4b83e0c8b3730b580c42434163d64f4b735d580303a8fade7c849d4d29eba"
    }
   }
  },

--- a/demo/MMSegmentation_Tutorial.ipynb
+++ b/demo/MMSegmentation_Tutorial.ipynb
@@ -33,7 +33,7 @@
     "## Install MMSegmentation\n",
     "This step may take several minutes. \n",
     "\n",
-    "We use PyTorch 1.10 and CUDA 11.1 for this tutorial. You may install other versions by change the version number in pip install command. "
+    "We use PyTorch 1.12 and CUDA 11.3 installed in Colab for this tutorial. You may install other versions by change the version number in pip install command. "
    ]
   },
   {
@@ -49,9 +49,13 @@
    "outputs": [],
    "source": [
     "# Check nvcc version\n",
+    "import torch\n",
+    "import torchvision\n",
     "!nvcc -V\n",
     "# Check GCC version\n",
-    "!gcc --version"
+    "!gcc - -version\n",
+    "# Check Pytorch installation\n",
+    "print(torch.__version__, torch.cuda.is_available())"
    ]
   },
   {
@@ -66,8 +70,6 @@
    },
    "outputs": [],
    "source": [
-    "# Install PyTorch\n",
-    "!conda install pytorch=1.10.0 torchvision cudatoolkit=11.1 -c pytorch\n",
     "# Install mim\n",
     "!pip install -U openmim\n",
     "# Install mmengine\n",
@@ -106,10 +108,6 @@
    },
    "outputs": [],
    "source": [
-    "# Check Pytorch installation\n",
-    "import torch, torchvision\n",
-    "print(torch.__version__, torch.cuda.is_available())\n",
-    "\n",
     "# Check MMSegmentation installation\n",
     "import mmseg\n",
     "print(mmseg.__version__)"
@@ -500,16 +498,17 @@
    },
    "outputs": [],
    "source": [
-    "from mmseg.apis import inference_model, show_result_pyplot\n",
+    "from mmseg.apis import init_model, inference_model, show_result_pyplot\n",
     "\n",
-    "model=runner.model\n",
-    "model.cfg=cfg\n",
+    "# Init the model from the config and the checkpoint\n",
+    "checkpoint_path = './work_dirs/tutorial/iter_200.pth'\n",
+    "model = init_model(cfg, checkpoint_path, 'cuda:0')\n",
     "\n",
     "img = mmcv.imread('iccv09Data/images/6000124.jpg')\n",
     "result = inference_model(model, img)\n",
     "plt.figure(figsize=(8, 6))\n",
-    "vis_result = show_result_pyplot(model, img, result, palette)\n",
-    "plt.imshow(mmcv.bgr2rgb(vis_result))"
+    "vis_result = show_result_pyplot(model, img, result)\n",
+    "plt.imshow(mmcv.bgr2rgb(vis_result))\n"
    ]
   }
  ],


### PR DESCRIPTION
## Motivation
- It does not need to install torch again in this tutorial because users usually have installed torch following [get_started.md](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/docs/en/get_started.md#installation) , or use default environment on colab.
- The api `show_result_pyplot()` does not have the parameter `palette` .
- Save the bug `AttributeError: 'EncoderDecoder' object has no attribute 'dataset_meta'` in ` vis_result = show result pyplot(model, img, result, palette)` . The 'dataset_meta' is saved in the checkpoint.

## Modification
- Remove the step of torch installation.
- Init the model from the checkpoint before inference and visualization.
- Remove the needless parameter `palette` in `show_result_pyplot(model, img, result, palette)` .