### PR TITLE
[Fix] Fix `reduce_zero_label` in evaluation

### DIFF
--- a/mmseg/core/evaluation/metrics.py
+++ b/mmseg/core/evaluation/metrics.py
@@ -26,9 +26,7 @@ def f_score(precision, recall, beta=1):
 def intersect_and_union(pred_label,
                         label,
                         num_classes,
-                        ignore_index,
-                        label_map=dict(),
-                        reduce_zero_label=False):
+                        ignore_index):
     """Calculate intersection and Union.
 
     Args:
@@ -38,10 +36,6 @@ def intersect_and_union(pred_label,
             or label filename.
         num_classes (int): Number of categories.
         ignore_index (int): Index that will be ignored in evaluation.
-        label_map (dict): Mapping old labels to new labels. The parameter will
-            work only when label is str. Default: dict().
-        reduce_zero_label (bool): Whether ignore zero label. The parameter will
-            work only when label is str. Default: False.
 
      Returns:
          torch.Tensor: The intersection of prediction and ground truth
@@ -63,15 +57,6 @@ def intersect_and_union(pred_label,
     else:
         label = torch.from_numpy(label)
 
-    if reduce_zero_label:
-        label[label == 0] = 255
-        label = label - 1
-        label[label == 254] = 255
-    if label_map is not None:
-        label_copy = label.clone()
-        for old_id, new_id in label_map.items():
-            label[label_copy == old_id] = new_id
-
     mask = (label != ignore_index)
     pred_label = pred_label[mask]
     label = label[mask]
@@ -90,9 +75,7 @@ def intersect_and_union(pred_label,
 def total_intersect_and_union(results,
                               gt_seg_maps,
                               num_classes,
-                              ignore_index,
-                              label_map=dict(),
-                              reduce_zero_label=False):
+                              ignore_index):
     """Calculate Total Intersection and Union.
 
     Args:
