### PR TITLE
[Fix] Unfinished label conversion from `-1` to `255` in 1.x

### DIFF
--- a/mmseg/datasets/basesegdataset.py
+++ b/mmseg/datasets/basesegdataset.py
@@ -220,7 +220,7 @@ class BaseSegDataset(BaseDataset):
             # return subset of palette
             for old_id, new_id in sorted(
                     self.label_map.items(), key=lambda x: x[1]):
-                if new_id != -1:
+                if new_id != 255:
                     new_palette.append(palette[old_id])
             new_palette = type(palette)(new_palette)
         else:


### PR DESCRIPTION
## Motivation

This is motivated by a previously unfinished PR (#2332). In that PR, the label -1 was changed to 255 in `BaseSegDataset`, which is correct. However, it was changed at only one location. There is another location in `mmseg/datasets/basesegdataset.py` where -1 was still being used that was not converted to 255. I have now converted it to 255.

This is exactly same as a similar fix to the `master` branch via #2515 .

## Modification

I've simply converted the snipped

```python
if new_id != -1:
    new_palette.append(palette[old_id])
```
to 
```python
if new_id != 255:
    new_palette.append(palette[old_id])
```

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
  - _I've fixed all linting/pre-commit errors._
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
  - _No unit tests need to be added or were affected.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
  - _I don't think this change affects MMDet or MMDet3D._
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
  - _This change fixes an existing bug and doesn't require modifying any documentation/docstring._