### PR TITLE
expose the weight in the decode head and in the loading pipeline

### DIFF
--- a/mmseg/datasets/pipelines/loading.py
+++ b/mmseg/datasets/pipelines/loading.py
@@ -147,6 +147,8 @@ class LoadAnnotations(object):
             gt_semantic_seg_copy = gt_semantic_seg.copy()
             for old_id, new_id in results['label_map'].items():
                 gt_semantic_seg[gt_semantic_seg_copy == old_id] = new_id
+        if "weight" in results["ann_info"]:
+            results["weight"] = results["ann_info"]["weight"]    
         results['gt_semantic_seg'] = gt_semantic_seg
         results['seg_fields'].append('gt_semantic_seg')
         return results

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -296,7 +296,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
         # item weight
         if weight is not None:
             # make dimensionality compatible (given )
-            for _ in seg_label.dim() - 1: 
+            for _ in range(seg_label.dim() - 1):
                 weight = weight.unsqueeze(-1)
 
         # combine them

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -240,7 +240,10 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             dict[str, Tensor]: a dictionary of loss components
         """
         seg_logits = self(inputs)
-        losses = self.losses(seg_logits, gt_semantic_seg)
+        weight = None
+        if "weight" in img_metas[0]:
+            weight = torch.Tensor([meta["weight"] for meta in img_metas])
+        losses = self.losses(seg_logits, gt_semantic_seg, weight)
         return losses
 
     def forward_test(self, inputs, img_metas, test_cfg):
@@ -268,7 +271,7 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
         return output
 
     @force_fp32(apply_to=('seg_logit', ))
-    def losses(self, seg_logit, seg_label):
+    def losses(self, seg_logit, seg_label, weight=None):
         """Compute segmentation loss."""
         loss = dict()
         if self.downsample_label_ratio > 0:
@@ -283,11 +286,24 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             size=seg_label.shape[2:],
             mode='bilinear',
             align_corners=self.align_corners)
+
+        # seg weight mask from sampler
+        seg_weight = None
         if self.sampler is not None:
             seg_weight = self.sampler.sample(seg_logit, seg_label)
-        else:
-            seg_weight = None
         seg_label = seg_label.squeeze(1)
+
+        # item weight
+        if weight is not None:
+            # make dimensionality compatible (given )
+            for _ in seg_label.dim() - 1: 
+                weight = weight.unsqueeze(-1)
+
+        # combine them
+        if weight is not None and seg_weight is not None:
+            seg_weight = seg_weight * weight
+        elif seg_weight is None:
+            seg_weight = weight
 
         if not isinstance(self.loss_decode, nn.ModuleList):
             losses_decode = [self.loss_decode]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Sample weighting is a common strategy used to deal with imbalanced datasets. The idea is to weight the contribution to the loss of each item on the dataset based to its frequency. 

There are different strategies, such as Inverso of Number of Samples (INS), Inverse of Square Root of Number of Samples (ISNS) or Effective Number of Samples ([ENS](https://openaccess.thecvf.com/content_CVPR_2019/papers/Cui_Class-Balanced_Loss_Based_on_Effective_Number_of_Samples_CVPR_2019_paper.pdf)https://openaccess.thecvf.com/content_CVPR_2019/papers/Cui_Class-Balanced_Loss_Based_on_Effective_Number_of_Samples_CVPR_2019_paper.pdf), to cite a few (see a brief summary [here](https://medium.com/gumgum-tech/handling-class-imbalance-by-introducing-sample-weighting-in-the-loss-function-3bdebd8203b4))

## Modification

The code already supports providing an item-wise weight to the loss. However, that weight is not exposed at the level of the head, so it can not be injected at runtime. 

There are mechanisms to weight different classes, or different losses (multi-loss scenario). But as far as I understand, it is not possible to carry out sample weighting.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?

No, the changes only extend the functionality without affecting any current scenario.

## Use cases (Optional)

Support added for sample weighting. In order to do so, the dataset just needs to add a float scalar named "weight" to the annotation info.

The loading pipeline has been uploaded to pick it up, and it will be injected to the loss function.

This should be quite useful when dealing with imbalanced datasets.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.

## Issue

https://github.com/open-mmlab/mmdetection/issues/9905