### PR TITLE
change typo in CrossEntropyLoss

### DIFF
--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -198,7 +198,7 @@ class CrossEntropyLoss(nn.Module):
     """CrossEntropyLoss.
 
     Args:
-        use_sigmoid (bool, optional): Whether the prediction uses sigmoid
+        use_sigmoid (bool, optional): Whether the prediction uses sigmoid instead
             of softmax. Defaults to False.
         use_mask (bool, optional): Whether to use mask cross entropy loss.
             Defaults to False.

--- a/mmseg/models/losses/cross_entropy_loss.py
+++ b/mmseg/models/losses/cross_entropy_loss.py
@@ -198,8 +198,8 @@ class CrossEntropyLoss(nn.Module):
     """CrossEntropyLoss.
 
     Args:
-        use_sigmoid (bool, optional): Whether the prediction uses sigmoid instead
-            of softmax. Defaults to False.
+        use_sigmoid (bool, optional): Whether the prediction uses sigmoid
+            instead of softmax. Defaults to False.
         use_mask (bool, optional): Whether to use mask cross entropy loss.
             Defaults to False.
         reduction (str, optional): . Defaults to 'mean'.


### PR DESCRIPTION
The documentation of the use_sigmoid argument in CrossEntropyLoss currently suggests the sigmoid would be applied in addition to the softmax function. This change fixes this typo.