### PR TITLE
[Feature] Add `gt_edge_map` field.

### DIFF
--- a/mmseg/datasets/transforms/formatting.py
+++ b/mmseg/datasets/transforms/formatting.py
@@ -73,6 +73,12 @@ class PackSegInputs(BaseTransform):
                                                      ...].astype(np.int64)))
             data_sample.gt_sem_seg = PixelData(**gt_sem_seg_data)
 
+        if 'gt_edge_map' in results:
+            gt_edge_data = dict(
+                data=to_tensor(results['gt_edge_map'][None,
+                                                      ...].astype(np.int64)))
+            data_sample.set_data(dict(gt_edge_map=PixelData(**gt_edge_data)))
+
         img_meta = {}
         for key in self.meta_keys:
             if key in results:

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1296,7 +1296,7 @@ class GenerateEdge(BaseTransform):
                                            (self.edge_width, self.edge_width))
         edge = cv2.dilate(edge, kernel)
 
-        results['gt_edge'] = edge
+        results['gt_edge_map'] = edge
         results['edge_width'] = self.edge_width
 
         return results

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1245,7 +1245,7 @@ class GenerateEdge(BaseTransform):
         - gt_seg_map
 
     Added Keys:
-        - gt_edge (np.ndarray, uint8): The edge annotation generated from the
+        - gt_edge_map (np.ndarray, uint8): The edge annotation generated from the
             seg map by extracting border between different semantics.
 
     Args:

--- a/mmseg/utils/misc.py
+++ b/mmseg/utils/misc.py
@@ -98,6 +98,11 @@ def stack_batch(inputs: List[torch.Tensor],
             del data_sample.gt_sem_seg.data
             data_sample.gt_sem_seg.data = F.pad(
                 gt_sem_seg, padding_size, value=seg_pad_val)
+            if 'gt_edge_map' in data_sample:
+                gt_edge_map = data_sample.gt_edge_map.data
+                del data_sample.gt_edge_map.data
+                data_sample.gt_edge_map.data = F.pad(
+                    gt_edge_map, padding_size, value=seg_pad_val)
             data_sample.set_metainfo({
                 'img_shape': tensor.shape[-2:],
                 'pad_shape': data_sample.gt_sem_seg.shape,

--- a/tests/test_datasets/test_transform.py
+++ b/tests/test_datasets/test_transform.py
@@ -792,7 +792,7 @@ def test_generate_edge():
     results['img_shape'] = seg_map.shape
 
     results = transform(results)
-    assert np.all(results['gt_edge'] == np.array([
+    assert np.all(results['gt_edge_map'] == np.array([
         [0, 0, 0, 1, 0],
         [0, 0, 1, 1, 1],
         [0, 1, 1, 1, 0],


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation of this PR is to add `gt_edge_map` field to support boundary loss.

## Modification

- GenerateEdge
Modify `gt_edge` field to `gt_edge_map`.

- PackSegInputs
Add `gt_edge_map` to data_sample.

- stack_batch
Pad `gt_edge_map` to max_shape.

## BC-breaking (Optional)

No

## Use cases (Optional)

Reference `GenerateEdge`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
