### PR TITLE
[WIP][Feature] Support MMEval mean IoU metric.

### DIFF
--- a/mmseg/evaluation/__init__.py
+++ b/mmseg/evaluation/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .metrics import CityscapesMetric, IoUMetric
+from .metrics import CityscapesMetric, IoUMetric, MMEvalIoUMetric
 
-__all__ = ['IoUMetric', 'CityscapesMetric']
+__all__ = ['IoUMetric', 'CityscapesMetric', 'MMEvalIoUMetric']

--- a/mmseg/evaluation/metrics/__init__.py
+++ b/mmseg/evaluation/metrics/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .citys_metric import CityscapesMetric
 from .iou_metric import IoUMetric
+from .mmeval_iou_metric import MMEvalIoUMetric
 
-__all__ = ['IoUMetric', 'CityscapesMetric']
+__all__ = ['IoUMetric', 'CityscapesMetric', 'MMEvalIoUMetric']

--- a/mmseg/evaluation/metrics/mmeval_iou_metric.py
+++ b/mmseg/evaluation/metrics/mmeval_iou_metric.py
@@ -49,7 +49,6 @@ class MMEvalIoUMetric(MeanIoU):
     def __init__(self,
                  output_dir: Optional[str] = None,
                  format_only: bool = False,
-                 dist_backend='torch_cuda',
                  **kwargs):
 
         if isinstance(self, IoUMetric):
@@ -58,8 +57,7 @@ class MMEvalIoUMetric(MeanIoU):
                 'please install MMEval first.')
 
         # Changes the default value of `classwise_results` to True.
-        super().__init__(
-            classwise_results=True, dist_backend=dist_backend, **kwargs)
+        super().__init__(classwise_results=True, **kwargs)
 
         self.output_dir = output_dir
         if self.output_dir and is_main_process():

--- a/mmseg/evaluation/metrics/mmeval_iou_metric.py
+++ b/mmseg/evaluation/metrics/mmeval_iou_metric.py
@@ -1,0 +1,136 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
+from typing import Optional, Sequence
+
+import numpy as np
+from mmengine import mkdir_or_exist
+from mmengine.dist import is_main_process
+from mmengine.logging import print_log
+from PIL import Image
+from prettytable import PrettyTable
+
+try:
+    import mmeval
+    from mmeval.metrics import MeanIoU
+except ImportError:
+    from .iou_metric import IoUMetric as MeanIoU
+
+from mmseg.registry import METRICS
+
+
+@METRICS.register_module()
+class MMEvalIoUMetric(MeanIoU):
+    """MeanIoU evaluation metric.
+
+    Args:
+        num_classes (int, optional): The number of classes. If None, it will be
+            obtained from the 'num_classes' or 'classes' field in
+            `self.dataset_meta`. Defaults to None.
+        ignore_index (int, optional): Index that will be ignored in evaluation.
+            Defaults to 255.
+        nan_to_num (int, optional): If specified, NaN values will be replaced
+            by the numbers defined by the user. Defaults to None.
+        beta (int, optional): Determines the weight of recall in the F-score.
+            Defaults to 1.
+        classwise_results (bool, optional): Whether to return the computed
+            results of each class. Defaults to False.
+        output_dir (str): The directory for output prediction. Defaults to
+            None.
+        format_only (bool): Only format result for results commit without
+            perform evaluation. It is useful when you want to save the result
+            to a specific format and submit it to the test server.
+            Defaults to False.
+
+    Keyword Args:
+        dataset_meta (dict, optional): Meta information of the dataset, this is
+            required for some metrics that require dataset information.
+            Defaults to None.
+        dist_collect_mode (str, optional): The method of concatenating the
+            collected synchronization results. This depends on how the
+            distributed data is split. Currently only 'unzip' and 'cat' are
+            supported. For PyTorch's ``DistributedSampler``, 'unzip' should
+            be used. Defaults to 'unzip'.
+        dist_backend (str, optional): The name of the distributed communication
+            backend, you can get all the backend names through
+            ``mmeval.core.list_all_backends()``.
+            If None, use the default backend. Defaults to None.
+    """
+
+    def __init__(self,
+                 num_classes: Optional[int] = None,
+                 ignore_index: Optional[int] = 255,
+                 nan_to_num: Optional[int] = None,
+                 beta: Optional[int] = 1,
+                 classwise_results: Optional[bool] = False,
+                 output_dir: Optional[str] = None,
+                 format_only: bool = False,
+                 **kwargs):
+
+        if not isinstance(super(), mmeval.MeanIoU):
+            raise TypeError(
+                'MMEvalIoUMetric must be a subclass of mmeval.MeanIoU,'
+                'please install MMEval first.')
+
+        super().__init__(num_classes, ignore_index, nan_to_num, beta,
+                         classwise_results, **kwargs)
+
+        self.output_dir = output_dir
+        if self.output_dir and is_main_process():
+            mkdir_or_exist(self.output_dir)
+        self.format_only = format_only
+
+    def process(self, data_batch: dict, data_samples: Sequence[dict]) -> None:
+        """Process the data_batch and data_samples. Parse predictions and
+        labels from ``data_samples`` and invoke ``self.add``.
+
+        Args:
+            data_batch (dict): The data batch.
+            data_samples (Sequence[dict]): The data samples.
+        """
+        predictions, labels = []
+        for data_sample in data_samples:
+            pred = data_sample['pred_sem_seg']['data'].squeeze()
+            if not self.format_only:
+                label = data_sample['gt_sem_seg']['data'].squeeze().to(pred)
+                predictions.append(pred)
+                labels.append(label)
+            # format_result:
+            if self.output_dir:
+                basename = osp.splitext(osp.basename(
+                    data_sample['img_path']))[0]
+                png_filename = osp.abspath(
+                    osp.join(self.output_dir, f'{basename}.png'))
+                output_mask = pred.cpu().numpy()
+                # The index range of official ADE20k dataset is from 0 to 150.
+                # But the index range of output is from 0 to 149.
+                # That is because we set reduce_zero_label=True.
+                if data_sample.get('reduce_zero_label', False):
+                    output_mask += 1
+                output = Image.fromarray(output_mask.astype(np.uint8))
+                output.save(png_filename)
+
+        self.add(predictions, labels)
+
+    def evaluate(self, *args, **kwargs) -> dict:
+        metric_results = self.compute(*args, **kwargs)
+        self.reset()
+
+        classwise_results = metric_results['classwise_results']
+        del metric_results['classwise_results']
+
+        # Pretty table of the metric results per class.
+        summary_table = PrettyTable()
+        summary_table.add_column('Class', self.dataset_meta['classes'])
+        for key, value in classwise_results.items():
+            value = np.round(value * 100, 2)
+            summary_table.add_column(key, value)
+
+        print_log('per class results:', logger='current')
+        print_log('\n' + summary_table.get_string(), logger='current')
+
+        # Multiply value by 100 to convert to percentage and rounding.
+        evaluate_results = {
+            k: round(v * 100, 2)
+            for k, v in metric_results.items()
+        }
+        return evaluate_results

