### PR TITLE
[Types] Fix misleading `List[Tensor]` types

### DIFF
--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -263,7 +263,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
         return losses
 
     def predict(self, inputs: Tuple[Tensor], batch_img_metas: List[dict],
-                test_cfg: ConfigType) -> List[Tensor]:
+                test_cfg: ConfigType) -> Tensor:
         """Forward function for prediction.
 
         Args:
@@ -276,7 +276,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             test_cfg (dict): The testing config.
 
         Returns:
-            List[Tensor]: Outputs segmentation logits map.
+            Tensor: Outputs segmentation logits map.
         """
         seg_logits = self.forward(inputs)
 

--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -126,7 +126,7 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
 
     def postprocess_result(self,
                            seg_logits: Tensor,
-                           data_samples: OptSampleList = None) -> list:
+                           data_samples: OptSampleList = None) -> SampleList:
         """ Convert results list to `SegDataSample`.
         Args:
             seg_logits (Tensor): The segmentation results, seg_logits from

--- a/mmseg/models/segmentors/cascade_encoder_decoder.py
+++ b/mmseg/models/segmentors/cascade_encoder_decoder.py
@@ -70,7 +70,7 @@ class CascadeEncoderDecoder(EncoderDecoder):
         self.num_classes = self.decode_head[-1].num_classes
 
     def encode_decode(self, inputs: Tensor,
-                      batch_img_metas: List[dict]) -> List[Tensor]:
+                      batch_img_metas: List[dict]) -> Tensor:
         """Encode images with backbone and decode into a semantic segmentation
         map of the same size as input."""
         x = self.extract_feat(inputs)

--- a/mmseg/models/segmentors/encoder_decoder.py
+++ b/mmseg/models/segmentors/encoder_decoder.py
@@ -120,7 +120,7 @@ class EncoderDecoder(BaseSegmentor):
         return x
 
     def encode_decode(self, inputs: Tensor,
-                      batch_img_metas: List[dict]) -> List[Tensor]:
+                      batch_img_metas: List[dict]) -> Tensor:
         """Encode images with backbone and decode into a semantic segmentation
         map of the same size as input."""
         x = self.extract_feat(inputs)


### PR DESCRIPTION
## Motivation

A few functions in the following files:
- `decode_head.py`
- `encoder_decoder.py`
- `cascade_encoder_decoder.py`
 
have a return type annotation as `List[Tensor]` whereas their actual return type is `Tensor`. This can be seen by following the trace of what each functions return internally, which eventually leads to `seg_logits: Tensor`.

This type annotation is misleading and confusing when a user is trying to read and understand the code.

## Modification

1. Fix type annotations from `List[Tensor]` to `Tensor`.
2. Make a return type more specific from `list` to `SampleList`.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
  - _I've fixed all linting/pre-commit errors._
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
  - _This involves only changing type annotations, so there is no need for tests._ 
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
  - _I don't think this change affects MMDet or MMDet3D._
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
  - _This change fixes existing type annotations, so it may require a change in the documentation/docstring that I don't have access to._
