### PR TITLE
BUG FIX in test_cfg for U-Net _base_ scripts

### DIFF
--- a/configs/_base_/models/deeplabv3_unet_s5-d16.py
+++ b/configs/_base_/models/deeplabv3_unet_s5-d16.py
@@ -47,4 +47,4 @@ model = dict(
             type='CrossEntropyLoss', use_sigmoid=False, loss_weight=0.4)),
     # model training and testing settings
     train_cfg=dict(),
-    test_cfg=dict(mode='slide', crop_size=256, stride=170))
+    test_cfg=dict(mode='slide', crop_size=(256, 256), stride=(170, 170)))

--- a/configs/_base_/models/fcn_unet_s5-d16.py
+++ b/configs/_base_/models/fcn_unet_s5-d16.py
@@ -48,4 +48,4 @@ model = dict(
             type='CrossEntropyLoss', use_sigmoid=False, loss_weight=0.4)),
     # model training and testing settings
     train_cfg=dict(),
-    test_cfg=dict(mode='slide', crop_size=256, stride=170))
+    test_cfg=dict(mode='slide', crop_size=(256, 256), stride=(170, 170)))

--- a/configs/_base_/models/pspnet_unet_s5-d16.py
+++ b/configs/_base_/models/pspnet_unet_s5-d16.py
@@ -47,4 +47,4 @@ model = dict(
             type='CrossEntropyLoss', use_sigmoid=False, loss_weight=0.4)),
     # model training and testing settings
     train_cfg=dict(),
-    test_cfg=dict(mode='slide', crop_size=256, stride=170))
+    test_cfg=dict(mode='slide', crop_size=(256, 256), stride=(170, 170)))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

**Bug fix on _base_ U-Net scripts**: The base U-Net scripts contain some variables in wrong type in `test_cfg` dictionary. The `stride` and `crop_size` fields in this dict are supposed to be `tuples(int, int)`, however, they are `int` which result in the following exception at validation step:

```
h_stride, w_stride = self.test_cfg.stride TypeError: cannot unpack non-iterable int object
```

An issue is created (https://github.com/open-mmlab/mmsegmentation/issues/2337) and this PR aims to fix it

## Modification

Please briefly describe what modification is made in this PR.

changing `stride` and `crop_size` from `int` to `(int, int)`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues: No impact on formatting
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness: couldn't find any unit-tests for configs
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D: No impact
4. The documentation has been modified accordingly, like docstring or example tutorials: I need help with this