--- a/mmseg/evaluation/metrics/mmeval_iou_metric.py
+++ b/mmseg/evaluation/metrics/mmeval_iou_metric.py
@@ -1,12 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
-from typing import Optional, Sequence
+# import os.path as osp
+from typing import Sequence
 
 import numpy as np
-from mmengine import mkdir_or_exist
-from mmengine.dist import is_main_process
+# from mmengine import mkdir_or_exist
+# from mmengine.dist import is_main_process
 from mmengine.logging import print_log
-from PIL import Image
+# from PIL import Image
 from prettytable import PrettyTable
 
 from .iou_metric import IoUMetric
@@ -55,35 +55,26 @@ class MMEvalIoUMetric(MeanIoU):
             If None, use the default backend. Defaults to None.
     """
 
-    def __init__(self,
-                 num_classes: Optional[int] = None,
-                 ignore_index: Optional[int] = 255,
-                 nan_to_num: Optional[int] = None,
-                 beta: Optional[int] = 1,
-                 output_dir: Optional[str] = None,
-                 format_only: bool = False,
-                 **kwargs):
+    def __init__(self, dist_backend='torch_cuda', **kwargs):
 
         if isinstance(self, IoUMetric):
             raise TypeError(
                 'MMEvalIoUMetric must be a subclass of mmeval.MeanIoU,'
                 'please install MMEval first.')
 
-        super().__init__(num_classes, ignore_index, nan_to_num, beta, True,
-                         **kwargs)
-
-        self.output_dir = output_dir
-        if self.output_dir and is_main_process():
-            mkdir_or_exist(self.output_dir)
-        self.format_only = format_only
+        # Changes the default value of `classwise_results` to True.
+        super().__init__(
+            classwise_results=True, dist_backend=dist_backend, **kwargs)
 
     def process(self, data_batch: dict, data_samples: Sequence[dict]) -> None:
-        """Process the data_batch and data_samples. Parse predictions and
-        labels from ``data_samples`` and invoke ``self.add``.
+        """Process one batch of data and data_samples.
+
+        Parse predictions and labels from ``data_samples`` and invoke
+        ``self.add``.
 
         Args:
-            data_batch (dict): The data batch.
-            data_samples (Sequence[dict]): The data samples.
+            data_batch (dict): A batch of data from the dataloader.
+            data_samples (Sequence[dict]): A batch of outputs from the model.
         """
         predictions, labels = [], []
         for data_sample in data_samples:
@@ -92,21 +83,6 @@ class MMEvalIoUMetric(MeanIoU):
             predictions.append(pred_label)
             labels.append(label)
 
