### PR TITLE
[Fix] Fix KNet IterativeDecodeHead bug in dev-1.x branch

### DIFF
--- a/data
+++ b/data
@@ -1,0 +1,1 @@
+/home/PJLAB/limengzhang/Downloads/datasets/

--- a/data
+++ b/data
@@ -1,1 +1,0 @@
-/home/PJLAB/limengzhang/Downloads/datasets/

--- a/mmseg/models/decode_heads/knet_head.py
+++ b/mmseg/models/decode_heads/knet_head.py
@@ -422,6 +422,7 @@ class IterativeDecodeHead(BaseDecodeHead):
         self.num_classes = self.kernel_generate_head.num_classes
         self.input_transform = self.kernel_generate_head.input_transform
         self.ignore_index = self.kernel_generate_head.ignore_index
+        self.out_channels = self.num_classes
 
         for head_cfg in kernel_update_head:
             self.kernel_update_head.append(MODELS.build(head_cfg))

--- a/mmseg/models/decode_heads/knet_head.py
+++ b/mmseg/models/decode_heads/knet_head.py
@@ -413,6 +413,9 @@ class IterativeDecodeHead(BaseDecodeHead):
 
     def __init__(self, num_stages, kernel_generate_head, kernel_update_head,
                  **kwargs):
+        # ``IterativeDecodeHead`` would skip initialization of
+        # ``BaseDecodeHead`` which would be called when building
+        # ``self.kernel_generate_head``.
         super(BaseDecodeHead, self).__init__(**kwargs)
         assert num_stages == len(kernel_update_head)
         self.num_stages = num_stages


### PR DESCRIPTION
Fix: https://github.com/open-mmlab/mmsegmentation/issues/2325

## Motivation
In latest dev-1.x branch, it would raise error when training K-Net like below:
![image](https://user-images.githubusercontent.com/24582831/203224142-94121236-754c-47e4-ab89-d2e055763426.png)


After adding `self.out_channels = self.num_classes` in `IterativeDecodeHead` initialization function, this bug would be fixed:
![image](https://user-images.githubusercontent.com/24582831/203224176-190e040e-371f-45ae-a85b-84504533a2ae.png)
