### PR TITLE
[Doc] Change some content from customize_runtime to engine ZN doc

### DIFF
--- a/docs/zh_cn/advanced_guides/engine.md
+++ b/docs/zh_cn/advanced_guides/engine.md
@@ -7,7 +7,7 @@ OpenMMLab 的算法库如 MMSegmentation 将模型训练, 测试和推理抽象�
 
 ### 配置训练长度
 
-循环控制器  指的是训练, 验证和测试时的执行流程. 我们在配置文件里面使用 `train_cfg`, `val_cfg` 和 `test_cfg` 来构建 `Loop`. 通过在 `configs/_base_/schedules` 文件夹里面的 `train_cfg` 设置训练长度.
+循环控制器指的是训练, 验证和测试时的执行流程，在配置文件里面使用 `train_cfg`, `val_cfg` 和 `test_cfg` 来构建这些流程. MMSegmentation 在 `configs/_base_/schedules` 文件夹里面的 `train_cfg` 设置常用的训练长度.
 例如, 使用基于迭代次数的训练循环 (`IterBasedTrainLoop`) 去训练 80,000 个迭代次数, 并且每 8,000 iteration 做一次验证, 可以如下设置:
 
 ```python
@@ -26,7 +26,7 @@ optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
 
 我们支持 PyTorch 里面所有的优化器, 更多细节可以参考 MMEngine [优化器文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/optim_wrapper.md).
 
-更多关于优化器的使用方法, 可以看下面优化器的章节.
+需要强调的是, `optim_wrapper` 是 `runner` 的变量, 而 `optimizer` 是一个中间变量. **训练中换优化器，需要更新优化器封装**. 更多关于优化器的使用方法, 可以看下面优化器的章节.
 
 ### 配置训练参数调度器
 
@@ -48,7 +48,7 @@ param_scheduler = [
 ]
 ```
 
-这样在训练时前 1,000 个 iteration 时采用线性变化的学习率策略做 warm up, 从 1,000 iteration 之后直到最后 16,000 个 iteration 时则采用默认的多项式学习率衰减.
+这样在训练时前 1,000 个 iteration 时采用线性变化的学习率策略作为训练预热, 从 1,000 iteration 之后直到最后 16,000 个 iteration 时则采用默认的多项式学习率衰减.
 
 注意: 当你修改 `train_cfg` 里面 `max_iters` 的时候, 请确保参数调度器 `param_scheduler` 里面的参数也被同时修改.
 
@@ -123,12 +123,9 @@ logger=dict(type='LoggerHook', interval=10)
 # TensorboardVisBackend
 visualizer = dict(
     type='SegLocalVisualizer', vis_backends=[dict(type='TensorboardVisBackend')], name='visualizer')
