### PR TITLE
[Fix] Fix pretrained models of SegNeXt in master branch.

### DIFF
--- a/configs/segnext/README.md
+++ b/configs/segnext/README.md
@@ -31,10 +31,6 @@ We present SegNeXt, a simple convolutional network architecture for semantic seg
 }
 ```
 
-## Pretrained model
-
-The pretrained model could be found [here](https://cloud.tsinghua.edu.cn/d/c15b25a6745946618462/) from [original repo](https://github.com/Visual-Attention-Network/SegNeXt). You can download and put them in `./pretrain` folder.
-
 ## Results and models
 
 ### ADE20K
@@ -47,6 +43,8 @@ The pretrained model could be found [here](https://cloud.tsinghua.edu.cn/d/c15b2
 | SegNeXt | MSCAN-L  | 512x512   | 160000  | 43.32    | 22.91          | 50.99 | 52.10         | [config](https://github.com/open-mmlab/mmsegmentation/blob/master/configs/segnext/segnext_mscan-l_1x16_512x512_adamw_160k_ade20k.py) | [model](https://download.openmmlab.com/mmsegmentation/v0.5/segnext/segnext_mscan-l_1x16_512x512_adamw_160k_ade20k/segnext_mscan-l_1x16_512x512_adamw_160k_ade20k_20230209_172055-19b14b63.pth) \| [log](https://download.openmmlab.com/mmsegmentation/v0.5/segnext/segnext_mscan-l_1x16_512x512_adamw_160k_ade20k/segnext_mscan-l_1x16_512x512_adamw_160k_ade20k_20230209_172055.log.json) |
 
 Note:
+
+- The keys of our provided pretrained models are different from [original weights](https://cloud.tsinghua.edu.cn/d/c15b25a6745946618462/) released in [original repo](https://github.com/Visual-Attention-Network/SegNeXt), please use them correctly.
 
 - The total batch size is 16. We trained for SegNeXt with a single GPU as the performance degrades significantly when using`SyncBN` (mainly in `OverlapPatchEmbed` modules of `MSCAN`) of PyTorch 1.9.
 

--- a/configs/segnext/README.md
+++ b/configs/segnext/README.md
@@ -44,7 +44,7 @@ We present SegNeXt, a simple convolutional network architecture for semantic seg
 
 Note:
 
-- The keys of our provided pretrained models are different from [original weights](https://cloud.tsinghua.edu.cn/d/c15b25a6745946618462/) released in [original repo](https://github.com/Visual-Attention-Network/SegNeXt), please use them correctly.
+- When we integrated SegNeXt into MMSegmentation, we modified some layers' names to make them more precise and concise without changing the model architecture. Therefore, the keys of pre-trained weights are different from the [original weights](https://cloud.tsinghua.edu.cn/d/c15b25a6745946618462/), but don't worry about these changes. we have converted them and uploaded the checkpoints, you might find URL of pre-trained checkpoints in config files and can use them directly for training.
 
 - The total batch size is 16. We trained for SegNeXt with a single GPU as the performance degrades significantly when using`SyncBN` (mainly in `OverlapPatchEmbed` modules of `MSCAN`) of PyTorch 1.9.
 

--- a/configs/segnext/segnext_mscan-b_1x16_512x512_adamw_160k_ade20k.py
+++ b/configs/segnext/segnext_mscan-b_1x16_512x512_adamw_160k_ade20k.py
@@ -1,12 +1,13 @@
 _base_ = './segnext_mscan-t_1x16_512x512_adamw_160k_ade20k.py'
 # model settings
+checkpoint_file = 'https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/segnext/mscan_b_20230227-3ab7d230.pth'  # noqa
 ham_norm_cfg = dict(type='GN', num_groups=32, requires_grad=True)
 model = dict(
     type='EncoderDecoder',
     backbone=dict(
         embed_dims=[64, 128, 320, 512],
         depths=[3, 3, 12, 3],
-        init_cfg=dict(type='Pretrained', checkpoint='pretrain/mscan_b.pth'),
+        init_cfg=dict(type='Pretrained', checkpoint=checkpoint_file),
         drop_path_rate=0.1,
         norm_cfg=dict(type='BN', requires_grad=True)),
     decode_head=dict(

--- a/configs/segnext/segnext_mscan-l_1x16_512x512_adamw_160k_ade20k.py
+++ b/configs/segnext/segnext_mscan-l_1x16_512x512_adamw_160k_ade20k.py
@@ -1,12 +1,13 @@
 _base_ = './segnext_mscan-t_1x16_512x512_adamw_160k_ade20k.py'
 # model settings
+checkpoint_file = 'https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/segnext/mscan_l_20230227-cef260d4.pth'  # noqa
 ham_norm_cfg = dict(type='GN', num_groups=32, requires_grad=True)
 model = dict(
     type='EncoderDecoder',
     backbone=dict(
         embed_dims=[64, 128, 320, 512],
         depths=[3, 5, 27, 3],
-        init_cfg=dict(type='Pretrained', checkpoint='pretrain/mscan_l.pth'),
+        init_cfg=dict(type='Pretrained', checkpoint=checkpoint_file),
         drop_path_rate=0.3,
         norm_cfg=dict(type='BN', requires_grad=True)),
     decode_head=dict(

--- a/configs/segnext/segnext_mscan-s_1x16_512x512_adamw_160k_ade20k.py
+++ b/configs/segnext/segnext_mscan-s_1x16_512x512_adamw_160k_ade20k.py
@@ -1,12 +1,13 @@
 _base_ = './segnext_mscan-t_1x16_512x512_adamw_160k_ade20k.py'
 # model settings
+checkpoint_file = 'https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/segnext/mscan_s_20230227-f33ccdf2.pth'  # noqa
 ham_norm_cfg = dict(type='GN', num_groups=32, requires_grad=True)
 model = dict(
     type='EncoderDecoder',
     backbone=dict(
         embed_dims=[64, 128, 320, 512],
         depths=[2, 2, 4, 2],
-        init_cfg=dict(type='Pretrained', checkpoint='./pretrain/mscan_s.pth'),
+        init_cfg=dict(type='Pretrained', checkpoint=checkpoint_file),
         norm_cfg=dict(type='BN', requires_grad=True)),
     decode_head=dict(
         type='LightHamHead',

--- a/configs/segnext/segnext_mscan-t_1x16_512x512_adamw_160k_ade20k.py
+++ b/configs/segnext/segnext_mscan-t_1x16_512x512_adamw_160k_ade20k.py
@@ -2,13 +2,14 @@ _base_ = [
     '../_base_/default_runtime.py', '../_base_/schedules/schedule_160k.py'
 ]
 # model settings
+checkpoint_file = 'https://download.openmmlab.com/mmsegmentation/v0.5/pretrain/segnext/mscan_t_20230227-119e8c9f.pth'  # noqa
 ham_norm_cfg = dict(type='GN', num_groups=32, requires_grad=True)
 model = dict(
     type='EncoderDecoder',
     pretrained=None,
     backbone=dict(
         type='MSCAN',
-        init_cfg=dict(type='Pretrained', checkpoint='./pretrain/mscan_t.pth'),
+        init_cfg=dict(type='Pretrained', checkpoint=checkpoint_file),
         embed_dims=[32, 64, 160, 256],
         mlp_ratios=[8, 8, 4, 4],
         drop_rate=0.0,


### PR DESCRIPTION
## Motivation

Transfer keys of each `mscan_x.pth` pretrained models of SegNeXt, and upload them in the website.

The reason of transferring keys is we modify original repo [`.dwconv.dwconv.xxx`](https://github.com/Visual-Attention-Network/SegNeXt/blob/main/mmseg/models/backbones/mscan.py#L21) to [`.dwconv.xxx`](https://github.com/open-mmlab/mmsegmentation/blob/master/mmseg/models/backbones/mscan.py#L43).