### PR TITLE
Fix bug that cannot use both '--tta' and '--out'

### DIFF
--- a/mmseg/models/segmentors/seg_tta.py
+++ b/mmseg/models/segmentors/seg_tta.py
@@ -42,7 +42,8 @@ class SegTTAModel(BaseTTAModel):
             data_sample = SegDataSample(
                 **{
                     'pred_sem_seg': PixelData(data=seg_pred),
-                    'gt_sem_seg': data_samples[0].gt_sem_seg
+                    'gt_sem_seg': data_samples[0].gt_sem_seg,
+                    'img_path': data_samples[0].img_path
                 })
             predictions.append(data_sample)
         return predictions

--- a/mmseg/structures/seg_data_sample.py
+++ b/mmseg/structures/seg_data_sample.py
@@ -90,3 +90,15 @@ class SegDataSample(BaseDataElement):
     @seg_logits.deleter
     def seg_logits(self) -> None:
         del self._seg_logits
+
+    @property
+    def img_path(self) -> str:
+        return self._img_path
+    
+    @img_path.setter
+    def img_path(self, value: str) -> None:
+        self.set_field(value, '_img_path', dtype=str)
+
+    @img_path.deleter
+    def img_path(self) -> None:
+        del self._img_path

--- a/mmseg/structures/seg_data_sample.py
+++ b/mmseg/structures/seg_data_sample.py
@@ -11,6 +11,7 @@ class SegDataSample(BaseDataElement):
         - ``gt_sem_seg``(PixelData): Ground truth of semantic segmentation.
         - ``pred_sem_seg``(PixelData): Prediction of semantic segmentation.
         - ``seg_logits``(PixelData): Predicted logits of semantic segmentation.
+        - ``img_path``(str): Filename of the image.
 
     Examples:
          >>> import torch
@@ -94,7 +95,7 @@ class SegDataSample(BaseDataElement):
     @property
     def img_path(self) -> str:
         return self._img_path
-    
+
     @img_path.setter
     def img_path(self, value: str) -> None:
         self.set_field(value, '_img_path', dtype=str)


### PR DESCRIPTION
## Motivation

Fix bug cannot use both '--tta' and '--out' while testing.
For details, please refer to #3064.

## Modification

Add 'img_path' in TTA result.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.