### PR TITLE
Backward merge #2535 from `1.x` into `dev-1.x`

### DIFF
--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -263,7 +263,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
         return losses
 
     def predict(self, inputs: Tuple[Tensor], batch_img_metas: List[dict],
-                test_cfg: ConfigType) -> List[Tensor]:
+                test_cfg: ConfigType) -> Tensor:
         """Forward function for prediction.
 
         Args:
@@ -276,7 +276,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             test_cfg (dict): The testing config.
 
         Returns:
-            List[Tensor]: Outputs segmentation logits map.
+            Tensor: Outputs segmentation logits map.
         """
         seg_logits = self.forward(inputs)
 

--- a/mmseg/models/segmentors/base.py
+++ b/mmseg/models/segmentors/base.py
@@ -126,7 +126,7 @@ class BaseSegmentor(BaseModel, metaclass=ABCMeta):
 
     def postprocess_result(self,
                            seg_logits: Tensor,
-                           data_samples: OptSampleList = None) -> list:
+                           data_samples: OptSampleList = None) -> SampleList:
         """ Convert results list to `SegDataSample`.
         Args:
             seg_logits (Tensor): The segmentation results, seg_logits from

--- a/mmseg/models/segmentors/cascade_encoder_decoder.py
+++ b/mmseg/models/segmentors/cascade_encoder_decoder.py
@@ -70,7 +70,7 @@ class CascadeEncoderDecoder(EncoderDecoder):
         self.num_classes = self.decode_head[-1].num_classes
 
     def encode_decode(self, inputs: Tensor,
-                      batch_img_metas: List[dict]) -> List[Tensor]:
+                      batch_img_metas: List[dict]) -> Tensor:
         """Encode images with backbone and decode into a semantic segmentation
         map of the same size as input."""
         x = self.extract_feat(inputs)

--- a/mmseg/models/segmentors/encoder_decoder.py
+++ b/mmseg/models/segmentors/encoder_decoder.py
@@ -120,7 +120,7 @@ class EncoderDecoder(BaseSegmentor):
         return x
 
     def encode_decode(self, inputs: Tensor,
-                      batch_img_metas: List[dict]) -> List[Tensor]:
+                      batch_img_metas: List[dict]) -> Tensor:
         """Encode images with backbone and decode into a semantic segmentation
         map of the same size as input."""
         x = self.extract_feat(inputs)


### PR DESCRIPTION
## Motivation

This is essentially #2535 that I had intended to submit to the `dev-1.x` branch but accidentally submitted it directly to the `1.x` branch (apologies!). This also got approved possibly because the core devs also didn't realize this.

The problem is that now `1.x` and `dev-1.x` are out of sync -- the changes introduced by #2535 will never be reflected in `dev-1.x`.

## Modification

I'm proposing this "backward-merge" so that `1.x` and `dev-1.x` can be in sync again. If you look at "files changed", they are exactly the changes introduced by #2535.