### PR TITLE
Fixed deadlock issue related with MMSegWandbHook

### DIFF
--- a/mmseg/core/hook/wandblogger_hook.py
+++ b/mmseg/core/hook/wandblogger_hook.py
@@ -168,7 +168,8 @@ class MMSegWandbHook(WandbLoggerHook):
             # Log ground truth data
             self._log_data_table()
 
-    @master_only
+    # for the reason of this double-layered structure, refer to
+    # https://github.com/open-mmlab/mmdetection/issues/8145#issuecomment-1345343076
     def after_train_iter(self, runner):
         if self.get_mode(runner) == 'train':
             # An ugly patch. The iter-based eval hook will call the
@@ -178,7 +179,10 @@ class MMSegWandbHook(WandbLoggerHook):
             return super(MMSegWandbHook, self).after_train_iter(runner)
         else:
             super(MMSegWandbHook, self).after_train_iter(runner)
+        self._after_train_iter(runner)
 
+    @master_only
+    def _after_train_iter(self, runner):
         if self.by_epoch:
             return
 


### PR DESCRIPTION
Co-authored-by: WangYudong <yudong.wang@akane.waseda.jp>

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Bug report on mmseg: https://github.com/open-mmlab/mmsegmentation/issues/2137
Bug report on mmdet: https://github.com/open-mmlab/mmdetection/issues/8145.

**deadlock occurs on both mmseg and mmdet, for the same reason.**

To summarize problem, when we use `MMSegWandbHook` after `TextLoggerHook`, deadlock problem occurs. These are because of same reason and I summarized the reason in https://github.com/open-mmlab/mmdetection/issues/8145#issuecomment-1345343076 here.

## Modification

Made MMSegWandbHook to clear `runner.log_buffer` on every process, including process for GPU 1,2,3...

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
