### PR TITLE
Fix typo in warning on binary classification

### DIFF
--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -120,7 +120,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
                 warnings.warn('For binary segmentation, we suggest using'
                               '`out_channels = 1` to define the output'
                               'channels of segmentor, and use `threshold`'
-                              'to convert seg_logist into a prediction'
+                              'to convert `seg_logits` into a prediction'
                               'applying a threshold')
             out_channels = num_classes
 


### PR DESCRIPTION
## Motivation

There is a typo in the seg_logits name and is missing backticks although it is a variable.

## Modification

Fixed.