### PR TITLE
[Fix] Remove dependcy mmdet  when do not use `MaskFormerHead` and `MMDET_Mask2FormerHead`

### DIFF
--- a/mmseg/models/decode_heads/mask2former_head.py
+++ b/mmseg/models/decode_heads/mask2former_head.py
@@ -4,12 +4,12 @@ from typing import List, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
+from mmengine.model import BaseModule
 try:
     from mmdet.models.dense_heads import \
         Mask2FormerHead as MMDET_Mask2FormerHead
 except ModuleNotFoundError:
-    MMDET_Mask2FormerHead = None
+    MMDET_Mask2FormerHead = BaseModule
 
 from mmengine.structures import InstanceData
 from torch import Tensor

--- a/mmseg/models/decode_heads/mask2former_head.py
+++ b/mmseg/models/decode_heads/mask2former_head.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmengine.model import BaseModule
+
 try:
     from mmdet.models.dense_heads import \
         Mask2FormerHead as MMDET_Mask2FormerHead

--- a/mmseg/models/decode_heads/maskformer_head.py
+++ b/mmseg/models/decode_heads/maskformer_head.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmengine.model import BaseModule
+
 try:
     from mmdet.models.dense_heads import MaskFormerHead as MMDET_MaskFormerHead
 except ModuleNotFoundError:

--- a/mmseg/models/decode_heads/maskformer_head.py
+++ b/mmseg/models/decode_heads/maskformer_head.py
@@ -4,11 +4,11 @@ from typing import List, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
+from mmengine.model import BaseModule
 try:
     from mmdet.models.dense_heads import MaskFormerHead as MMDET_MaskFormerHead
 except ModuleNotFoundError:
-    MMDET_MaskFormerHead = None
+    MMDET_MaskFormerHead = BaseModule
 
 from mmengine.structures import InstanceData
 from torch import Tensor


### PR DESCRIPTION
## Motivation

Calling `mmseg.utils.register_all_modules` will import `MaskFormerHead` and `Mask2FormerHead`, it will crash if mmdet is not installed as `None` cannot be initialized.

## Modification

- Modify `MMDET_MaskFormerHead=BaseModule` and `MMDET_Mask2FormerHead = BaseModule` when cannot import from mmdet
