### PR TITLE
CodeCamp #141 [Feature] Add BioMedical3DRandomFlip.

### DIFF
--- a/mmseg/datasets/__init__.py
+++ b/mmseg/datasets/__init__.py
@@ -21,9 +21,9 @@ from .stare import STAREDataset
 from .synapse import SynapseDataset
 # yapf: disable
 from .transforms import (CLAHE, AdjustGamma, BioMedical3DPad,
-                         BioMedical3DRandomCrop, BioMedicalGaussianBlur,
-                         BioMedicalGaussianNoise, BioMedicalRandomGamma,
-                         GenerateEdge, LoadAnnotations,
+                         BioMedical3DRandomCrop, BioMedical3DRandomFlip,
+                         BioMedicalGaussianBlur, BioMedicalGaussianNoise,
+                         BioMedicalRandomGamma, GenerateEdge, LoadAnnotations,
                          LoadBiomedicalAnnotation, LoadBiomedicalData,
                          LoadBiomedicalImageFromFile, LoadImageFromNDArray,
                          PackSegInputs, PhotoMetricDistortion, RandomCrop,
@@ -34,15 +34,15 @@ from .voc import PascalVOCDataset
 
 # yapf: enable
 __all__ = [
-    'BaseSegDataset', 'BioMedical3DRandomCrop', 'CityscapesDataset',
-    'PascalVOCDataset', 'ADE20KDataset', 'PascalContextDataset',
-    'PascalContextDataset59', 'ChaseDB1Dataset', 'DRIVEDataset', 'HRFDataset',
-    'STAREDataset', 'DarkZurichDataset', 'NightDrivingDataset',
-    'COCOStuffDataset', 'LoveDADataset', 'MultiImageMixDataset',
-    'iSAIDDataset', 'ISPRSDataset', 'PotsdamDataset', 'LoadAnnotations',
-    'RandomCrop', 'SegRescale', 'PhotoMetricDistortion', 'RandomRotate',
-    'AdjustGamma', 'CLAHE', 'Rerange', 'RGB2Gray', 'RandomCutOut',
-    'RandomMosaic', 'PackSegInputs', 'ResizeToMultiple',
+    'BaseSegDataset', 'BioMedical3DRandomCrop', 'BioMedical3DRandomFlip',
+    'CityscapesDataset', 'PascalVOCDataset', 'ADE20KDataset',
+    'PascalContextDataset', 'PascalContextDataset59', 'ChaseDB1Dataset',
+    'DRIVEDataset', 'HRFDataset', 'STAREDataset', 'DarkZurichDataset',
+    'NightDrivingDataset', 'COCOStuffDataset', 'LoveDADataset',
+    'MultiImageMixDataset', 'iSAIDDataset', 'ISPRSDataset', 'PotsdamDataset',
+    'LoadAnnotations', 'RandomCrop', 'SegRescale', 'PhotoMetricDistortion',
+    'RandomRotate', 'AdjustGamma', 'CLAHE', 'Rerange', 'RGB2Gray',
+    'RandomCutOut', 'RandomMosaic', 'PackSegInputs', 'ResizeToMultiple',
     'LoadImageFromNDArray', 'LoadBiomedicalImageFromFile',
     'LoadBiomedicalAnnotation', 'LoadBiomedicalData', 'GenerateEdge',
     'DecathlonDataset', 'LIPDataset', 'ResizeShortestEdge',

--- a/mmseg/datasets/transforms/__init__.py
+++ b/mmseg/datasets/transforms/__init__.py
@@ -5,12 +5,13 @@ from .loading import (LoadAnnotations, LoadBiomedicalAnnotation,
                       LoadImageFromNDArray)
 # yapf: disable
 from .transforms import (CLAHE, AdjustGamma, BioMedical3DPad,
-                         BioMedical3DRandomCrop, BioMedicalGaussianBlur,
-                         BioMedicalGaussianNoise, BioMedicalRandomGamma,
-                         GenerateEdge, PhotoMetricDistortion, RandomCrop,
-                         RandomCutOut, RandomMosaic, RandomRotate,
-                         RandomRotFlip, Rerange, ResizeShortestEdge,
-                         ResizeToMultiple, RGB2Gray, SegRescale)
+                         BioMedical3DRandomCrop, BioMedical3DRandomFlip,
+                         BioMedicalGaussianBlur, BioMedicalGaussianNoise,
+                         BioMedicalRandomGamma, GenerateEdge,
+                         PhotoMetricDistortion, RandomCrop, RandomCutOut,
+                         RandomMosaic, RandomRotate, RandomRotFlip, Rerange,
+                         ResizeShortestEdge, ResizeToMultiple, RGB2Gray,
+                         SegRescale)
 
 # yapf: enable
 __all__ = [
@@ -20,5 +21,6 @@ __all__ = [
     'ResizeToMultiple', 'LoadImageFromNDArray', 'LoadBiomedicalImageFromFile',
     'LoadBiomedicalAnnotation', 'LoadBiomedicalData', 'GenerateEdge',
     'ResizeShortestEdge', 'BioMedicalGaussianNoise', 'BioMedicalGaussianBlur',
-    'BioMedicalRandomGamma', 'BioMedical3DPad', 'RandomRotFlip'
+    'BioMedical3DRandomFlip', 'BioMedicalRandomGamma', 'BioMedical3DPad',
+    'RandomRotFlip'
 ]

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -2019,12 +2019,14 @@ class BioMedical3DPad(BaseTransform):
 
 @TRANSFORMS.register_module()
 class BioMedical3DRandomFlip(BaseTransform):
-    """Flip biomedical 3D images and segmentations. Modified from
-    https://github.com/MIC-DKFZ/batchgenerators/blob/master/batchgenerators/tra
-    nsforms/spatial_transforms.py # noqa:E501 Copyright 2021 Division of
+    """Flip biomedical 3D images and segmentations.
+
+    Modified from https://github.com/MIC-DKFZ/batchgenerators/blob/master/batchgenerators/transforms/spatial_transforms.py # noqa:E501
+
+    Copyright 2021 Division of
     Medical Image Computing, German Cancer Research Center (DKFZ) and Applied
-    Computer Vision Lab, Helmholtz Imaging Platform. Licensed under the
-    Apache-2.0 License.
+    Computer Vision Lab, Helmholtz Imaging Platform.
+    Licensed under the Apache-2.0 License.
 
     Required Keys:
 

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
 import warnings
-from typing import Dict, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import cv2
 import mmcv
@@ -2014,4 +2014,117 @@ class BioMedical3DPad(BaseTransform):
         repr_str += f'pad_shape={self.pad_shape}, '
         repr_str += f'pad_val={self.pad_val}), '
         repr_str += f'seg_pad_val={self.seg_pad_val})'
+        return repr_str
+
+
+@TRANSFORMS.register_module()
+class BioMedical3DRandomFlip(BaseTransform):
+    """Flip biomedical 3D images and segmentations. Modified from
+    https://github.com/MIC-DKFZ/batchgenerators/blob/master/batchgenerators/tra
+    nsforms/spatial_transforms.py # noqa:E501 Copyright 2021 Division of
+    Medical Image Computing, German Cancer Research Center (DKFZ) and Applied
+    Computer Vision Lab, Helmholtz Imaging Platform. Licensed under the
+    Apache-2.0 License.
+
+    Required Keys:
+
+    - img
+    - gt_seg_map (optional)
+
+    Modified Keys:
+
+    - img
+    - gt_seg_map (optional)
+
+    Added Keys:
+
+    - do_flip
+    - flip_axes
+
+    Args:
+        prob (float): Flipping probability.
+        axes (Tuple[int, ...]): Flipping axes with order 'ZXY'.
+        swap_label_pairs (Optional[List[Tuple[int, int]]]):
+        The segmentation label pairs that are swapped when flipping.
+    """
+
+    def __init__(self,
+                 prob: float,
+                 axes: Tuple[int, ...],
+                 swap_label_pairs: Optional[List[Tuple[int, int]]] = None):
+        self.prob = prob
+        self.axes = axes
+        self.swap_label_pairs = swap_label_pairs
+        assert prob >= 0 and prob <= 1
+        if axes is not None:
+            assert max(axes) <= 2
+
+    @staticmethod
+    def _flip(img, direction: Tuple[bool, bool, bool]) -> np.ndarray:
+        if direction[0]:
+            img[:, :] = img[:, ::-1]
+        if direction[1]:
+            img[:, :, :] = img[:, :, ::-1]
+        if direction[2]:
+            img[:, :, :, :] = img[:, :, :, ::-1]
+        return img
+
+    def _do_flip(self, img: np.ndarray) -> Tuple[bool, bool, bool]:
+        """Call function to determine which axis to flip.
+
+        Args:
+            img (np.ndarry): Image or segmentation map array.
+        Returns:
+            tuple: Flip action, whether to flip on the z, x, and y axes.
+        """
+        flip_c, flip_x, flip_y = False, False, False
+        if self.axes is not None:
+            flip_c = 0 in self.axes and np.random.rand() < self.prob
+            flip_x = 1 in self.axes and np.random.rand() < self.prob
+            if len(img.shape) == 4:
+                flip_y = 2 in self.axes and np.random.rand() < self.prob
+        return flip_c, flip_x, flip_y
+
+    def _swap_label(self, seg: np.ndarray) -> np.ndarray:
+        out = seg.copy()
+        for first, second in self.swap_label_pairs:
+            first_area = (seg == first)
+            second_area = (seg == second)
+            out[first_area] = second
+            out[second_area] = first
+        return out
+
+    def transform(self, results: Dict) -> Dict:
+        """Call function to flip and swap pair labels.
+
+        Args:
+            results (dict): Result dict.
+        Returns:
+            dict: Flipped results, 'do_flip', 'flip_axes' keys are added into
+                result dict.
+        """
+        # get actual flipped axis
+        if 'do_flip' not in results:
+            results['do_flip'] = self._do_flip(results['img'])
+        if 'flip_axes' not in results:
+            results['flip_axes'] = self.axes
+        # flip image
+        results['img'] = self._flip(
+            results['img'], direction=results['do_flip'])
+        # flip seg
+        if results['gt_seg_map'] is not None:
+            if results['gt_seg_map'].shape != results['img'].shape:
+                results['gt_seg_map'] = results['gt_seg_map'][None, :]
+            results['gt_seg_map'] = self._flip(
+                results['gt_seg_map'], direction=results['do_flip'])
+            results['gt_seg_map'] = results['gt_seg_map'].squeeze()
+            # swap label pairs
+            if self.swap_label_pairs is not None:
+                results['gt_seg_map'] = self._swap_label(results['gt_seg_map'])
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += f'(prob={self.prob}, axes={self.axes}, ' \
+                    f'swap_label_pairs={self.swap_label_pairs})'
         return repr_str

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -2028,13 +2028,17 @@ class BioMedical3DRandomFlip(BaseTransform):
 
     Required Keys:
 
-    - img
-    - gt_seg_map (optional)
+    - img (np.ndarry): Biomedical image with shape (N, Z, Y, X) by default,
+        N is the number of modalities.
+    - gt_seg_map (np.ndarray, optional): Biomedical seg map with shape
+        (Z, Y, X) by default.
 
     Modified Keys:
 
-    - img
-    - gt_seg_map (optional)
+    - img (np.ndarry): Biomedical image with shape (N, Z, Y, X) by default,
+        N is the number of modalities.
+    - gt_seg_map (np.ndarray, optional): Biomedical seg map with shape
+        (Z, Y, X) by default.
 
     Added Keys:
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support for biomedical 3d images augmentation.

## Modification

Add BioMedical3DRandomFlip in mmseg/datasets/transforms/transforms.py.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

Add the function to support the flipping for biomedical 3d images and segmentation maps.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
