### PR TITLE
[Typo] Change indexes to indices

### DIFF
--- a/mmseg/datasets/dataset_wrappers.py
+++ b/mmseg/datasets/dataset_wrappers.py
@@ -106,11 +106,11 @@ class MultiImageMixDataset:
                 continue
 
             if hasattr(transform, 'get_indices'):
-                indexes = transform.get_indices(self.dataset)
-                if not isinstance(indexes, collections.abc.Sequence):
-                    indexes = [indexes]
+                indices = transform.get_indices(self.dataset)
+                if not isinstance(indices, collections.abc.Sequence):
+                    indices = [indices]
                 mix_results = [
-                    copy.deepcopy(self.dataset[index]) for index in indexes
+                    copy.deepcopy(self.dataset[index]) for index in indices
                 ]
                 results['mix_results'] = mix_results
 

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -1029,17 +1029,17 @@ class RandomMosaic(BaseTransform):
         return results
 
     def get_indices(self, dataset: MultiImageMixDataset) -> list:
-        """Call function to collect indexes.
+        """Call function to collect indices.
 
         Args:
             dataset (:obj:`MultiImageMixDataset`): The dataset.
 
         Returns:
-            list: indexes.
+            list: indices.
         """
 
-        indexes = [random.randint(0, len(dataset)) for _ in range(3)]
-        return indexes
+        indices = [random.randint(0, len(dataset)) for _ in range(3)]
+        return indices
 
     @cache_randomness
     def generate_mosaic_center(self):

--- a/projects/mapillary_dataset/tools/dataset_converters/mapillary.py
+++ b/projects/mapillary_dataset/tools/dataset_converters/mapillary.py
@@ -106,7 +106,7 @@ def mapillary_colormap2label(colormap: np.ndarray) -> list:
 
     Returns:
         list: values are mask labels,
-              indexes are  palette's convert results.、
+              indices are palette's convert results.
     """
     colormap2label = np.zeros(256**3, dtype=np.longlong)
     for i, colormap_ in enumerate(colormap):


### PR DESCRIPTION
## Modification

I just replaced the `indexes` variable name with `indices` for naming consistency.