-# 或者 WandbVisBackend
-visualizer = dict(
-    type='SegLocalVisualizer', vis_backends=[dict(type='WandbVisBackend')], name='visualizer')
 ```
 
-关于更多相关用法，可以参考 [MMEngine 存储后端用户教程](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/advanced_tutorials/visualization.md).
+关于更多相关用法，可以参考 [MMEngine 可视化后端用户教程](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/advanced_tutorials/visualization.md).
 
 - 自定义钩子 (custom hooks)
 
@@ -198,15 +195,13 @@ class SegVisualizationHook(Hook):
 OpenMMLab 2.0 设计了优化器封装, 它支持不同的训练策略, 包括混合精度训练、梯度累加和梯度截断等, 用户可以根据需求选择合适的训练策略.
 优化器封装还定义了一套标准的参数更新流程, 用户可以基于这一套流程, 在同一套代码里, 实现不同训练策略的切换. 如果想了解更多, 可以参考 [MMEngine 优化器封装文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/optim_wrapper.md).
 
-需要强调的是, `optim_wrapper` 是 `runner` 的变量, 而 `optimizer` 是一个中间变量. **训练中换优化器，需要更新优化器封装**.
-MMSegmentation 训练模型也是使用优化器封装来优化参数, 以下是 MMSegmentation 中常用的使用方法:
+以下是 MMSegmentation 中常用的使用方法:
 
 #### 配置 PyTorch 支持的优化器
 
 OpenMMLab 2.0 支持 PyTorch 原生所有优化器, 参考[这里](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/optim_wrapper.md#%E7%AE%80%E5%8D%95%E9%85%8D%E7%BD%AE).
 
-[优化器封装 (Optimizer wrapper)](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/docs/zh_cn/advanced_guides/engine.md#%E4%BC%98%E5%8C%96%E5%99%A8%E5%B0%81%E8%A3%85)
-提供一个统一的在不同硬件 (如 CPU, GPU, MLU, IPU 等) 上的接口. 在配置文件中设置训练时 `Runner` 所使用的优化器, 需要定义 `optim_wrapper`, 下面是一个 `optim_wrapper` 的例子:
+在配置文件中设置训练时 `Runner` 所使用的优化器, 需要定义 `optim_wrapper`, 而不是 `optimizer`，下面是一个 `optim_wrapper` 的例子:
 
 ```python
 optim_wrapper = dict(
@@ -215,7 +210,7 @@ optim_wrapper = dict(
     clip_grad=None)
 ```
 
-#### 梯度裁剪
+#### 配置梯度裁剪
 
 一些模型需要使用梯度裁剪来让训练过程更加稳定. 示例如下:
 
@@ -227,7 +222,7 @@ optim_wrapper = dict(type='OptimWrapper', optimizer=optimizer,
 
 这里 max_norm 指的是裁剪后梯度的最大值,  norm_type 指的是裁剪梯度时使用的范数. 相关方法可参考 [torch.nn.utils.clip_grad_norm\_](https://pytorch.org/docs/stable/generated/torch.nn.utils.clip_grad_norm_.html).
 
-#### 混合精度训练
+#### 配置混合精度训练
 
 除此之外, 如果你想应用混合精度训练, 可以将 OptimWrapper 换成 AmpOptimWrapper，例如:
 
@@ -238,7 +233,7 @@ optim_wrapper = dict(type='AmpOptimWrapper', optimizer=optimizer)
 
 [`AmpOptimWrapper`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/optim/optimizer/amp_optimizer_wrapper.py#L20) 中 `loss_scale` 的默认设置是 `dynamic`.
 
-#### 自定义模型网络不同层的超参数
+#### 配置模型网络不同层的超参数
 
 在模型训练中, 如果想在优化器里为不同参数分别设置优化策略, 例如设置不同的学习率、权重衰减等超参数, 可以通过设置配置文件里 `optim_wrapper` 中的 `paramwise_cfg` 来实现.
 

--- a/docs/zh_cn/advanced_guides/engine.md
+++ b/docs/zh_cn/advanced_guides/engine.md
@@ -1,13 +1,13 @@
 # 训练引擎
 
-MMEngine 定义了一些[基础循环控制器](https://github.com/open-mmlab/mmengine/blob/main/mmengine/runner/loops.py) 例如`基于轮次的训练循环 (EpochBasedTrainLoop)`, `基于迭代次数的训练循环 (IterBasedTrainLoop)`, `标准的验证循环 (ValLoop)` 和`标准的测试循环 (TestLoop)`.
-OpenMMLab 的算法库如 MMSegmentation 将模型训练, 测试和推理抽象为 `Runner (执行器)` 来处理。用户可以直接使用 MMEngine 中的默认执行器，也可以对执行器进行修改以满足定制化需求. 这个文档主要介绍用户如何配置已有的运行设定, 钩子和优化器的基本概念与使用方法.
+MMEngine 定义了一些[基础循环控制器](https://github.com/open-mmlab/mmengine/blob/main/mmengine/runner/loops.py) 例如基于轮次的训练循环 (`EpochBasedTrainLoop`), 基于迭代次数的训练循环 (`IterBasedTrainLoop`), 标准的验证循环 (`ValLoop`) 和标准的测试循环 (`TestLoop`).
+OpenMMLab 的算法库如 MMSegmentation 将模型训练, 测试和推理抽象为执行器(`Runner`) 来处理. 用户可以直接使用 MMEngine 中的默认执行器, 也可以对执行器进行修改以满足定制化需求. 这个文档主要介绍用户如何配置已有的运行设定, 钩子和优化器的基本概念与使用方法.
 
 ## 配置运行设定
 
 ### 配置训练长度
 
-循环控制器指的是训练, 验证和测试时的执行流程，在配置文件里面使用 `train_cfg`, `val_cfg` 和 `test_cfg` 来构建这些流程. MMSegmentation 在 `configs/_base_/schedules` 文件夹里面的 `train_cfg` 设置常用的训练长度.
+循环控制器指的是训练, 验证和测试时的执行流程, 在配置文件里面使用 `train_cfg`, `val_cfg` 和 `test_cfg` 来构建这些流程. MMSegmentation 在 `configs/_base_/schedules` 文件夹里面的 `train_cfg` 设置常用的训练长度.
 例如, 使用基于迭代次数的训练循环 (`IterBasedTrainLoop`) 去训练 80,000 个迭代次数, 并且每 8,000 iteration 做一次验证, 可以如下设置:
 
 ```python
@@ -16,23 +16,24 @@ train_cfg = dict(type='IterBasedTrainLoop', max_iters=80000, val_interval=8000)
 
 ### 配置训练优化器
 
-在修改优化器配置文件之前, 推荐参考 MMEngine 的 [engine 文档](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/docs/en/advanced_guides/engine.md) 了解 mmsegmentation 1.x 中优化器的定义.
-
 这里是一个 SGD 优化器的例子:
 
 ```python
-optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
+optim_wrapper = dict(
+    type='OptimWrapper',
+    optimizer=dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0005),
+    clip_grad=None)
 ```
 
-我们支持 PyTorch 里面所有的优化器, 更多细节可以参考 MMEngine [优化器文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/optim_wrapper.md).
+OpenMMLab 支持 PyTorch 里面所有的优化器, 更多细节可以参考 MMEngine [优化器文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/optim_wrapper.md).
 
-需要强调的是, `optim_wrapper` 是 `runner` 的变量, 而 `optimizer` 是一个中间变量. **训练中换优化器，需要更新优化器封装**. 更多关于优化器的使用方法, 可以看下面优化器的章节.
+需要强调的是, `optim_wrapper` 是 `runner` 的变量, 所以需要配置优化器时配置的字段是 `optim_wrapper` 字段. 更多关于优化器的使用方法, 可以看下面优化器的章节.
 
 ### 配置训练参数调度器
 
 在配置训练参数调度器前, 推荐先了解 [MMEngine 文档](https://github.com/open-mmlab/mmengine/blob/main/docs/en/tutorials/param_scheduler.md) 里面关于参数调度器的基本概念.
 
-这里是一个参数调度器的例子, 例如我们想在前 1000 个 iteration 对学习率做 warm up:
+以下是一个参数调度器的例子, 训练时前 1,000 个 iteration 时采用线性变化的学习率策略作为训练预热, 从 1,000 iteration 之后直到最后 16,000 个 iteration 时则采用默认的多项式学习率衰减:
 
 ```python
 param_scheduler = [
@@ -48,13 +49,9 @@ param_scheduler = [
 ]
 ```
 
-这样在训练时前 1,000 个 iteration 时采用线性变化的学习率策略作为训练预热, 从 1,000 iteration 之后直到最后 16,000 个 iteration 时则采用默认的多项式学习率衰减.
-
-注意: 当你修改 `train_cfg` 里面 `max_iters` 的时候, 请确保参数调度器 `param_scheduler` 里面的参数也被同时修改.
+注意: 当修改 `train_cfg` 里面 `max_iters` 的时候, 请确保参数调度器 `param_scheduler` 里面的参数也被同时修改.
 
 ## 钩子 (Hook)
-
-在了解如何修改这些钩子的配置之前, 推荐参考 [engine.md](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/docs/en/advanced_guides/engine.md) 文档了解 mmsegmentation 1.x 中钩子的定义.
 
 ### 介绍
 
@@ -64,19 +61,19 @@ OpenMMLab 将模型训练和测试过程抽象为 `Runner`, 插入钩子可以�
 
 - 默认钩子 (default hooks)
 
-它们实现了训练时所必需的功能，在配置文件中用 `default_hooks` 定义传给 `Runner`, `Runner` 通过 [`register_default_hooks`](https://github.com/open-mmlab/mmengine/blob/090104df21acd05a8aadae5a0d743a7da3314f6f/mmengine/runner/runner.py#L1780) 方法注册.
+它们实现了训练时所必需的功能, 在配置文件中用 `default_hooks` 定义传给 `Runner`, `Runner` 通过 [`register_default_hooks`](https://github.com/open-mmlab/mmengine/blob/090104df21acd05a8aadae5a0d743a7da3314f6f/mmengine/runner/runner.py#L1780) 方法注册.
 钩子有对应的优先级, 优先级越高, 越早被执行器调用. 如果优先级一样, 被调用的顺序和钩子注册的顺序一致.
-不建议用户修改默认钩子的优先级，可以参考 [mmengine hooks 文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/hook.md) 了解钩子优先级的定义.
+不建议用户修改默认钩子的优先级, 可以参考 [mmengine hooks 文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/hook.md) 了解钩子优先级的定义.
 下面是 MMSegmentation 中所用到的默认钩子：
 
-|                                                           钩子                                                            |                                               功能                                               |      优先级       |
-| :-----------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: | :---------------: |
-|            [IterTimerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/iter_timer_hook.py)            |                                    记录 iteration 花费的时间.                                    |    NORMAL (50)    |
-|               [LoggerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/logger_hook.py)                | 从 `Runner` 里不同的组件中收集日志记录，并将其输出到终端， JSON 文件，tensorboard，wandb 等下游. | BELOW_NORMAL (60) |
-|       [ParamSchedulerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/param_scheduler_hook.py)       |                          更新优化器里面的一些超参数，例如学习率的动量.                           |     LOW (70)      |
-|           [CheckpointHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/checkpoint_hook.py)            |                                  规律性地保存 checkpoint 文件.                                   |   VERY_LOW (90)   |
-|        [DistSamplerSeedHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/sampler_seed_hook.py)        |                                确保分布式采样器 shuffle 是打开的.                                |    NORMAL (50)    |
-| [SegVisualizationHook](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/mmseg/visualization/local_visualizer.py) |                                可视化验证和测试过程里的预测结果.                                 |    NORMAL (50)    |
+|                                                           钩子                                                            |                                              功能                                               |      优先级       |
+| :-----------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: | :---------------: |
+|            [IterTimerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/iter_timer_hook.py)            |                                   记录 iteration 花费的时间.                                    |    NORMAL (50)    |
+|               [LoggerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/logger_hook.py)                | 从 `Runner` 里不同的组件中收集日志记录, 并将其输出到终端, JSON 文件, tensorboard, wandb 等下游. | BELOW_NORMAL (60) |
+|       [ParamSchedulerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/param_scheduler_hook.py)       |                          更新优化器里面的一些超参数, 例如学习率的动量.                          |     LOW (70)      |
+|           [CheckpointHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/checkpoint_hook.py)            |                                  规律性地保存 checkpoint 文件.                                  |   VERY_LOW (90)   |
+|        [DistSamplerSeedHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/sampler_seed_hook.py)        |                               确保分布式采样器 shuffle 是打开的.                                |    NORMAL (50)    |
+| [SegVisualizationHook](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/mmseg/visualization/local_visualizer.py) |                                可视化验证和测试过程里的预测结果.                                |    NORMAL (50)    |
 
 MMSegmentation 会在 [`defualt_hooks`](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/configs/_base_/schedules/schedule_160k.py#L19-L25) 里面注册一些训练所必需功能的钩子::
 
@@ -114,10 +111,10 @@ logger=dict(type='LoggerHook', interval=10)
 ```
 
 在最新的 1.x 版本的 MMSegmentation 里面, 一些日志钩子 (LoggerHook) 例如 `TextLoggerHook`, `WandbLoggerHook` 和 `TensorboardLoggerHook` 将不再被使用.
-作为替代, MMEngine 使用 `LogProcessor` 来处理上述钩子处理的信息，它们现在在 [`MessageHub`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/logging/message_hub.py#L17),
+作为替代, MMEngine 使用 `LogProcessor` 来处理上述钩子处理的信息, 它们现在在 [`MessageHub`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/logging/message_hub.py#L17),
 [`WandbVisBackend`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/visualization/vis_backend.py#L324) 和 [`TensorboardVisBackend`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/visualization/vis_backend.py#L472) 里面.
 
-如果想使用这些后端, 只需要修改配置文件即可:
+具体使用方法如下, 配置可视化器和同时指定可视化后端, 这里使用 Tensorboard 作为可视化器的后端:
 
 ```python
 # TensorboardVisBackend
@@ -125,7 +122,7 @@ visualizer = dict(
     type='SegLocalVisualizer', vis_backends=[dict(type='TensorboardVisBackend')], name='visualizer')
 ```
 
-关于更多相关用法，可以参考 [MMEngine 可视化后端用户教程](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/advanced_tutorials/visualization.md).
+关于更多相关用法, 可以参考 [MMEngine 可视化后端用户教程](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/advanced_tutorials/visualization.md).
 
 - 自定义钩子 (custom hooks)
 
@@ -149,7 +146,7 @@ custom_hooks = [
 ### SegVisualizationHook
 
 MMSegmentation 实现了 [`SegVisualizationHook`](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/mmseg/engine/hooks/visualization_hook.py#L17), 用来在验证和测试时可视化预测结果.
-`SegVisualizationHook` 重写了基类 `Hook` 中的 `_after_iter` 方法, 在验证或测试时, 根据指定的迭代次数间隔调用 `visualizer` 的 `add_datasample` 方法绘制语义分割结果，具体实现如下:
+`SegVisualizationHook` 重写了基类 `Hook` 中的 `_after_iter` 方法, 在验证或测试时, 根据指定的迭代次数间隔调用 `visualizer` 的 `add_datasample` 方法绘制语义分割结果, 具体实现如下:
 
 ```python
 ...
@@ -201,7 +198,7 @@ OpenMMLab 2.0 设计了优化器封装, 它支持不同的训练策略, 包括�
 
 OpenMMLab 2.0 支持 PyTorch 原生所有优化器, 参考[这里](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/optim_wrapper.md#%E7%AE%80%E5%8D%95%E9%85%8D%E7%BD%AE).
 
-在配置文件中设置训练时 `Runner` 所使用的优化器, 需要定义 `optim_wrapper`, 而不是 `optimizer`，下面是一个 `optim_wrapper` 的例子:
+在配置文件中设置训练时 `Runner` 所使用的优化器, 需要定义 `optim_wrapper`, 而不是 `optimizer`, 下面是一个配置训练中优化器的例子:
 
 ```python
 optim_wrapper = dict(
@@ -212,7 +209,7 @@ optim_wrapper = dict(
 
 #### 配置梯度裁剪
 
-一些模型需要使用梯度裁剪来让训练过程更加稳定. 示例如下:
+当模型训练需要使用梯度裁剪的训练技巧式, 可以按照如下示例进行配置:
 
 ```python
 optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
@@ -220,11 +217,11 @@ optim_wrapper = dict(type='OptimWrapper', optimizer=optimizer,
                         clip_grad=dict(max_norm=0.01, norm_type=2))
 ```
 
-这里 max_norm 指的是裁剪后梯度的最大值,  norm_type 指的是裁剪梯度时使用的范数. 相关方法可参考 [torch.nn.utils.clip_grad_norm\_](https://pytorch.org/docs/stable/generated/torch.nn.utils.clip_grad_norm_.html).
+这里 `max_norm` 指的是裁剪后梯度的最大值,  `norm_type` 指的是裁剪梯度时使用的范数. 相关方法可参考 [torch.nn.utils.clip_grad_norm\_](https://pytorch.org/docs/stable/generated/torch.nn.utils.clip_grad_norm_.html).
 
 #### 配置混合精度训练
 
-除此之外, 如果你想应用混合精度训练, 可以将 OptimWrapper 换成 AmpOptimWrapper，例如:
+当需要使用混合精度训练降低内存时, 可以使用 `AmpOptimWrapper`, 具体配置如下:
 
 ```python
 optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
@@ -237,8 +234,8 @@ optim_wrapper = dict(type='AmpOptimWrapper', optimizer=optimizer)
 
 在模型训练中, 如果想在优化器里为不同参数分别设置优化策略, 例如设置不同的学习率、权重衰减等超参数, 可以通过设置配置文件里 `optim_wrapper` 中的 `paramwise_cfg` 来实现.
 
-下面的配置文件以 [ViT `optim_wrapper`](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/configs/vit/vit_vit-b16-ln_mln_upernet_8xb2-160k_ade20k-512x512.py#L15-L27) 为例,
-优化器中设置了权重衰减 (weight decay) 系数, 但是将 `pos_embed`, `mask_token`, `norm` 模块的 weight decay multiplication 设置成 0.
+下面的配置文件以 [ViT `optim_wrapper`](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/configs/vit/vit_vit-b16-ln_mln_upernet_8xb2-160k_ade20k-512x512.py#L15-L27) 为例介绍 `paramwise_cfg` 参数使用.
+训练时将 `pos_embed`, `mask_token`, `norm` 模块的 weight decay 参数的系数设置成 0.
 即: 在训练时, 这些模块的 weight decay 将被变为 `weight_decay * decay_mult`=0.
 
 ```python
@@ -279,4 +276,4 @@ optim_wrapper = dict(
     loss_scale='dynamic')
 ```
 
-注意: 如果你的配置文件继承自基配置文件, 后者已经设置了 `optim_wrapper`, 你需要使用 `_delete_=True` 来重写不必须的设置.
+`_delete_=True` 的作用是 OpenMMLab Config 中的忽略继承的配置, 在该代码片段中忽略继承的 `optim_wrapper` 配置, 更多 `_delete_` 字段的内容可以参考 [MMEngine 文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/advanced_tutorials/config.md#%E5%88%A0%E9%99%A4%E5%AD%97%E5%85%B8%E4%B8%AD%E7%9A%84-key).

--- a/docs/zh_cn/advanced_guides/engine.md
+++ b/docs/zh_cn/advanced_guides/engine.md
@@ -15,7 +15,7 @@ OpenMMLab 将模型训练和测试过程抽象为 `Runner`, 插入钩子可以�
 不建议用户修改默认钩子的优先级，可以参考 [mmengine hooks 文档](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/tutorials/hook.md) 了解钩子优先级的定义.
 下面是 MMSegmentation 中所用到的默认钩子：
 
-|                                                           钩子                                                            |                                               用法                                               |      优先级       |
+|                                                           钩子                                                            |                                               功能                                               |      优先级       |
 | :-----------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: | :---------------: |
 |            [IterTimerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/iter_timer_hook.py)            |                                    记录 iteration 花费的时间.                                    |    NORMAL (50)    |
 |               [LoggerHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/logger_hook.py)                | 从 `Runner` 里不同的组件中收集日志记录，并将其输出到终端， JSON 文件，tensorboard，wandb 等下游. | BELOW_NORMAL (60) |
@@ -37,6 +37,31 @@ default_hooks = dict(
 ```
 
 以上默认钩子除 `SegVisualizationHook` 外都是在 MMEngine 中所实现, `SegVisualizationHook` 是在 MMSegmentation 里被实现的钩子, 之后会专门介绍.
+
+- 修改默认的钩子
+
+以 `default_hooks` 里面的 `logger` 和 `checkpoint` 为例, 我们来介绍如何修改 `default_hooks` 中默认的钩子.
+
+(1) 模型保存配置
+MMEngine 执行器将使用 `checkpoint` 来初始化[模型保存钩子 (CheckpointHook)](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/checkpoint_hook.py#L19).
+
+```python
+checkpoint = dict(interval=1)
+```
+
+用户可以设置 `max_keep_ckpts` 来只保存少量的检查点或者用 `save_optimizer` 来决定是否保存 optimizer 的信息.
+更多相关参数的细节可以参考[这里](https://mmengine.readthedocs.io/en/latest/api/generated/mmengine.hooks.CheckpointHook.html?highlight=CheckpointHook).
+
+(2) 日志配置
+`日志钩子 (LoggerHook)` 被用来收集 `执行器 (Runner)` 里面不同组件的日志信息然后写入终端, JSON 文件, tensorboard 和 wandb 等地方.
+
+```python
+logger_hook_cfg = dict(interval=20)
+```
+
+在最新的 1.x 版本的 MMSegmentation 里面, 一些日志钩子 (LoggerHook) 例如 `TextLoggerHook`, `WandbLoggerHook` 和 `TensorboardLoggerHook` 将不再被使用.
+作为替代, MMEngine 使用 `LogProcessor` 来处理上述钩子处理的信息，它们现在在 [`MessageHub`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/logging/message_hub.py#L17),
+[`WandbVisBackend`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/visualization/vis_backend.py#L324) 和 [`TensorboardVisBackend`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/visualization/vis_backend.py#L472) 里面.
 
 - 自定义钩子 (custom hooks)
 

--- a/docs/zh_cn/advanced_guides/engine.md
+++ b/docs/zh_cn/advanced_guides/engine.md
@@ -52,35 +52,9 @@ param_scheduler = [
 
 注意: 当你修改 `train_cfg` 里面 `max_iters` 的时候, 请确保参数调度器 `param_scheduler` 里面的参数也被同时修改.
 
-### 配置 Default hooks
+## 钩子 (Hook)
 
 在了解如何修改这些钩子的配置之前, 推荐参考 [engine.md](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/docs/en/advanced_guides/engine.md) 文档了解 mmsegmentation 1.x 中钩子的定义.
-MMSegmentation 会在 [`defualt_hooks`](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/configs/_base_/schedules/schedule_160k.py#L19-L25) 里面注册一些训练所必需功能的钩子:
-
-```python
-default_hooks = dict(
-    timer=dict(type='IterTimerHook'),
-    logger=dict(type='LoggerHook', interval=50, log_metric_by_epoch=False),
-    param_scheduler=dict(type='ParamSchedulerHook'),
-    checkpoint=dict(type='CheckpointHook', by_epoch=False, interval=2000),
-    sampler_seed=dict(type='DistSamplerSeedHook'),
-    visualization=dict(type='SegVisualizationHook'))
-```
-
-下表列出了这些默认钩子可能涉及到的配置修改, 用户也可以参考链接里的 readthedocs API 文档, 通过修改配置文件里对应的内容满足自己特定的需求.
-
-|                                                                         默认钩子                                                                         |                        一些相关的配置修改                        |
-| :------------------------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------: |
-|           [IterTimerHook](https://mmengine.readthedocs.io/en/latest/api/generated/mmengine.hooks.IterTimerHook.html?highlight=iter_timer_hook)           |                                -                                 |
-|                [LoggerHook](https://mmengine.readthedocs.io/en/latest/api/generated/mmengine.hooks.LoggerHook.html?highlight=LoggerHook)                 |                      日志里的迭代次数间隔.                       |
-|    [ParamSchedulerHook](https://mmengine.readthedocs.io/en/latest/api/generated/mmengine.hooks.ParamSchedulerHook.html?highlight=ParamSchedulerHook)     |                                -                                 |
-|        [CheckpointHook](https://mmengine.readthedocs.io/en/latest/api/generated/mmengine.hooks.CheckpointHook.html#mmengine.hooks.CheckpointHook)        | 是否只保存最好结果的 checkpoint, 保存 checkpoint 在特定的路径等. |
-| [DistSamplerSeedHook](https://mmengine.readthedocs.io/zh_CN/latest/api/generated/mmengine.hooks.DistSamplerSeedHook.html?highlight=DistSamplerSeedHook)  |                                -                                 |
-| [SegVisualizationHook](https://mmsegmentation.readthedocs.io/en/dev-1.x/api.html?highlight=SegVisualizationHook#mmseg.engine.hooks.SegVisualizationHook) |                                -                                 |
-
-没有在优化器里被设置的训练技巧可以在优化器构造器 (例如逐个模型参数去设置学习率) 和钩子里实现. 我们在上面列出了一些训练的常用设置, 如果想增加更多设置, 欢迎提交 issue 和 PR.
-
-## 钩子 (Hook)
 
 ### 介绍
 
@@ -104,7 +78,7 @@ OpenMMLab 将模型训练和测试过程抽象为 `Runner`, 插入钩子可以�
 |        [DistSamplerSeedHook](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/sampler_seed_hook.py)        |                                确保分布式采样器 shuffle 是打开的.                                |    NORMAL (50)    |
 | [SegVisualizationHook](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/mmseg/visualization/local_visualizer.py) |                                可视化验证和测试过程里的预测结果.                                 |    NORMAL (50)    |
 
-它们在配置文件中的配置为:
+MMSegmentation 会在 [`defualt_hooks`](https://github.com/open-mmlab/mmsegmentation/blob/dev-1.x/configs/_base_/schedules/schedule_160k.py#L19-L25) 里面注册一些训练所必需功能的钩子::
 
 ```python
 default_hooks = dict(

--- a/docs/zh_cn/advanced_guides/engine.md
+++ b/docs/zh_cn/advanced_guides/engine.md
@@ -43,25 +43,38 @@ default_hooks = dict(
 以 `default_hooks` 里面的 `logger` 和 `checkpoint` 为例, 我们来介绍如何修改 `default_hooks` 中默认的钩子.
 
 (1) 模型保存配置
-MMEngine 执行器将使用 `checkpoint` 来初始化[模型保存钩子 (CheckpointHook)](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/checkpoint_hook.py#L19).
+`default_hooks` 使用 `checkpoint` 字段来初始化[模型保存钩子 (CheckpointHook)](https://github.com/open-mmlab/mmengine/blob/main/mmengine/hooks/checkpoint_hook.py#L19).
 
 ```python
-checkpoint = dict(interval=1)
+checkpoint = dict(type='CheckpointHook', interval=1)
 ```
 
 用户可以设置 `max_keep_ckpts` 来只保存少量的检查点或者用 `save_optimizer` 来决定是否保存 optimizer 的信息.
-更多相关参数的细节可以参考[这里](https://mmengine.readthedocs.io/en/latest/api/generated/mmengine.hooks.CheckpointHook.html?highlight=CheckpointHook).
+更多相关参数的细节可以参考[这里](https://mmengine.readthedocs.io/zh_CN/latest/api/generated/mmengine.hooks.CheckpointHook.html#checkpointhook).
 
 (2) 日志配置
 `日志钩子 (LoggerHook)` 被用来收集 `执行器 (Runner)` 里面不同组件的日志信息然后写入终端, JSON 文件, tensorboard 和 wandb 等地方.
 
 ```python
-logger_hook_cfg = dict(interval=20)
+logger=dict(type='LoggerHook', interval=10)
 ```
 
 在最新的 1.x 版本的 MMSegmentation 里面, 一些日志钩子 (LoggerHook) 例如 `TextLoggerHook`, `WandbLoggerHook` 和 `TensorboardLoggerHook` 将不再被使用.
 作为替代, MMEngine 使用 `LogProcessor` 来处理上述钩子处理的信息，它们现在在 [`MessageHub`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/logging/message_hub.py#L17),
 [`WandbVisBackend`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/visualization/vis_backend.py#L324) 和 [`TensorboardVisBackend`](https://github.com/open-mmlab/mmengine/blob/main/mmengine/visualization/vis_backend.py#L472) 里面.
+
+如果想使用这些后端, 只需要修改配置文件即可:
+
+```python
+# TensorboardVisBackend
+visualizer = dict(
+    type='SegLocalVisualizer', vis_backends=[dict(type='TensorboardVisBackend')], name='visualizer')
+# 或者 WandbVisBackend
+visualizer = dict(
+    type='SegLocalVisualizer', vis_backends=[dict(type='WandbVisBackend')], name='visualizer')
+```
+
+关于更多相关用法，可以参考 [MMEngine 存储后端用户教程](https://github.com/open-mmlab/mmengine/blob/main/docs/zh_cn/advanced_tutorials/visualization.md).
 
 - 自定义钩子 (custom hooks)
 


### PR DESCRIPTION
## Motivation

When refining PR: https://github.com/open-mmlab/mmsegmentation/pull/2169, I found some contents of PR2169 is useful but unnecessary to be added in customized runtime doc.

So I move some content to engine.doc