### PR TITLE
[Feature] Add ResizeShortestEdge transform

### DIFF
--- a/mmseg/__init__.py
+++ b/mmseg/__init__.py
@@ -7,7 +7,7 @@ from packaging.version import parse
 
 from .version import __version__, version_info
 
-MMCV_MIN = '2.0.0rc1'
+MMCV_MIN = '2.0.0rc3'
 MMCV_MAX = '2.1.0'
 MMENGINE_MIN = '0.1.0'
 MMENGINE_MAX = '1.0.0'

--- a/mmseg/datasets/__init__.py
+++ b/mmseg/datasets/__init__.py
@@ -22,7 +22,8 @@ from .transforms import (CLAHE, AdjustGamma, GenerateEdge, LoadAnnotations,
                          LoadBiomedicalImageFromFile, LoadImageFromNDArray,
                          PackSegInputs, PhotoMetricDistortion, RandomCrop,
                          RandomCutOut, RandomMosaic, RandomRotate, Rerange,
-                         ResizeToMultiple, RGB2Gray, SegRescale)
+                         ResizeShortestEdge, ResizeToMultiple, RGB2Gray,
+                         SegRescale)
 from .voc import PascalVOCDataset
 
 __all__ = [
@@ -36,5 +37,5 @@ __all__ = [
     'RandomCutOut', 'RandomMosaic', 'PackSegInputs', 'ResizeToMultiple',
     'LoadImageFromNDArray', 'LoadBiomedicalImageFromFile',
     'LoadBiomedicalAnnotation', 'LoadBiomedicalData', 'GenerateEdge',
-    'DecathlonDataset', 'LIPDataset'
+    'DecathlonDataset', 'LIPDataset', 'ResizeShortestEdge'
 ]

--- a/mmseg/datasets/transforms/__init__.py
+++ b/mmseg/datasets/transforms/__init__.py
@@ -5,13 +5,15 @@ from .loading import (LoadAnnotations, LoadBiomedicalAnnotation,
                       LoadImageFromNDArray)
 from .transforms import (CLAHE, AdjustGamma, GenerateEdge,
                          PhotoMetricDistortion, RandomCrop, RandomCutOut,
-                         RandomMosaic, RandomRotate, Rerange, ResizeToMultiple,
-                         RGB2Gray, SegRescale)
+                         RandomMosaic, RandomRotate, Rerange,
+                         ResizeShortestEdge, ResizeToMultiple, RGB2Gray,
+                         SegRescale)
 
 __all__ = [
     'LoadAnnotations', 'RandomCrop', 'SegRescale', 'PhotoMetricDistortion',
     'RandomRotate', 'AdjustGamma', 'CLAHE', 'Rerange', 'RGB2Gray',
     'RandomCutOut', 'RandomMosaic', 'PackSegInputs', 'ResizeToMultiple',
     'LoadImageFromNDArray', 'LoadBiomedicalImageFromFile',
-    'LoadBiomedicalAnnotation', 'LoadBiomedicalData', 'GenerateEdge'
+    'LoadBiomedicalAnnotation', 'LoadBiomedicalData', 'GenerateEdge',
+    'ResizeShortestEdge'
 ]

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1303,7 +1303,7 @@ class ResizeShortestEdge(BaseTransform):
 
         new_h = int(new_h + 0.5)
         new_w = int(new_w + 0.5)
-        return (new_h, new_w)
+        return (new_w, new_h)
 
     def transform(self, results: Dict) -> Dict:
         self.resize.scale = self._get_output_shape(results['img'], self.scale)

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1232,7 +1232,9 @@ class GenerateEdge(BaseTransform):
 class ResizeShortestEdge(BaseTransform):
     """Resize the image and mask while keeping the aspect ratio unchanged.
 
-    Modified from https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/transforms/augmentation_impl.py#L130 (Apache-2.0 License) # noqa:E501
+    Modified from https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/transforms/augmentation_impl.py#L130 # noqa:E501
+    Copyright (c) Facebook, Inc. and its affiliates.
+    Licensed under the Apache-2.0 License
 
     This transform attempts to scale the shorter edge to the given
     `scale`, as long as the longer edge does not exceed `max_size`.

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1232,7 +1232,7 @@ class GenerateEdge(BaseTransform):
 class ResizeShortestEdge(BaseTransform):
     """Resize the image and mask while keeping the aspect ratio unchanged.
 
-    Modified from https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/transforms/augmentation_impl.py#L130  # noqa:E501
+    Modified from https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/transforms/augmentation_impl.py#L130 (Apache-2.0 License) # noqa:E501
 
     This transform attempts to scale the shorter edge to the given
     `scale`, as long as the longer edge does not exceed `max_size`.
@@ -1258,12 +1258,15 @@ class ResizeShortestEdge(BaseTransform):
 
 
     Args:
