### PR TITLE
[Fix]Add input argument for datasets

### DIFF
--- a/mmseg/datasets/ade.py
+++ b/mmseg/datasets/ade.py
@@ -80,9 +80,13 @@ class ADE20KDataset(BaseSegDataset):
                  [184, 255, 0], [0, 133, 255], [255, 214, 0], [25, 194, 194],
                  [102, 255, 0], [92, 0, 255]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.jpg',
+                 seg_map_suffix='.png',
+                 reduce_zero_label=True,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.jpg',
-            seg_map_suffix='.png',
-            reduce_zero_label=True,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)

--- a/mmseg/datasets/chase_db1.py
+++ b/mmseg/datasets/chase_db1.py
@@ -17,10 +17,14 @@ class ChaseDB1Dataset(BaseSegDataset):
         classes=('background', 'vessel'),
         palette=[[120, 120, 120], [6, 230, 230]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='_1stHO.png',
+                 reduce_zero_label=False,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='_1stHO.png',
-            reduce_zero_label=False,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)
         assert self.file_client.exists(self.data_prefix['img_path'])

--- a/mmseg/datasets/coco_stuff.py
+++ b/mmseg/datasets/coco_stuff.py
@@ -91,6 +91,9 @@ class COCOStuffDataset(BaseSegDataset):
                  [192, 192, 0], [128, 64, 96], [192, 32, 64], [192, 64, 128],
                  [64, 192, 96], [64, 160, 64], [64, 64, 0]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.jpg',
+                 seg_map_suffix='_labelTrainIds.png',
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.jpg', seg_map_suffix='_labelTrainIds.png', **kwargs)
+            img_suffix=img_suffix, seg_map_suffix=seg_map_suffix, **kwargs)

--- a/mmseg/datasets/dark_zurich.py
+++ b/mmseg/datasets/dark_zurich.py
@@ -7,8 +7,9 @@ from .cityscapes import CityscapesDataset
 class DarkZurichDataset(CityscapesDataset):
     """DarkZurichDataset dataset."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='_rgb_anon.png',
+                 seg_map_suffix='_gt_labelTrainIds.png',
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='_rgb_anon.png',
-            seg_map_suffix='_gt_labelTrainIds.png',
-            **kwargs)
+            img_suffix=img_suffix, seg_map_suffix=seg_map_suffix, **kwargs)

--- a/mmseg/datasets/drive.py
+++ b/mmseg/datasets/drive.py
@@ -17,10 +17,14 @@ class DRIVEDataset(BaseSegDataset):
         classes=('background', 'vessel'),
         palette=[[120, 120, 120], [6, 230, 230]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='_manual1.png',
+                 reduce_zero_label=False,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='_manual1.png',
-            reduce_zero_label=False,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)
         assert self.file_client.exists(self.data_prefix['img_path'])

--- a/mmseg/datasets/hrf.py
+++ b/mmseg/datasets/hrf.py
@@ -17,10 +17,14 @@ class HRFDataset(BaseSegDataset):
         classes=('background', 'vessel'),
         palette=[[120, 120, 120], [6, 230, 230]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='.png',
+                 reduce_zero_label=False,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='.png',
-            reduce_zero_label=False,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)
         assert self.file_client.exists(self.data_prefix['img_path'])

--- a/mmseg/datasets/isaid.py
+++ b/mmseg/datasets/isaid.py
@@ -23,10 +23,14 @@ class iSAIDDataset(BaseSegDataset):
                  [0, 0, 127], [0, 0, 191], [0, 0, 255], [0, 191, 127],
                  [0, 127, 191], [0, 127, 255], [0, 100, 155]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='_instance_color_RGB.png',
+                 ignore_index=255,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='_instance_color_RGB.png',
-            ignore_index=255,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            ignore_index=ignore_index,
             **kwargs)
         assert self.file_client.exists(self.data_prefix['img_path'])

--- a/mmseg/datasets/isprs.py
+++ b/mmseg/datasets/isprs.py
@@ -17,9 +17,13 @@ class ISPRSDataset(BaseSegDataset):
         palette=[[255, 255, 255], [0, 0, 255], [0, 255, 255], [0, 255, 0],
                  [255, 255, 0], [255, 0, 0]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='.png',
+                 reduce_zero_label=True,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='.png',
-            reduce_zero_label=True,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)

--- a/mmseg/datasets/lip.py
+++ b/mmseg/datasets/lip.py
@@ -39,5 +39,9 @@ class LIPDataset(BaseSegDataset):
             [255, 170, 0],
         ))
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(img_suffix='.jpg', seg_map_suffix='.png', **kwargs)
+    def __init__(self,
+                 img_suffix='.jpg',
+                 seg_map_suffix='.png',
+                 **kwargs) -> None:
+        super().__init__(
+            img_suffix=img_suffix, seg_map_suffix=seg_map_suffix, **kwargs)

--- a/mmseg/datasets/loveda.py
+++ b/mmseg/datasets/loveda.py
@@ -17,9 +17,13 @@ class LoveDADataset(BaseSegDataset):
         palette=[[255, 255, 255], [255, 0, 0], [255, 255, 0], [0, 0, 255],
                  [159, 129, 183], [0, 255, 0], [255, 195, 128]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='.png',
+                 reduce_zero_label=True,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='.png',
-            reduce_zero_label=True,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)

--- a/mmseg/datasets/night_driving.py
+++ b/mmseg/datasets/night_driving.py
@@ -7,8 +7,9 @@ from .cityscapes import CityscapesDataset
 class NightDrivingDataset(CityscapesDataset):
     """NightDrivingDataset dataset."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='_leftImg8bit.png',
