### PR TITLE
[Fix] Fix incorrect `img_shape` value assignment in RandomCrop

### DIFF
--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -314,9 +314,9 @@ class RandomCrop(BaseTransform):
         # crop semantic seg
         for key in results.get('seg_fields', []):
             results[key] = self.crop(results[key], crop_bbox)
-        img_shape = img.shape
+
         results['img'] = img
-        results['img_shape'] = img_shape
+        results['img_shape'] = img.shape[:2]
         return results
 
     def __repr__(self):

--- a/tests/test_datasets/test_transform.py
+++ b/tests/test_datasets/test_transform.py
@@ -321,7 +321,7 @@ def test_random_crop():
 
     results = pipeline(results)
     assert results['img'].shape[:2] == (h - 20, w - 20)
-    assert results['img_shape'][:2] == (h - 20, w - 20)
+    assert results['img_shape'] == (h - 20, w - 20)
     assert results['gt_semantic_seg'].shape[:2] == (h - 20, w - 20)
 
 


### PR DESCRIPTION
## Motivation

Fix incorrect `img_shape` value assignment.

## Modification

- mmseg/datasets/transforms/transforms.py


