### PR TITLE
[FIx] Set default `backend_args` values to None

### DIFF
--- a/configs/_base_/datasets/ade20k.py
+++ b/configs/_base_/datasets/ade20k.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/ade20k_640x640.py
+++ b/configs/_base_/datasets/ade20k_640x640.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/chase_db1.py
+++ b/configs/_base_/datasets/chase_db1.py
@@ -26,7 +26,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/cityscapes.py
+++ b/configs/_base_/datasets/cityscapes.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/coco-stuff10k.py
+++ b/configs/_base_/datasets/coco-stuff10k.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/coco-stuff164k.py
+++ b/configs/_base_/datasets/coco-stuff164k.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/drive.py
+++ b/configs/_base_/datasets/drive.py
@@ -26,7 +26,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/hrf.py
+++ b/configs/_base_/datasets/hrf.py
@@ -26,7 +26,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/isaid.py
+++ b/configs/_base_/datasets/isaid.py
@@ -32,7 +32,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/loveda.py
+++ b/configs/_base_/datasets/loveda.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/pascal_context_59.py
+++ b/configs/_base_/datasets/pascal_context_59.py
@@ -28,7 +28,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/pascal_voc12.py
+++ b/configs/_base_/datasets/pascal_voc12.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/pascal_voc12_aug.py
+++ b/configs/_base_/datasets/pascal_voc12_aug.py
@@ -27,7 +27,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/potsdam.py
+++ b/configs/_base_/datasets/potsdam.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/stare.py
+++ b/configs/_base_/datasets/stare.py
@@ -26,7 +26,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/_base_/datasets/vaihingen.py
+++ b/configs/_base_/datasets/vaihingen.py
@@ -25,7 +25,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/docs/en/migration/interface.md
+++ b/docs/en/migration/interface.md
@@ -237,7 +237,7 @@ test_pipeline = [
 ]
 img_ratios = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
 tta_pipeline = [
-    dict(type='LoadImageFromFile', backend_args=dict(backend='local')),
+    dict(type='LoadImageFromFile', backend_args=None),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/mmseg/datasets/basesegdataset.py
+++ b/mmseg/datasets/basesegdataset.py
@@ -73,38 +73,36 @@ class BaseSegDataset(BaseDataset):
         ignore_index (int): The label index to be ignored. Default: 255
         reduce_zero_label (bool): Whether to mark label zero as ignored.
             Default to False.
-        backend_args (dict): Arguments to instantiate a file backend.
+        backend_args (dict, Optional): Arguments to instantiate a file backend.
             See https://mmengine.readthedocs.io/en/latest/api/fileio.htm
-            for details. Defaults to ``dict(backend='local')``
+            for details. Defaults to None.
             Notes: mmcv>=2.0.0rc4, mmengine>=0.2.0 required.
     """
     METAINFO: dict = dict()
 
-    def __init__(
-        self,
-        ann_file: str = '',
-        img_suffix='.jpg',
-        seg_map_suffix='.png',
-        metainfo: Optional[dict] = None,
-        data_root: Optional[str] = None,
-        data_prefix: dict = dict(img_path='', seg_map_path=''),
-        filter_cfg: Optional[dict] = None,
-        indices: Optional[Union[int, Sequence[int]]] = None,
-        serialize_data: bool = True,
-        pipeline: List[Union[dict, Callable]] = [],
-        test_mode: bool = False,
-        lazy_init: bool = False,
-        max_refetch: int = 1000,
-        ignore_index: int = 255,
-        reduce_zero_label: bool = False,
-        backend_args: dict = dict(backend='local')
-    ) -> None:
+    def __init__(self,
+                 ann_file: str = '',
+                 img_suffix='.jpg',
+                 seg_map_suffix='.png',
+                 metainfo: Optional[dict] = None,
+                 data_root: Optional[str] = None,
+                 data_prefix: dict = dict(img_path='', seg_map_path=''),
+                 filter_cfg: Optional[dict] = None,
+                 indices: Optional[Union[int, Sequence[int]]] = None,
+                 serialize_data: bool = True,
+                 pipeline: List[Union[dict, Callable]] = [],
+                 test_mode: bool = False,
+                 lazy_init: bool = False,
+                 max_refetch: int = 1000,
+                 ignore_index: int = 255,
+                 reduce_zero_label: bool = False,
+                 backend_args: Optional[dict] = None) -> None:
 
         self.img_suffix = img_suffix
         self.seg_map_suffix = seg_map_suffix
         self.ignore_index = ignore_index
         self.reduce_zero_label = reduce_zero_label
-        self.backend_args = backend_args.copy()
+        self.backend_args = backend_args.copy() if backend_args else None
 
         self.data_root = data_root
         self.data_prefix = copy.copy(data_prefix)

--- a/mmseg/datasets/transforms/loading.py
+++ b/mmseg/datasets/transforms/loading.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import warnings
-from typing import Dict
+from typing import Dict, Optional
 
 import mmcv
 import mmengine.fileio as fileio
@@ -56,14 +56,14 @@ class LoadAnnotations(MMCV_LoadAnnotations):
             Defaults to 'pillow'.
         backend_args (dict): Arguments to instantiate a file backend.
             See https://mmengine.readthedocs.io/en/latest/api/fileio.htm
-            for details. Defaults to ``dict(backend='local')``
+            for details. Defaults to None.
             Notes: mmcv>=2.0.0rc4, mmengine>=0.2.0 required.
     """
 
     def __init__(
         self,
         reduce_zero_label=None,
-        backend_args=dict(backend='local'),
+        backend_args=None,
         imdecode_backend='pillow',
     ) -> None:
         super().__init__(
@@ -203,23 +203,21 @@ class LoadBiomedicalImageFromFile(BaseTransform):
         to_float32 (bool): Whether to convert the loaded image to a float32
             numpy array. If set to False, the loaded image is an float64 array.
             Defaults to True.
-        backend_args (dict): Arguments to instantiate a file backend.
+        backend_args (dict, Optional): Arguments to instantiate a file backend.
             See https://mmengine.readthedocs.io/en/latest/api/fileio.htm
-            for details. Defaults to ``dict(backend='local')``
+            for details. Defaults to None.
             Notes: mmcv>=2.0.0rc4, mmengine>=0.2.0 required.
     """
 
-    def __init__(
-        self,
-        decode_backend: str = 'nifti',
-        to_xyz: bool = False,
-        to_float32: bool = True,
-        backend_args: dict = dict(backend='local')
-    ) -> None:
+    def __init__(self,
+                 decode_backend: str = 'nifti',
+                 to_xyz: bool = False,
+                 to_float32: bool = True,
+                 backend_args: Optional[dict] = None) -> None:
         self.decode_backend = decode_backend
         self.to_xyz = to_xyz
         self.to_float32 = to_float32
-        self.backend_args = backend_args.copy()
+        self.backend_args = backend_args.copy() if backend_args else None
 
     def transform(self, results: Dict) -> Dict:
         """Functions to load image.
@@ -295,24 +293,22 @@ class LoadBiomedicalAnnotation(BaseTransform):
         to_float32 (bool): Whether to convert the loaded seg map to a float32
             numpy array. If set to False, the loaded image is an float64 array.
             Defaults to True.
-        backend_args (dict): Arguments to instantiate a file backend.
+        backend_args (dict, Optional): Arguments to instantiate a file backend.
             See :class:`mmengine.fileio` for details.
-            Defaults to ``dict(backend='local')``.
+            Defaults to None.
             Notes: mmcv>=2.0.0rc4, mmengine>=0.2.0 required.
     """
 
-    def __init__(
-        self,
-        decode_backend: str = 'nifti',
-        to_xyz: bool = False,
-        to_float32: bool = True,
-        backend_args: dict = dict(backend='local')
-    ) -> None:
+    def __init__(self,
+                 decode_backend: str = 'nifti',
+                 to_xyz: bool = False,
+                 to_float32: bool = True,
+                 backend_args: Optional[dict] = None) -> None:
         super().__init__()
         self.decode_backend = decode_backend
         self.to_xyz = to_xyz
         self.to_float32 = to_float32
-        self.backend_args = backend_args.copy()
+        self.backend_args = backend_args.copy() if backend_args else None
 
     def transform(self, results: Dict) -> Dict:
         """Functions to load image.
@@ -384,23 +380,21 @@ class LoadBiomedicalData(BaseTransform):
             backend is 'nifti'. Defaults to 'nifti'.
         to_xyz (bool): Whether transpose data from Z, Y, X to X, Y, Z.
             Defaults to False.
-        backend_args (dict): Arguments to instantiate a file backend.
+        backend_args (dict, Optional): Arguments to instantiate a file backend.
             See https://mmengine.readthedocs.io/en/latest/api/fileio.htm
-            for details. Defaults to ``dict(backend='local')``
+            for details. Defaults to None.
             Notes: mmcv>=2.0.0rc4, mmengine>=0.2.0 required.
     """
 
-    def __init__(
-        self,
-        with_seg=False,
-        decode_backend: str = 'numpy',
-        to_xyz: bool = False,
-        backend_args: dict = dict(backend='local')
-    ) -> None:  # noqa
+    def __init__(self,
+                 with_seg=False,
+                 decode_backend: str = 'numpy',
+                 to_xyz: bool = False,
+                 backend_args: Optional[dict] = None) -> None:  # noqa
         self.with_seg = with_seg
         self.decode_backend = decode_backend
         self.to_xyz = to_xyz
-        self.backend_args = backend_args.copy()
+        self.backend_args = backend_args.copy() if backend_args else None
 
     def transform(self, results: Dict) -> Dict:
         """Functions to load image.

--- a/mmseg/engine/hooks/visualization_hook.py
+++ b/mmseg/engine/hooks/visualization_hook.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
 import warnings
-from typing import Sequence
+from typing import Optional, Sequence
 
 import mmcv
 import mmengine.fileio as fileio
@@ -30,9 +30,9 @@ class SegVisualizationHook(Hook):
         interval (int): The interval of visualization. Defaults to 50.
         show (bool): Whether to display the drawn image. Default to False.
         wait_time (float): The interval of show (s). Defaults to 0.
-        backend_args (dict): Arguments to instantiate a file backend.
+        backend_args (dict, Optional): Arguments to instantiate a file backend.
             See https://mmengine.readthedocs.io/en/latest/api/fileio.htm
-            for details. Defaults to ``dict(backend='local')``
+            for details. Defaults to None.
             Notes: mmcv>=2.0.0rc4, mmengine>=0.2.0 required.
     """
 
@@ -41,7 +41,7 @@ class SegVisualizationHook(Hook):
                  interval: int = 50,
                  show: bool = False,
                  wait_time: float = 0.,
-                 backend_args: dict = dict(backend='local')):
+                 backend_args: Optional[dict] = None):
         self._visualizer: SegLocalVisualizer = \
             SegLocalVisualizer.get_current_instance()
         self.interval = interval
@@ -55,7 +55,7 @@ class SegVisualizationHook(Hook):
                           'needs to be excluded.')
 
         self.wait_time = wait_time
-        self.backend_args = backend_args.copy()
+        self.backend_args = backend_args.copy() if backend_args else None
         self.draw = draw
         if not self.draw:
             warnings.warn('The draw is False, it means that the '

--- a/tests/test_datasets/test_loading.py
+++ b/tests/test_datasets/test_loading.py
@@ -57,9 +57,9 @@ class TestLoading:
         results = transform(copy.deepcopy(results))
         assert results['gt_seg_map'].shape == (288, 512)
         assert results['gt_seg_map'].dtype == np.uint8
-        # assert repr(transform) == transform.__class__.__name__ + \
-        #     "(reduce_zero_label=True, imdecode_backend='pillow', " + \
-        #     "backend_args={'backend': 'local'})"
+        assert repr(transform) == transform.__class__.__name__ + \
+            "(reduce_zero_label=True, imdecode_backend='pillow', " + \
+            'backend_args=None)'
 
         # reduce_zero_label
         transform = LoadAnnotations(reduce_zero_label=True)
@@ -241,7 +241,7 @@ class TestLoading:
                                    "decode_backend='nifti', "
                                    'to_xyz=False, '
                                    'to_float32=True, '
-                                   "backend_args={'backend': 'local'})")
+                                   'backend_args=None)')
 
     def test_load_biomedical_annotation(self):
         results = dict(
@@ -265,7 +265,7 @@ class TestLoading:
                                    'with_seg=True, '
                                    "decode_backend='numpy', "
                                    'to_xyz=False, '
-                                   "backend_args={'backend': 'local'})")
+                                   'backend_args=None)')
 
         transform = LoadBiomedicalData(with_seg=False)
         results = transform(copy.deepcopy(input_results))
@@ -275,4 +275,4 @@ class TestLoading:
                                    'with_seg=False, '
                                    "decode_backend='numpy', "
                                    'to_xyz=False, '
-                                   "backend_args={'backend': 'local'})")
+                                   'backend_args=None)')


### PR DESCRIPTION
## Motivation

In MMEngine >= 0.2.0, it might directly determine what the backend is by using the `data_root` path.

## Modification

All default `backend_args` values.


