### PR TITLE
[Feature] Support mmseg with NPU backend.

### DIFF
--- a/tests/test_utils/test_util_distribution.py
+++ b/tests/test_utils/test_util_distribution.py
@@ -46,6 +46,13 @@ def test_build_dp():
             mludp = build_dp(model, 'mlu')
             assert isinstance(mludp, MLUDataParallel)
 
+    if digit_version(mmcv.__version__) >= digit_version('1.7.0'):
+        from mmcv.device.npu import NPUDataParallel
+        from mmcv.utils import IS_NPU_AVAILABLE
+        if IS_NPU_AVAILABLE:
+            npu_dp = model.npu(model, 'npu')
+            assert isinstance(npu_dp, NPUDataParallel)
+
 
 @patch('torch.distributed._broadcast_coalesced', mock)
 @patch('torch.distributed.broadcast', mock)
@@ -66,3 +73,11 @@ def test_build_ddp():
             mluddp = build_ddp(
                 model, 'mlu', device_ids=[0], process_group=MagicMock())
             assert isinstance(mluddp, MLUDistributedDataParallel)
+
+    if digit_version(mmcv.__version__) >= digit_version('1.7.0'):
+        from mmcv.device.npu import NPUDistributedDataParallel
+        from mmcv.utils import IS_NPU_AVAILABLE
+        if IS_NPU_AVAILABLE:
+            npu_ddp = build_ddp(
+                model, 'npu', device_ids=[0], process_group=MagicMock())
+            assert isinstance(npu_ddp, NPUDistributedDataParallel)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Added ascending device support in mmseg.

## Modification

The main modification points are as follows:
   We added an NPU device in the DDP scenario and DP scenario when using the NPU.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
None

## Use cases (Optional)

We tested [fcn_unet_s5-d16_4x4_512x1024_160k_cityscapes.py](https://github.com/open-mmlab/mmsegmentation/blob/master/configs/unet/fcn_unet_s5-d16_4x4_512x1024_160k_cityscapes.py) .

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