@@ -102,8 +85,6 @@ def total_intersect_and_union(results,
             truth segmentation maps or list of label filenames.
         num_classes (int): Number of categories.
         ignore_index (int): Index that will be ignored in evaluation.
-        label_map (dict): Mapping old labels to new labels. Default: dict().
-        reduce_zero_label (bool): Whether ignore zero label. Default: False.
 
      Returns:
          ndarray: The intersection of prediction and ground truth histogram
@@ -119,9 +100,7 @@ def total_intersect_and_union(results,
     total_area_label = torch.zeros((num_classes, ), dtype=torch.float64)
     for result, gt_seg_map in zip(results, gt_seg_maps):
         area_intersect, area_union, area_pred_label, area_label = \
-            intersect_and_union(
-                result, gt_seg_map, num_classes, ignore_index,
-                label_map, reduce_zero_label)
+            intersect_and_union(result, gt_seg_map, num_classes, ignore_index)
         total_area_intersect += area_intersect
         total_area_union += area_union
         total_area_pred_label += area_pred_label
@@ -134,9 +113,7 @@ def mean_iou(results,
              gt_seg_maps,
              num_classes,
              ignore_index,
-             nan_to_num=None,
-             label_map=dict(),
-             reduce_zero_label=False):
+             nan_to_num=None):
     """Calculate Mean Intersection and Union (mIoU)
 
     Args:
@@ -148,8 +125,6 @@ def mean_iou(results,
         ignore_index (int): Index that will be ignored in evaluation.
         nan_to_num (int, optional): If specified, NaN values will be replaced
             by the numbers defined by the user. Default: None.
-        label_map (dict): Mapping old labels to new labels. Default: dict().
-        reduce_zero_label (bool): Whether ignore zero label. Default: False.
 
      Returns:
         dict[str, float | ndarray]:
@@ -163,9 +138,7 @@ def mean_iou(results,
         num_classes=num_classes,
         ignore_index=ignore_index,
         metrics=['mIoU'],
-        nan_to_num=nan_to_num,
-        label_map=label_map,
-        reduce_zero_label=reduce_zero_label)
+        nan_to_num=nan_to_num)
     return iou_result
 
 
@@ -173,9 +146,7 @@ def mean_dice(results,
               gt_seg_maps,
               num_classes,
               ignore_index,
-              nan_to_num=None,
-              label_map=dict(),
-              reduce_zero_label=False):
+              nan_to_num=None):
     """Calculate Mean Dice (mDice)
 
     Args:
@@ -187,8 +158,6 @@ def mean_dice(results,
         ignore_index (int): Index that will be ignored in evaluation.
         nan_to_num (int, optional): If specified, NaN values will be replaced
             by the numbers defined by the user. Default: None.
-        label_map (dict): Mapping old labels to new labels. Default: dict().
-        reduce_zero_label (bool): Whether ignore zero label. Default: False.
 
      Returns:
         dict[str, float | ndarray]: Default metrics.
@@ -203,9 +172,7 @@ def mean_dice(results,
         num_classes=num_classes,
         ignore_index=ignore_index,
         metrics=['mDice'],
-        nan_to_num=nan_to_num,
-        label_map=label_map,
-        reduce_zero_label=reduce_zero_label)
+        nan_to_num=nan_to_num)
     return dice_result
 
 
@@ -214,8 +181,6 @@ def mean_fscore(results,
                 num_classes,
                 ignore_index,
                 nan_to_num=None,
-                label_map=dict(),
-                reduce_zero_label=False,
                 beta=1):
     """Calculate Mean F-Score (mFscore)
 
@@ -228,8 +193,6 @@ def mean_fscore(results,
         ignore_index (int): Index that will be ignored in evaluation.
         nan_to_num (int, optional): If specified, NaN values will be replaced
             by the numbers defined by the user. Default: None.
-        label_map (dict): Mapping old labels to new labels. Default: dict().
-        reduce_zero_label (bool): Whether ignore zero label. Default: False.
         beta (int): Determines the weight of recall in the combined score.
             Default: False.
 
@@ -248,8 +211,6 @@ def mean_fscore(results,
         ignore_index=ignore_index,
         metrics=['mFscore'],
         nan_to_num=nan_to_num,
-        label_map=label_map,
-        reduce_zero_label=reduce_zero_label,
         beta=beta)
     return fscore_result
 
@@ -260,8 +221,6 @@ def eval_metrics(results,
                  ignore_index,
                  metrics=['mIoU'],
                  nan_to_num=None,
-                 label_map=dict(),
-                 reduce_zero_label=False,
                  beta=1):
     """Calculate evaluation metrics
     Args:
@@ -274,8 +233,6 @@ def eval_metrics(results,
         metrics (list[str] | str): Metrics to be evaluated, 'mIoU' and 'mDice'.
         nan_to_num (int, optional): If specified, NaN values will be replaced
             by the numbers defined by the user. Default: None.
-        label_map (dict): Mapping old labels to new labels. Default: dict().
-        reduce_zero_label (bool): Whether ignore zero label. Default: False.
      Returns:
         float: Overall accuracy on all images.
         ndarray: Per category accuracy, shape (num_classes, ).
@@ -284,8 +241,7 @@ def eval_metrics(results,
 
     total_area_intersect, total_area_union, total_area_pred_label, \
         total_area_label = total_intersect_and_union(
-            results, gt_seg_maps, num_classes, ignore_index, label_map,
-            reduce_zero_label)
+            results, gt_seg_maps, num_classes, ignore_index)
     ret_metrics = total_area_to_metrics(total_area_intersect, total_area_union,
                                         total_area_pred_label,
                                         total_area_label, metrics, nan_to_num,

--- a/mmseg/core/evaluation/metrics.py
+++ b/mmseg/core/evaluation/metrics.py
@@ -23,10 +23,7 @@ def f_score(precision, recall, beta=1):
     return score
 
 
-def intersect_and_union(pred_label,
-                        label,
-                        num_classes,
-                        ignore_index):
+def intersect_and_union(pred_label, label, num_classes, ignore_index):
     """Calculate intersection and Union.
 
     Args:
@@ -72,10 +69,7 @@ def intersect_and_union(pred_label,
     return area_intersect, area_union, area_pred_label, area_label
 
 
-def total_intersect_and_union(results,
-                              gt_seg_maps,
-                              num_classes,
-                              ignore_index):
+def total_intersect_and_union(results, gt_seg_maps, num_classes, ignore_index):
     """Calculate Total Intersection and Union.
 
     Args:
@@ -109,11 +103,7 @@ def total_intersect_and_union(results,
         total_area_label
 
 
-def mean_iou(results,
-             gt_seg_maps,
-             num_classes,
-             ignore_index,
-             nan_to_num=None):
+def mean_iou(results, gt_seg_maps, num_classes, ignore_index, nan_to_num=None):
     """Calculate Mean Intersection and Union (mIoU)
 
     Args:

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -301,14 +301,7 @@ class CustomDataset(Dataset):
                     pred,
                     seg_map,
                     len(self.CLASSES),
-                    self.ignore_index,
-                    # as the labels has been converted when dataset initialized
-                    # in `get_palette_for_custom_classes ` this `label_map`
-                    # should be `dict()`, see
-                    # https://github.com/open-mmlab/mmsegmentation/issues/1415
-                    # for more ditails
-                    label_map=dict(),
-                    reduce_zero_label=False))
+                    self.ignore_index))
 
         return pre_eval_results
 
@@ -424,9 +417,7 @@ class CustomDataset(Dataset):
                 gt_seg_maps,
                 num_classes,
                 self.ignore_index,
-                metric,
-                label_map=dict(),
-                reduce_zero_label=self.reduce_zero_label)
+                metric)
         # test a list of pre_eval_results
         else:
             ret_metrics = pre_eval_to_metrics(results, metric)

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -297,11 +297,8 @@ class CustomDataset(Dataset):
         for pred, index in zip(preds, indices):
             seg_map = self.get_gt_seg_map_by_idx(index)
             pre_eval_results.append(
-                intersect_and_union(
-                    pred,
-                    seg_map,
-                    len(self.CLASSES),
-                    self.ignore_index))
+                intersect_and_union(pred, seg_map, len(self.CLASSES),
+                                    self.ignore_index))
 
         return pre_eval_results
 
@@ -412,12 +409,8 @@ class CustomDataset(Dataset):
             if gt_seg_maps is None:
                 gt_seg_maps = self.get_gt_seg_maps()
             num_classes = len(self.CLASSES)
-            ret_metrics = eval_metrics(
-                results,
-                gt_seg_maps,
-                num_classes,
-                self.ignore_index,
-                metric)
+            ret_metrics = eval_metrics(results, gt_seg_maps, num_classes,
+                                       self.ignore_index, metric)
         # test a list of pre_eval_results
         else:
             ret_metrics = pre_eval_to_metrics(results, metric)

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -297,8 +297,21 @@ class CustomDataset(Dataset):
         for pred, index in zip(preds, indices):
             seg_map = self.get_gt_seg_map_by_idx(index)
             pre_eval_results.append(
-                intersect_and_union(pred, seg_map, len(self.CLASSES),
-                                    self.ignore_index))
+                intersect_and_union(
+                    pred,
+                    seg_map,
+                    len(self.CLASSES),
+                    self.ignore_index,
+                    # as the label map has already been applied and zero label
+                    # has already been reduced by get_gt_seg_map_by_idx() i.e.
+                    # LoadAnnotations.__call__(), these operations should not
+                    # be duplicated. See the following issues/PRs:
+                    # https://github.com/open-mmlab/mmsegmentation/issues/1415
+                    # https://github.com/open-mmlab/mmsegmentation/pull/1417
+                    # https://github.com/open-mmlab/mmsegmentation/pull/2504
+                    # for more details
+                    label_map=dict(),
+                    reduce_zero_label=False))
 
         return pre_eval_results
 
@@ -409,8 +422,14 @@ class CustomDataset(Dataset):
             if gt_seg_maps is None:
                 gt_seg_maps = self.get_gt_seg_maps()
             num_classes = len(self.CLASSES)
-            ret_metrics = eval_metrics(results, gt_seg_maps, num_classes,
-                                       self.ignore_index, metric)
+            ret_metrics = eval_metrics(
+                results,
+                gt_seg_maps,
+                num_classes,
+                self.ignore_index,
+                metric,
+                label_map=dict(),
+                reduce_zero_label=False)
         # test a list of pre_eval_results
         else:
             ret_metrics = pre_eval_to_metrics(results, metric)

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -66,8 +66,8 @@ class CustomDataset(Dataset):
             The palette of segmentation map. If None is given, and
             self.PALETTE is None, random palette will be generated.
             Default: None
-        gt_seg_map_loader_cfg (dict, optional): build LoadAnnotations to
-            load gt for evaluation, load from disk by default. Default: None.
+        gt_seg_map_loader_cfg (dict): build LoadAnnotations to load gt for
+            evaluation, load from disk by default. Default: empty.
         file_client_args (dict): Arguments to instantiate a FileClient.
             See :class:`mmcv.fileio.FileClient` for details.
             Defaults to ``dict(backend='disk')``.
@@ -90,7 +90,7 @@ class CustomDataset(Dataset):
                  reduce_zero_label=False,
                  classes=None,
                  palette=None,
-                 gt_seg_map_loader_cfg=None,
+                 gt_seg_map_loader_cfg=dict(),
                  file_client_args=dict(backend='disk')):
         self.pipeline = Compose(pipeline)
         self.img_dir = img_dir
@@ -106,8 +106,7 @@ class CustomDataset(Dataset):
         self.CLASSES, self.PALETTE = self.get_classes_and_palette(
             classes, palette)
         self.gt_seg_map_loader = LoadAnnotations(
-        ) if gt_seg_map_loader_cfg is None else LoadAnnotations(
-            **gt_seg_map_loader_cfg)
+            reduce_zero_label=reduce_zero_label, **gt_seg_map_loader_cfg)
 
         self.file_client_args = file_client_args
         self.file_client = mmcv.FileClient.infer_client(self.file_client_args)
@@ -309,7 +308,7 @@ class CustomDataset(Dataset):
                     # https://github.com/open-mmlab/mmsegmentation/issues/1415
                     # for more ditails
                     label_map=dict(),
-                    reduce_zero_label=self.reduce_zero_label))
+                    reduce_zero_label=False))
 
         return pre_eval_results
 

--- a/mmseg/datasets/custom.py
+++ b/mmseg/datasets/custom.py
@@ -67,7 +67,7 @@ class CustomDataset(Dataset):
             self.PALETTE is None, random palette will be generated.
             Default: None
         gt_seg_map_loader_cfg (dict): build LoadAnnotations to load gt for
-            evaluation, load from disk by default. Default: empty.
+            evaluation, load from disk by default. Default: ``dict()``.
         file_client_args (dict): Arguments to instantiate a FileClient.
             See :class:`mmcv.fileio.FileClient` for details.
             Defaults to ``dict(backend='disk')``.

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -365,6 +365,72 @@ def test_custom_dataset():
     assert not np.isnan(eval_results['mRecall'])
 
 
+def test_custom_dataset_pre_eval():
+    """
+    Test pre-eval function of custom dataset with reduce zero label and removed
+    classes.
+
+    The GT segmentation contain 4 classes: "A", "B", "C", "D", as well as
+    a zero label. Therefore, the labels go from 0 to 4.
+
+    Then, we will remove class "C" while instantiating the dataset. Therefore,
+    pre-eval must reduce the zero label and also apply label_map in the correct
+    order.
+    """
+
+    # create a dummy dataset on disk
+    img = np.random.rand(10, 10)
+    ann = np.zeros_like(img)
+    ann[2:4, 2:4] = 1
+    ann[2:4, 6:8] = 2
+    ann[6:8, 2:4] = 3
+    ann[6:8, 6:8] = 4
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    img_path = osp.join(tmp_dir.name, 'img', '00000.jpg')
+    ann_path = osp.join(tmp_dir.name, 'ann', '00000.png')
+
+    import mmcv
+    mmcv.imwrite(img, img_path)
+    mmcv.imwrite(ann, ann_path)
+
+    class FiveClassDatasetWithZeroLabel(CustomDataset):
+        CLASSES = ['A', 'B', 'C', 'D']  # 4 classes
+        PALETTE = [(0, 0, 0)] * 4  # dummy palette
+
+    # with img_dir, ann_dir, split
+    dataset = FiveClassDatasetWithZeroLabel(
+        [],
+        classes=['A', 'B', 'D'],  # original classes with class "C" removed
+        reduce_zero_label=True,  # reduce zero label set to True
+        data_root=osp.join(osp.dirname(__file__), tmp_dir.name),
+        img_dir='img/',
+        ann_dir='ann/',
+        img_suffix='.jpg',
+        seg_map_suffix='.png')
+    assert len(dataset) == 1
+
+    # there are three classes ("A", "B", "D") that the network predicts
+    perfect_pred = np.zeros([10, 10], dtype=np.int64)
+    perfect_pred[2:4, 2:4] = 0  # 1 gets reduced to 0 that maps to 0
+    perfect_pred[2:4, 6:8] = 1  # 2 gets reduced to 1 that maps to 1
+    perfect_pred[6:8, 2:4] = 0  # 2 gets reduced to 1 that maps to -1, ignored
+    perfect_pred[6:8, 6:8] = 2  # 4 gets reduced to 3 that maps to 2
+
+    results = dataset.pre_eval([perfect_pred], [0])
+    from mmseg.core.evaluation.metrics import pre_eval_to_metrics
+    eval_results = pre_eval_to_metrics(results, ['mIoU', 'mDice', 'mFscore'])
+
+    # the results should be perfect
+    assert (eval_results['IoU']       == 1.0).all()
+    assert (eval_results['aAcc']      == 1.0).all()
+    assert (eval_results['Acc']       == 1.0).all()
+    assert (eval_results['Dice']      == 1.0).all()
+    assert (eval_results['Fscore']    == 1.0).all()
+    assert (eval_results['Precision'] == 1.0).all()
+    assert (eval_results['Recall']    == 1.0).all()
+
+
 @pytest.mark.parametrize('separate_eval', [True, False])
 def test_eval_concat_custom_dataset(separate_eval):
     img_norm_cfg = dict(

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -411,10 +411,10 @@ def test_custom_dataset_pre_eval():
 
     # there are three classes ("A", "B", "D") that the network predicts
     perfect_pred = np.zeros([10, 10], dtype=np.int64)
-    perfect_pred[2:4, 2:4] = 0  # 1 gets reduced to 0 that maps to 0
-    perfect_pred[2:4, 6:8] = 1  # 2 gets reduced to 1 that maps to 1
-    perfect_pred[6:8, 2:4] = 0  # 2 gets reduced to 1 that maps to -1, ignored
-    perfect_pred[6:8, 6:8] = 2  # 4 gets reduced to 3 that maps to 2
+    perfect_pred[2:4, 2:4] = 0  # 'A': 1 reduced to 0 that maps to 0
+    perfect_pred[2:4, 6:8] = 1  # 'B': 2 reduced to 1 that maps to 1
+    perfect_pred[6:8, 2:4] = 0  # 'C': 3 reduced to 2 that maps to -1, ignored
+    perfect_pred[6:8, 6:8] = 2  # 'D': 4 reduced to 3 that maps to 2
 
     results = dataset.pre_eval([perfect_pred], [0])
     from mmseg.core.evaluation.metrics import pre_eval_to_metrics

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -366,9 +366,8 @@ def test_custom_dataset():
 
 
 def test_custom_dataset_pre_eval():
-    """
-    Test pre-eval function of custom dataset with reduce zero label and removed
-    classes.
+    """Test pre-eval function of custom dataset with reduce zero label and
+    removed classes.
 
     The GT segmentation contain 4 classes: "A", "B", "C", "D", as well as
     a zero label. Therefore, the labels go from 0 to 4.
@@ -422,13 +421,11 @@ def test_custom_dataset_pre_eval():
     eval_results = pre_eval_to_metrics(results, ['mIoU', 'mDice', 'mFscore'])
 
     # the results should be perfect
-    assert (eval_results['IoU']       == 1.0).all()
-    assert (eval_results['aAcc']      == 1.0).all()
-    assert (eval_results['Acc']       == 1.0).all()
-    assert (eval_results['Dice']      == 1.0).all()
-    assert (eval_results['Fscore']    == 1.0).all()
-    assert (eval_results['Precision'] == 1.0).all()
-    assert (eval_results['Recall']    == 1.0).all()
+    for metric in 'IoU', 'aAcc', 'Acc', 'Dice', 'Fscore', 'Precision', \
+                  'Recall':
+        assert (eval_results[metric] == 1.0).all()
+
+    tmp_dir.cleanup()
 
 
 @pytest.mark.parametrize('separate_eval', [True, False])

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -393,12 +393,12 @@ def test_custom_dataset_pre_eval():
     mmcv.imwrite(img, img_path)
     mmcv.imwrite(ann, ann_path)
 
-    class FiveClassDatasetWithZeroLabel(CustomDataset):
+    class FourClassDatasetWithZeroLabel(CustomDataset):
         CLASSES = ['A', 'B', 'C', 'D']  # 4 classes
         PALETTE = [(0, 0, 0)] * 4  # dummy palette
 
     # with img_dir, ann_dir, split
-    dataset = FiveClassDatasetWithZeroLabel(
+    dataset = FourClassDatasetWithZeroLabel(
         [],
         classes=['A', 'B', 'D'],  # original classes with class "C" removed
         reduce_zero_label=True,  # reduce zero label set to True


### PR DESCRIPTION
## Motivation

Through this PR, I (1) fix a bug, and (2) perform some associated cleanup, and (3) add a unit test. The bug occurs during evaluation when two options -- `reduce_zero_label=True`, and custom classes are used. The bug was that the `reduce_zero_label` is not properly propagated (see details below).

## Modification

1. **Bugfix**

The bug occurs [in the initialization of `CustomDataset`](https://github.com/open-mmlab/mmsegmentation/blob/5d49918b3c48df5544213562aa322bfa89d67ef1/mmseg/datasets/custom.py#L108-L110) where the `reduce_zero_label` flag is not propagated to its member `self.gt_seg_map_loader_cfg`:

```python
self.gt_seg_map_loader = LoadAnnotations(
) if gt_seg_map_loader_cfg is None else LoadAnnotations(
    **gt_seg_map_loader_cfg)
```

Because the `reduce_zero_label` flag was not being propagated, the zero label reduction was being [unnecessarily and explicitly duplicated during the evaluation](https://github.com/open-mmlab/mmsegmentation/blob/5d49918b3c48df5544213562aa322bfa89d67ef1/mmseg/core/evaluation/metrics.py#L66-L69).

As pointed in a previous PR (#2500), `reduce_zero_label` must occur before applying the `label_map`. Due to this bug, the order gets reversed when both features are used simultaneously.

This has been fixed to:

```python
self.gt_seg_map_loader = LoadAnnotations(
    reduce_zero_label=reduce_zero_label, **gt_seg_map_loader_cfg)
```

2. **Cleanup**

Due to the bug fix, since both `reduce_zero_label` and `label_map` are being applied in `get_gt_seg_map_by_idx()` (i.e. `LoadAnnotations.__call__()`), the evaluation does not need perform them anymore.

This was pointed out for `label_map` in a previous issue (#1415) that the `label_map` should  not be applied in the evaluation. This was handled by [passing an empty dict](https://github.com/open-mmlab/mmsegmentation/blob/5d49918b3c48df5544213562aa322bfa89d67ef1/mmseg/datasets/custom.py#L306-L311):

```python
# as the labels has been converted when dataset initialized
# in `get_palette_for_custom_classes ` this `label_map`
# should be `dict()`, see
# https://github.com/open-mmlab/mmsegmentation/issues/1415
# for more ditails
label_map=dict(),
reduce_zero_label=self.reduce_zero_label))
```

Similar to this, I now also set `reduce_label=False` since it is now also being handled by `get_gt_seg_map_by_idx()` (i.e. `LoadAnnotations.__call__()`).

3. **Unit test**

I've added a unit test that tests the `CustomDataset.pre_eval()` function when `reduce_zero_label=True` and custom classes are used. The test fails on the original `master` branch but passes with this fix.

## BC-breaking (Optional)

I do not anticipate this change braking any backward-compatibility.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
  - _I've fixed all linting/pre-commit errors._
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
  - _I've added a test that passes when the fix is introduced, and fails on the original master branch._
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
  - _I don't think this change affects MMDet or MMDet3D._
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
  - _This change fixes an existing bug and doesn't require modifying any documentation/docstring._
