### PR TITLE
[Fix] Fix module PascalContextDataset

### DIFF
--- a/mmseg/datasets/pascal_context.py
+++ b/mmseg/datasets/pascal_context.py
@@ -10,8 +10,8 @@ class PascalContextDataset(BaseSegDataset):
     """PascalContext dataset.
 
     In segmentation map annotation for PascalContext, 0 stands for background,
-    which is included in 60 categories. ``reduce_zero_label`` is set to True.
-    The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
+    which is included in 60 categories. ``reduce_zero_label`` is fixed to
+    False. The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
     fixed to '.png'.
 
     Args:
@@ -49,7 +49,7 @@ class PascalContextDataset(BaseSegDataset):
                  ann_file='',
                  img_suffix='.jpg',
                  seg_map_suffix='.png',
-                 reduce_zero_label=True,
+                 reduce_zero_label=False,
                  **kwargs) -> None:
         super().__init__(
             img_suffix=img_suffix,
@@ -66,8 +66,10 @@ class PascalContextDataset59(BaseSegDataset):
 
     In segmentation map annotation for PascalContext, 0 stands for background,
     which is included in 60 categories. ``reduce_zero_label`` is fixed to
-    False. The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
+    True. The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
     fixed to '.png'.
+    Noted: If the background is 255 and the ids of categories are from 0 to 58,
+    ``reduce_zero_label`` needs to be set to False.
 
     Args:
         ann_file (str): Annotation file path.
@@ -103,7 +105,7 @@ class PascalContextDataset59(BaseSegDataset):
                  ann_file='',
                  img_suffix='.jpg',
                  seg_map_suffix='.png',
-                 reduce_zero_label=False,
+                 reduce_zero_label=True,
                  **kwargs):
         super().__init__(
             img_suffix=img_suffix,

--- a/mmseg/datasets/pascal_context.py
+++ b/mmseg/datasets/pascal_context.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
+import mmengine.fileio as fileio
 
 from mmseg.registry import DATASETS
 from .basesegdataset import BaseSegDataset
@@ -10,8 +10,8 @@ class PascalContextDataset(BaseSegDataset):
     """PascalContext dataset.
 
     In segmentation map annotation for PascalContext, 0 stands for background,
-    which is included in 60 categories. ``reduce_zero_label`` is fixed to
-    False. The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
+    which is included in 60 categories. ``reduce_zero_label`` is set to True.
+    The ``img_suffix`` is fixed to '.jpg' and ``seg_map_suffix`` is
     fixed to '.png'.
 
     Args:
@@ -46,18 +46,18 @@ class PascalContextDataset(BaseSegDataset):
                  [255, 71, 0], [0, 235, 255], [0, 173, 255], [31, 0, 255]])
 
     def __init__(self,
-                 ann_file: str,
+                 ann_file='',
                  img_suffix='.jpg',
                  seg_map_suffix='.png',
+                 reduce_zero_label=True,
                  **kwargs) -> None:
         super().__init__(
             img_suffix=img_suffix,
             seg_map_suffix=seg_map_suffix,
             ann_file=ann_file,
-            reduce_zero_label=False,
+            reduce_zero_label=reduce_zero_label,
             **kwargs)
-        assert self.file_client.exists(
-            self.data_prefix['img_path']) and osp.isfile(self.ann_file)
+        assert fileio.exists(self.data_prefix['img_path'], self.backend_args)
 
 
 @DATASETS.register_module()
@@ -100,10 +100,10 @@ class PascalContextDataset59(BaseSegDataset):
                  [255, 71, 0], [0, 235, 255], [0, 173, 255], [31, 0, 255]])
 
     def __init__(self,
-                 ann_file: str,
+                 ann_file='',
                  img_suffix='.jpg',
                  seg_map_suffix='.png',
-                 reduce_zero_label=True,
+                 reduce_zero_label=False,
                  **kwargs):
         super().__init__(
             img_suffix=img_suffix,
@@ -111,5 +111,4 @@ class PascalContextDataset59(BaseSegDataset):
             ann_file=ann_file,
             reduce_zero_label=reduce_zero_label,
             **kwargs)
-        assert self.file_client.exists(
-            self.data_prefix['img_path']) and osp.isfile(self.ann_file)
+        assert fileio.exists(self.data_prefix['img_path'], self.backend_args)


### PR DESCRIPTION
## Motivation

-  'PascalContextDataset' object has no attribute 'file_client', it will cause an error. 
-  The attribute ‘ann_file’ is not allowed to be empty, otherwise, an error will be reported.

## Modification
- Replace file_client with fileio