-        scale (int): The target short edge length.
+        scale (Union[int, Tuple[int, int]]): The target short edge length.
+            If it's tuple, will select the min value as the short edge length.
         max_size (int): The maximum allowed longest edge length.
     """
 
-    def __init__(self, scale: int, max_size: int) -> None:
+    def __init__(self, scale: Union[int, Tuple[int, int]],
+                 max_size: int) -> None:
         super().__init__()
+        self.scale = scale
         self.max_size = max_size
 
         # Create a empty Resize object
@@ -1272,9 +1275,16 @@ class ResizeShortestEdge(BaseTransform):
             'scale': 0,
             'keep_ratio': True
         })
-        self.scale = scale
 
     def _get_output_shape(self, img, short_edge_length) -> Tuple[int, int]:
+        """Compute the target image shape with the given `short_edge_length`.
+
+        Args:
+            img (np.ndarray): The input image.
+            short_edge_length (Union[int, Tuple[int, int]]): The target short
+                edge length. If it's tuple, will select the min value as the
+                short edge length.
+        """
         h, w = img.shape[:2]
         if isinstance(short_edge_length, int):
             size = short_edge_length * 1.0

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1235,8 +1235,8 @@ class ResizeShortestEdge(BaseTransform):
     Modified from https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/transforms/augmentation_impl.py#L130  # noqa:E501
 
     This transform attempts to scale the shorter edge to the given
-    `short_edge_length` , as long as the longer edge does not exceed
-    `max_size`. If `max_size` is reached, then downscale so that the longer
+    `scale`, as long as the longer edge does not exceed `max_size`.
+    If `max_size` is reached, then downscale so that the longer
     edge does not exceed `max_size`.
 
     Required Keys:

--- a/tests/test_datasets/test_transform.py
+++ b/tests/test_datasets/test_transform.py
@@ -10,6 +10,9 @@ from PIL import Image
 from mmseg.datasets.transforms import *  # noqa
 from mmseg.datasets.transforms import PhotoMetricDistortion, RandomCrop
 from mmseg.registry import TRANSFORMS
+from mmseg.utils import register_all_modules
+
+register_all_modules()
 
 
 def test_resize():
@@ -73,7 +76,6 @@ def test_resize():
 
     # test RandomChoiceResize, which `resize_type` is `ResizeShortestEdge`
     transform = dict(
-        _scope_='mmseg',
         type='RandomChoiceResize',
         scales=[128, 256, 512],
         resize_type='ResizeShortestEdge',
@@ -83,7 +85,6 @@ def test_resize():
     assert resized_results['img_shape'][0] in [128, 256, 512]
 
     transform = dict(
-        _scope_='mmseg',
         type='RandomChoiceResize',
         scales=[512],
         resize_type='ResizeShortestEdge',
@@ -93,7 +94,6 @@ def test_resize():
     assert resized_results['img_shape'][1] == 512
 
     transform = dict(
-        _scope_='mmseg',
         type='RandomChoiceResize',
         scales=[(128, 256), (256, 512), (512, 1024)],
         resize_type='ResizeShortestEdge',

--- a/tests/test_datasets/test_transform.py
+++ b/tests/test_datasets/test_transform.py
@@ -706,3 +706,77 @@ def test_generate_edge():
         [1, 1, 0, 0, 0],
         [1, 0, 0, 0, 0],
     ]))
+
+
+def test_resize_shortest_edge():
+    # test sampel_style
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='ResizeShortestEdge',
+            short_edge_length=[128, 256, 512],
+            max_size=1024,
+            sample_style='choose')
+        transform = TRANSFORMS.build(transform)
+
+    # test short_edge_length is List[int] when sample_style == 'choice'
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='ResizeShortestEdge',
+            short_edge_length=[0.1, 0.2, 0.3],
+            max_size=512,
+            sample_style='choice')
+        transform = TRANSFORMS.build(transform)
+
+    # test short_edge_length when sample_style == 'range'
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='ResizeShortestEdge',
+            short_edge_length=(100, 200, 300),
+            max_size=512,
+            sample_style='range')
+        transform = TRANSFORMS.build(transform)
+
+    # test sample_style='choice'
+    transform = dict(
+        type='ResizeShortestEdge',
+        short_edge_length=[128, 256, 512],
+        max_size=1024,
+        sample_style='choice')
+    transform = TRANSFORMS.build(transform)
+
+    results = dict()
+    results['img'] = np.random.randn(233, 332, 3)
+    results['gt_seg_map'] = np.random.randint(0, 19, (288, 288))
+
+    results = transform(results)
+    assert results['img_shape'][0] in [128, 256, 512]
+    assert results['gt_seg_map'].shape[0] in [128, 256, 512]
+
+    # test sample_style='range'
+    transform = dict(
+        type='ResizeShortestEdge',
+        short_edge_length=(256, 512),
+        max_size=1024,
+        sample_style='range')
+    transform = TRANSFORMS.build(transform)
+
+    results['img'] = np.random.randn(233, 332, 3)
+    results['gt_seg_map'] = np.random.randint(0, 19, (233, 332))
+    results = transform(results)
+    assert 256 <= results['img_shape'][0] <= 512
+    assert 256 <= results['gt_seg_map'].shape[0] <= 512
+
+    # test max_size
+    transform = dict(
+        type='ResizeShortestEdge',
+        short_edge_length=(256, 256),
+        max_size=300,
+        sample_style='range')
+    transform = TRANSFORMS.build(transform)
+
+    results['img'] = np.random.randn(233, 332, 3)
+    results['gt_seg_map'] = np.random.randint(0, 19, (233, 332))
+
+    results = transform(results)
+    assert results['img_shape'][1] == 300
+    assert results['gt_seg_map'].shape[1] == 300


### PR DESCRIPTION
## Motivation

Support resize shortest edge while keeping the aspect ratio unchanged.

Modifed from https://github.com/facebookresearch/detectron2/blob/main/detectron2/data/transforms/augmentation_impl.py#L130

## Modification

- Add `ResizeShortestEdge` to mmseg/datasets/transforms/transforms.py
- Add unit test

## BC-breaking (Optional)

Depend on `mmcv >= 2.0.0rc3`

## Use cases (Optional)

At `train_pipeline`:

```python
train_pipeline = [
    ...
    dict(
        type='RandomChoiceResize',
        scales=[128, 256, 512],
        resize_type='ResizeShortestEdge',
        max_size=2048,
    )
    ...
]
```
