### PR TITLE
[Fix]Fix the deprecation of np.float and fix ci configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,7 +307,7 @@ jobs:
       - name: Install MMCV
         run: |
           pip install -U openmim
-          mim isnall mmcv-full
+          mim install mmcv-full
       - name: Install unittest dependencies
         run: pip install -r requirements/tests.txt -r requirements/optional.txt
       - name: Build and install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,10 +164,12 @@ jobs:
           fail_ci_if_error: false
 
   build_cuda102:
+    env:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
     runs-on: ubuntu-18.04
     container:
       image: pytorch/pytorch:1.9.0-cuda10.2-cudnn7-devel
-
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -176,7 +178,6 @@ jobs:
           - torch: 1.9.0+cu102
             torch_version: torch1.9
             torchvision: 0.10.0+cu102
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -189,8 +190,6 @@ jobs:
           apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
       - name: Install system dependencies
         run: |
-          export LC_ALL=C.UTF-8
-          export LANG=C.UTF-8
           apt-get update && apt-get install -y libgl1-mesa-glx ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6
           apt-get clean
           rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,11 +189,11 @@ jobs:
           apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
       - name: Install system dependencies
         run: |
+          export LC_ALL=C.UTF-8
+          export LANG=C.UTF-8
           apt-get update && apt-get install -y libgl1-mesa-glx ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6
           apt-get clean
           rm -rf /var/lib/apt/lists/*
-          export LC_ALL=C.UTF-8
-          export LANG=C.UTF-8
       - name: Install Pillow
         run: python -m pip install Pillow==6.2.2
         if: ${{matrix.torchvision < 0.5}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,13 +147,13 @@ jobs:
           coverage xml
           coverage report -m
         # timm from v0.6.11 requires torch>=1.7
-        if: ${{matrix.torch >= '1.7.0'}}
+        if: ${{matrix.torch != '1.5.1' || matrix.torch != '1.6.0'}}
       - name: Skip timm unittests and generate coverage report
         run: |
           coverage run --branch --source mmseg -m pytest tests/ --ignore tests/test_models/test_backbones/test_timm_backbone.py
           coverage xml
           coverage report -m
-        if: ${{matrix.torch < '1.7.0'}}
+        if: ${{matrix.torch == '1.5.1' || matrix.torch == '1.6.0'}}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.10
         with:
@@ -313,7 +313,7 @@ jobs:
         run: pip install -e .
       - name: Run unittests
         run: |
-          python -m pip install 'timm<0.6.11'
+          python -m pip install timm
           coverage run --branch --source mmseg -m pytest tests/
       - name: Generate coverage report
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,13 +144,13 @@ jobs:
           coverage xml
           coverage report -m
         # timm from v0.6.11 requires torch>=1.7
-        if: ${{matrix.torch != '1.5.1' || matrix.torch != '1.6.0'}}
+        if: ${{matrix.torch != '1.5.1+cu101' || matrix.torch != '1.6.0+cu101'}}
       - name: Skip timm unittests and generate coverage report
         run: |
           coverage run --branch --source mmseg -m pytest tests/ --ignore tests/test_models/test_backbones/test_timm_backbone.py
           coverage xml
           coverage report -m
-        if: ${{matrix.torch == '1.5.1' || matrix.torch == '1.6.0'}}
+        if: ${{matrix.torch == '1.5.1+cu101' || matrix.torch == '1.6.0+cu101'}}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.10
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,8 @@ jobs:
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV
         run: |
-          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/${{matrix.torch_version}}/index.html
+          pip install openmim
+          mim install 'mmcv<=2.0.0rc1'
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
         run: |
@@ -131,7 +132,8 @@ jobs:
       - name: Install mmseg dependencies
         run: |
           python -V
-          python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.torch_version}}/index.html
+          python -m pip install -U openmim
+          mim install mmcv-full
           python -m pip install -r requirements.txt
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Build and install
@@ -199,7 +201,8 @@ jobs:
       - name: Install mmseg dependencies
         run: |
           python -V
-          python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/${{matrix.torch_version}}/index.html
+          python -m pip install openmim
+          mim install mmcv-full
           python -m pip install -r requirements.txt
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Build and install
@@ -264,7 +267,8 @@ jobs:
       - name: Install mmseg dependencies
         run: |
           python -V
-          python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu116/${{matrix.torch_version}}/index.html
+          python -m pip install openmim
+          mim install mmcv-full
           python -m pip install -r requirements.txt
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Build and install
@@ -301,7 +305,8 @@ jobs:
         run: pip install torch==1.8.2+${{ matrix.platform }} torchvision==0.9.2+${{ matrix.platform }} -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
       - name: Install MMCV
         run: |
-          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/torch1.8/index.html --only-binary mmcv-full
+          pip install -U openmim
+          mim isnall mmcv-full
       - name: Install unittest dependencies
         run: pip install -r requirements/tests.txt -r requirements/optional.txt
       - name: Build and install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,13 @@ jobs:
           coverage xml
           coverage report -m
         # timm from v0.6.11 requires torch>=1.7
-        if: ${{matrix.torch >= '1.7.0'}}
+        if: ${{matrix.torch != '1.5.1' || matrix.torch != '1.6.0'}}
       - name: Skip timm unittests and generate coverage report
         run: |
           coverage run --branch --source mmseg -m pytest tests/ --ignore tests/test_models/test_backbones/test_timm_backbone.py
           coverage xml
           coverage report -m
-        if: ${{matrix.torch < '1.7.0'}}
+        if: ${{matrix.torch == '1.5.1' || matrix.torch == '1.6.0'}}
 
   build_cuda101:
     runs-on: ubuntu-18.04
@@ -123,9 +123,6 @@ jobs:
           apt-get update && apt-get install -y libgl1-mesa-glx ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 python${{matrix.python-version}}-dev
           apt-get clean
           rm -rf /var/lib/apt/lists/*
-      - name: Install Pillow
-        run: python -m pip install Pillow==6.2.2
-        if: ${{matrix.torchvision < 0.5}}
       - name: Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install mmseg dependencies
@@ -193,9 +190,6 @@ jobs:
           apt-get update && apt-get install -y libgl1-mesa-glx ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6
           apt-get clean
           rm -rf /var/lib/apt/lists/*
-      - name: Install Pillow
-        run: python -m pip install Pillow==6.2.2
-        if: ${{matrix.torchvision < 0.5}}
       - name: Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install mmseg dependencies
@@ -259,9 +253,6 @@ jobs:
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install system dependencies
         run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
-      - name: Install Pillow
-        run: python -m pip install Pillow==6.2.2
-        if: ${{matrix.torchvision < 0.5}}
       - name: Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install mmseg dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install MMCV
         run: |
           pip install openmim
-          mim install 'mmcv<=2.0.0rc1'
+          mim install 'mmcv<2.0.0rc0'
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,8 @@ jobs:
           apt-get update && apt-get install -y libgl1-mesa-glx ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6
           apt-get clean
           rm -rf /var/lib/apt/lists/*
+          export LC_ALL=C.UTF-8
+          export LANG=C.UTF-8
       - name: Install Pillow
         run: python -m pip install Pillow==6.2.2
         if: ${{matrix.torchvision < 0.5}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           coverage xml
           coverage report -m
         # timm from v0.6.11 requires torch>=1.7
-        if: ${{matrix.torch != '1.5.1' || matrix.torch != '1.6.0'}}
+        if: ${{matrix.torch != '1.5.1' && matrix.torch != '1.6.0'}}
       - name: Skip timm unittests and generate coverage report
         run: |
           coverage run --branch --source mmseg -m pytest tests/ --ignore tests/test_models/test_backbones/test_timm_backbone.py
@@ -144,7 +144,7 @@ jobs:
           coverage xml
           coverage report -m
         # timm from v0.6.11 requires torch>=1.7
-        if: ${{matrix.torch != '1.5.1+cu101' || matrix.torch != '1.6.0+cu101'}}
+        if: ${{matrix.torch != '1.5.1+cu101' && matrix.torch != '1.6.0+cu101'}}
       - name: Skip timm unittests and generate coverage report
         run: |
           coverage run --branch --source mmseg -m pytest tests/ --ignore tests/test_models/test_backbones/test_timm_backbone.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,7 @@ jobs:
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV
         run: |
-          pip install openmim
-          mim install 'mmcv<2.0.0rc0'
+          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/${{matrix.torch_version}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
         run: |

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -69,7 +69,7 @@ def legacy_mean_fscore(results,
                        beta=1):
     num_imgs = len(results)
     assert len(gt_seg_maps) == num_imgs
-    total_mat = np.zeros((num_classes, num_classes), dtype=np.float)
+    total_mat = np.zeros((num_classes, num_classes), dtype=np.float32)
     for i in range(num_imgs):
         mat = get_confusion_matrix(
             results[i], gt_seg_maps[i], num_classes, ignore_index=ignore_index)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -100,7 +100,7 @@ def test_metrics():
         'IoU']
     all_acc_l, acc_l, iou_l = legacy_mean_iou(results, label, num_classes,
                                               ignore_index)
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, iou_l)
     # Test the correctness of the implementation of mDice calculation.
@@ -110,7 +110,7 @@ def test_metrics():
         'Dice']
     all_acc_l, acc_l, dice_l = legacy_mean_dice(results, label, num_classes,
                                                 ignore_index)
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(acc, acc_l)
     assert np.allclose(dice, dice_l)
     # Test the correctness of the implementation of mDice calculation.
@@ -120,7 +120,7 @@ def test_metrics():
         'Recall'], ret_metrics['Precision'], ret_metrics['Fscore']
     all_acc_l, recall_l, precision_l, fscore_l = legacy_mean_fscore(
         results, label, num_classes, ignore_index)
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(recall, recall_l)
     assert np.allclose(precision, precision_l)
     assert np.allclose(fscore, fscore_l)
@@ -135,7 +135,7 @@ def test_metrics():
         'aAcc'], ret_metrics['Acc'], ret_metrics['IoU'], ret_metrics[
             'Dice'], ret_metrics['Precision'], ret_metrics[
                 'Recall'], ret_metrics['Fscore']
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, iou_l)
     assert np.allclose(dice, dice_l)
@@ -228,7 +228,7 @@ def test_mean_iou():
         'IoU']
     all_acc_l, acc_l, iou_l = legacy_mean_iou(results, label, num_classes,
                                               ignore_index)
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, iou_l)
 
@@ -254,7 +254,7 @@ def test_mean_dice():
         'Dice']
     all_acc_l, acc_l, dice_l = legacy_mean_dice(results, label, num_classes,
                                                 ignore_index)
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(acc, acc_l)
     assert np.allclose(iou, dice_l)
 
@@ -280,7 +280,7 @@ def test_mean_fscore():
         'Recall'], ret_metrics['Precision'], ret_metrics['Fscore']
     all_acc_l, recall_l, precision_l, fscore_l = legacy_mean_fscore(
         results, label, num_classes, ignore_index)
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(recall, recall_l)
     assert np.allclose(precision, precision_l)
     assert np.allclose(fscore, fscore_l)
@@ -291,7 +291,7 @@ def test_mean_fscore():
         'Recall'], ret_metrics['Precision'], ret_metrics['Fscore']
     all_acc_l, recall_l, precision_l, fscore_l = legacy_mean_fscore(
         results, label, num_classes, ignore_index, beta=2)
-    assert all_acc == all_acc_l
+    assert np.allclose(all_acc, all_acc_l)
     assert np.allclose(recall, recall_l)
     assert np.allclose(precision, precision_l)
     assert np.allclose(fscore, fscore_l)
@@ -346,6 +346,6 @@ def test_filename_inputs():
             'Acc'], ret_metrics['IoU']
         all_acc_l, acc_l, iou_l = legacy_mean_iou(results, labels, num_classes,
                                                   ignore_index)
-        assert all_acc == all_acc_l
+        assert np.allclose(all_acc, all_acc_l)
         assert np.allclose(acc, acc_l)
         assert np.allclose(iou, iou_l)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -31,7 +31,7 @@ def get_confusion_matrix(pred_label, label, num_classes, ignore_index):
 def legacy_mean_iou(results, gt_seg_maps, num_classes, ignore_index):
     num_imgs = len(results)
     assert len(gt_seg_maps) == num_imgs
-    total_mat = np.zeros((num_classes, num_classes), dtype=np.float)
+    total_mat = np.zeros((num_classes, num_classes), dtype=np.float32)
     for i in range(num_imgs):
         mat = get_confusion_matrix(
             results[i], gt_seg_maps[i], num_classes, ignore_index=ignore_index)
@@ -48,7 +48,7 @@ def legacy_mean_iou(results, gt_seg_maps, num_classes, ignore_index):
 def legacy_mean_dice(results, gt_seg_maps, num_classes, ignore_index):
     num_imgs = len(results)
     assert len(gt_seg_maps) == num_imgs
-    total_mat = np.zeros((num_classes, num_classes), dtype=np.float)
+    total_mat = np.zeros((num_classes, num_classes), dtype=np.float32)
     for i in range(num_imgs):
         mat = get_confusion_matrix(
             results[i], gt_seg_maps[i], num_classes, ignore_index=ignore_index)


### PR DESCRIPTION
## Motivation

1. numpy from 1.24 deprecated the aliases np.object, np.bool, np.float, np.complex, np.str, and np.int
https://numpy.org/devdocs/release/1.24.0-notes.html

2. timm needs to pytorch>=1.7, so ignore test timm in pytorch 1.5 and 1.6

3. Remove install pillow as it doesn't test torchvision < 0.5

## Modification

1. np.float->np.float32
 
2. torch >= '1.7.0' -> matrix.torch != '1.5.1+cu101' && matrix.torch != '1.6.0+cu101' (as '1.10' < '1.7'

3. Remove install pillow
