### PR TITLE
Update seg tta py

### DIFF
--- a/mmseg/models/segmentors/seg_tta.py
+++ b/mmseg/models/segmentors/seg_tta.py
@@ -39,11 +39,18 @@ class SegTTAModel(BaseTTAModel):
                             ).to(logits).squeeze(1)
             else:
                 seg_pred = logits.argmax(dim=0)
-            data_sample = SegDataSample(
-                **{
-                    'pred_sem_seg': PixelData(data=seg_pred),
-                    'gt_sem_seg': data_samples[0].gt_sem_seg
-                })
+            if hasattr(data_samples[0], 'gt_sem_seg'): 
+                data_sample = SegDataSample(
+                    **{
+                        'pred_sem_seg': PixelData(data=seg_pred),
+                        'gt_sem_seg': data_samples[0].gt_sem_seg
+                    })
+            else:
+                data_sample = SegDataSample(
+                    **{
+                        'pred_sem_seg': PixelData(data=seg_pred),
+                        'gt_sem_seg': PixelData(data=seg_pred)
+                    }) 
             data_sample.set_metainfo({'img_path': data_samples[0].img_path})
             predictions.append(data_sample)
         return predictions

--- a/mmseg/models/segmentors/seg_tta.py
+++ b/mmseg/models/segmentors/seg_tta.py
@@ -39,7 +39,7 @@ class SegTTAModel(BaseTTAModel):
                             ).to(logits).squeeze(1)
             else:
                 seg_pred = logits.argmax(dim=0)
-            if hasattr(data_samples[0], 'gt_sem_seg'): 
+            if hasattr(data_samples[0], 'gt_sem_seg'):
                 data_sample = SegDataSample(
                     **{
                         'pred_sem_seg': PixelData(data=seg_pred),
@@ -50,7 +50,7 @@ class SegTTAModel(BaseTTAModel):
                     **{
                         'pred_sem_seg': PixelData(data=seg_pred),
                         'gt_sem_seg': PixelData(data=seg_pred)
-                    }) 
+                    })
             data_sample.set_metainfo({'img_path': data_samples[0].img_path})
             predictions.append(data_sample)
         return predictions


### PR DESCRIPTION

## Motivation

When using the - tta command for multi-scale prediction, and the test set is not annotated, although format_only has been set true in test_evaluator,  but SegTTAModel class  still threw error 'AttributeError: 'SegDataSample' object has no attribute '_gt_sem_seg''. 

## Modification

The reason is SegTTAModel  didn't determine if there were annotations in the dataset, so I added the code to make the judgment and let the program run normally on my computer.