-            # format_result:
-            if self.output_dir:
-                basename = osp.splitext(osp.basename(
-                    data_sample['img_path']))[0]
-                png_filename = osp.abspath(
-                    osp.join(self.output_dir, f'{basename}.png'))
-                output_mask = pred_label.cpu().numpy()
-                # The index range of official ADE20k dataset is from 0 to 150.
-                # But the index range of output is from 0 to 149.
-                # That is because we set reduce_zero_label=True.
-                if data_sample.get('reduce_zero_label', False):
-                    output_mask += 1
-                output = Image.fromarray(output_mask.astype(np.uint8))
-                output.save(png_filename)
-
         self.add(predictions, labels)
 
     def evaluate(self, *args, **kwargs):
@@ -114,8 +90,6 @@ class MMEvalIoUMetric(MeanIoU):
 
         This method would be invoked by ``mmengine.Evaluator``.
         """
-        if self.format_only:
-            return {}
         metric_results = self.compute(*args, **kwargs)
         self.reset()
 

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,3 @@
 cityscapesscripts
+mmeval
 nibabel

--- a/tests/test_evaluation/test_metrics/test_mmeval_iout_metric.py
+++ b/tests/test_evaluation/test_metrics/test_mmeval_iout_metric.py
@@ -1,0 +1,73 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import unittest
+
+import mmeval
+import torch
+from mmengine.structures import PixelData
+
+from mmseg.evaluation import IoUMetric, MMEvalIoUMetric
+from mmseg.structures import SegDataSample
+from mmseg.utils import SampleList
+
+
+class TestMMEvalIoUMetric(unittest.TestCase):
+
+    @unittest.skipIf(mmeval is None, 'MMEval is not installed.')
+    def test_evalluate(self):
+        dataset_metas = {
+            'classes': ('person', 'rider', 'car', 'truck', 'bus', 'train',
+                        'motorcycle', 'bicycle')
+        }
+        data_samples = self._demo_mm_inputs(1, num_classes=8)
+        mmeval_iou_metric = MMEvalIoUMetric(dataset_meta=dataset_metas)
+        iou_metric = IoUMetric(iou_metrics=['mIoU', 'mFscore', 'mDice'])
+        iou_metric.dataset_meta = dataset_metas
+        mmeval_iou_metric.process({}, data_samples)
+        iou_metric.process({}, data_samples)
+
+        results = mmeval_iou_metric.evaluate()
+        iou_results = iou_metric.evaluate(len(data_samples))
+
+        assert results['mIoU'] == iou_results['mIoU']
+        assert results['aAcc'] == iou_results['aAcc']
+        assert results['mAcc'] == iou_results['mAcc']
+        assert results['mFscore'] == iou_results['mFscore']
+        assert results['mDice'] == iou_results['mDice']
+        assert results['mPrecision'] == iou_results['mPrecision']
+        assert results['mRecall'] == iou_results['mRecall']
+
+    def _demo_mm_inputs(self,
+                        batch_size=2,
+                        image_shapes=(3, 64, 64),
+                        num_classes=5) -> SampleList:
+        """Create a superset of inputs needed to run test or train batches.
+
+        Args:
+            batch_size (int): batch size. Default to 2.
+            image_shapes (List[tuple], Optional): image shape.
+                Default to (3, 64, 64)
+            num_classes (int): number of different classes.
+                Default to 5.
+        """
+        if isinstance(image_shapes, list):
+            assert len(image_shapes) == batch_size
+        else:
+            image_shapes = [image_shapes] * batch_size
+
+        data_samples = []
+        for idx in range(batch_size):
+            image_shape = image_shapes[idx]
+            _, h, w = image_shape
+            data_sample = SegDataSample()
+            preds = torch.randint(0, num_classes, (1, h, w), dtype=torch.long)
+            gt_sem_seg = torch.randint(
+                0, num_classes, (1, h, w), dtype=torch.long)
+            data_sample.set_data({
+                'pred_sem_seg':
+                PixelData(**{'data': preds}),
+                'gt_sem_seg':
+                PixelData(**{'data': gt_sem_seg})
+            })
+            data_samples.append(data_sample.to_dict())
+
+        return data_samples

--- a/tests/test_evaluation/test_metrics/test_mmeval_iout_metric.py
+++ b/tests/test_evaluation/test_metrics/test_mmeval_iout_metric.py
@@ -1,13 +1,17 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import unittest
 
-import mmeval
 import torch
 from mmengine.structures import PixelData
 
 from mmseg.evaluation import IoUMetric, MMEvalIoUMetric
 from mmseg.structures import SegDataSample
 from mmseg.utils import SampleList
+
+try:
+    import mmeval
+except ImportError:
+    mmeval = None
 
 
 class TestMMEvalIoUMetric(unittest.TestCase):


### PR DESCRIPTION

## Motivation

As title.

## Modification

Add a wrapper to support mmeval.metrics.MeanIoU

## BC-breaking (Optional)

None

## Use cases (Optional)

Modify the config files like:
```python
# default metric
val_evaluator = dict(type='IoUMetric', iou_metrics=['mIoU'])
test_evaluator = val_evaluator

# MMEvalIoUMetric
val_evaluator = dict(type='MMEvalIoUMetric')
test_evaluator = val_evaluator
```

## Checklist

- [ ] MMEval >= 0.3.0 https://github.com/open-mmlab/mmeval/pull/108
