### PR TITLE
Fix the docstring error in the class PascalContextDataset59

### DIFF
--- a/mmseg/datasets/pascal_context.py
+++ b/mmseg/datasets/pascal_context.py
@@ -58,10 +58,10 @@ class PascalContextDataset(CustomDataset):
 class PascalContextDataset59(CustomDataset):
     """PascalContext dataset.
 
-    In segmentation map annotation for PascalContext, 0 stands for background,
-    which is included in 60 categories. ``reduce_zero_label`` is fixed to
-    False. The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
-    fixed to '.png'.
+    In segmentation map annotation for PascalContext59, background is not
+    included in 59 categories. ``reduce_zero_label`` is fixed to True.
+    The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is fixed 
+    to '.png'.
 
     Args:
         split (str): Split txt file for PascalContext.

--- a/mmseg/datasets/pascal_context.py
+++ b/mmseg/datasets/pascal_context.py
@@ -60,7 +60,7 @@ class PascalContextDataset59(CustomDataset):
 
     In segmentation map annotation for PascalContext59, background is not
     included in 59 categories. ``reduce_zero_label`` is fixed to True.
-    The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is fixed 
+    The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is fixed
     to '.png'.
 
     Args:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The docstring in the class PascalContextDataset59 is misleading. Try to fix it.

## Modification

The docstring in the class PascalContextDataset59 is changed.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