+                 seg_map_suffix='_gtCoarse_labelTrainIds.png',
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='_leftImg8bit.png',
-            seg_map_suffix='_gtCoarse_labelTrainIds.png',
-            **kwargs)
+            img_suffix=img_suffix, seg_map_suffix=seg_map_suffix, **kwargs)

--- a/mmseg/datasets/pascal_context.py
+++ b/mmseg/datasets/pascal_context.py
@@ -45,10 +45,14 @@ class PascalContextDataset(BaseSegDataset):
                  [255, 31, 0], [255, 224, 0], [153, 255, 0], [0, 0, 255],
                  [255, 71, 0], [0, 235, 255], [0, 173, 255], [31, 0, 255]])
 
-    def __init__(self, ann_file: str, **kwargs) -> None:
+    def __init__(self,
+                 ann_file: str,
+                 img_suffix='.jpg',
+                 seg_map_suffix='.png',
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.jpg',
-            seg_map_suffix='.png',
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
             ann_file=ann_file,
             reduce_zero_label=False,
             **kwargs)
@@ -95,12 +99,17 @@ class PascalContextDataset59(BaseSegDataset):
                  [255, 31, 0], [255, 224, 0], [153, 255, 0], [0, 0, 255],
                  [255, 71, 0], [0, 235, 255], [0, 173, 255], [31, 0, 255]])
 
-    def __init__(self, ann_file: str, **kwargs):
+    def __init__(self,
+                 ann_file: str,
+                 img_suffix='.jpg',
+                 seg_map_suffix='.png',
+                 reduce_zero_label=True,
+                 **kwargs):
         super().__init__(
-            img_suffix='.jpg',
-            seg_map_suffix='.png',
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
             ann_file=ann_file,
-            reduce_zero_label=True,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)
         assert self.file_client.exists(
             self.data_prefix['img_path']) and osp.isfile(self.ann_file)

--- a/mmseg/datasets/potsdam.py
+++ b/mmseg/datasets/potsdam.py
@@ -17,9 +17,13 @@ class PotsdamDataset(BaseSegDataset):
         palette=[[255, 255, 255], [0, 0, 255], [0, 255, 255], [0, 255, 0],
                  [255, 255, 0], [255, 0, 0]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='.png',
+                 reduce_zero_label=True,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='.png',
-            reduce_zero_label=True,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)

--- a/mmseg/datasets/stare.py
+++ b/mmseg/datasets/stare.py
@@ -16,10 +16,14 @@ class STAREDataset(BaseSegDataset):
         classes=('background', 'vessel'),
         palette=[[120, 120, 120], [6, 230, 230]])
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self,
+                 img_suffix='.png',
+                 seg_map_suffix='.ah.png',
+                 reduce_zero_label=False,
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.png',
-            seg_map_suffix='.ah.png',
-            reduce_zero_label=False,
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)
         assert self.file_client.exists(self.data_prefix['img_path'])

--- a/mmseg/datasets/voc.py
+++ b/mmseg/datasets/voc.py
@@ -24,10 +24,14 @@ class PascalVOCDataset(BaseSegDataset):
                  [0, 64, 0], [128, 64, 0], [0, 192, 0], [128, 192, 0],
                  [0, 64, 128]])
 
-    def __init__(self, ann_file, **kwargs) -> None:
+    def __init__(self,
+                 ann_file,
+                 img_suffix='.jpg',
+                 seg_map_suffix='.png',
+                 **kwargs) -> None:
         super().__init__(
-            img_suffix='.jpg',
-            seg_map_suffix='.png',
+            img_suffix=img_suffix,
+            seg_map_suffix=seg_map_suffix,
             ann_file=ann_file,
             **kwargs)
         assert self.file_client.exists(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

before this modification, the key-word arguments don't allow input, like
```python
class ADE20KDataset(BaseSegDataset):

    def __init__(self, **kwargs) -> None:

        super().__init__(
            img_suffix='.jpg',
            seg_map_suffix='.png',
            reduce_zero_label=True,
            **kwargs)
```
It would not allow `img_suffix` and `seg_map_suffix`, and raise `TypeError: __init__() got multiple values for keyword argument 'img_suffix'`
```python
ADE20KDataset(data_root = 'data/ade/ADEChallengeData2016',
   ...:     data_prefix=dict(img_path='images/training', seg_map_path='annotations/training'),
   ...:     img_suffix='.jpg',
   ...:     seg_map_suffix='.png')
```

## Modification

- Add default values `__init__`
- Remove default inputs `supper().__init__()`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
