### PR TITLE
[Fix] Fix KNet IterativeDecodeHead bug in master branch

### DIFF
--- a/mmseg/models/decode_heads/knet_head.py
+++ b/mmseg/models/decode_heads/knet_head.py
@@ -411,6 +411,9 @@ class IterativeDecodeHead(BaseDecodeHead):
 
     def __init__(self, num_stages, kernel_generate_head, kernel_update_head,
                  **kwargs):
+        # ``IterativeDecodeHead`` would skip initialization of
+        # ``BaseDecodeHead`` which would be called when building
+        # ``self.kernel_generate_head``.
         super(BaseDecodeHead, self).__init__(**kwargs)
         assert num_stages == len(kernel_update_head)
         self.num_stages = num_stages

--- a/mmseg/models/decode_heads/knet_head.py
+++ b/mmseg/models/decode_heads/knet_head.py
@@ -420,6 +420,7 @@ class IterativeDecodeHead(BaseDecodeHead):
         self.num_classes = self.kernel_generate_head.num_classes
         self.input_transform = self.kernel_generate_head.input_transform
         self.ignore_index = self.kernel_generate_head.ignore_index
+        self.out_channels = self.num_classes
 
         for head_cfg in kernel_update_head:
             self.kernel_update_head.append(build_head(head_cfg))


### PR DESCRIPTION
Fix: https://github.com/open-mmlab/mmsegmentation/issues/2325

## Motivation
In latest master branch, it would raise error when training K-Net like below:
![image](https://user-images.githubusercontent.com/24582831/203223431-8c9750fb-6049-4112-bd33-40d2e96bd956.png)

After adding `self.out_channels = self.num_classes` in `IterativeDecodeHead` initialization function, this bug would be fixed:

![image](https://user-images.githubusercontent.com/24582831/203223552-f8fb5277-cb79-40ac-b6a5-220c35f62684.png)
