### PR TITLE
[Doc] fix albumentation typo

### DIFF
--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -68,7 +68,7 @@ pip install mmsegmentation
 ```
 
 **注意：**
-如果你想使用 albumentations，我们建议使用 pip install-U albumentations --no-binary qudida,albumentations 进行安装。如果您仅使用 pip install albumentations>=0.3.2 进行安装，它将同时安装 opencv-python-headless（即使您已经安装了 opencv-python）。我们建议在安装了 albumentations 后检查环境，以确保没有同时安装 opencv-python 和 opencv-python-headless，因为如果两者都安装了，可能会导致意外问题。请参阅[官方文档](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies)了解更多详细信息。
+如果你想使用 albumentations，我们建议使用 pip install -U albumentations --no-binary qudida,albumentations 进行安装。如果您仅使用 pip install albumentations>=0.3.2 进行安装，它将同时安装 opencv-python-headless（即使您已经安装了 opencv-python）。我们建议在安装了 albumentations 后检查环境，以确保没有同时安装 opencv-python 和 opencv-python-headless，因为如果两者都安装了，可能会导致意外问题。请参阅[官方文档](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies)了解更多详细信息。
 
 ## 验证安装
 
@@ -80,7 +80,7 @@ pip install mmsegmentation
 mim download mmsegmentation --config pspnet_r50-d8_512x1024_40k_cityscapes --dest .
 ```
 
-下载将需要几秒钟或更长时间，这取决于你的网络环境。完成后，你会在当前文件夹中发现两个文件`pspnet_r50-d8_512x1024_40k_cityscapes.py`和`pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth`。
+下载将需要几秒钟或更长时间，这取决于你的网络环境。完成后，你会在当前文件夹中发现两个文件 `pspnet_r50-d8_512x1024_40k_cityscapes.py`和 `pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth`。
 
 **第二步** 验证推理示例
 
@@ -90,7 +90,7 @@ mim download mmsegmentation --config pspnet_r50-d8_512x1024_40k_cityscapes --des
 python demo/image_demo.py demo/demo.png pspnet_r50-d8_512x1024_40k_cityscapes.py pspnet_r50-d8_512x1024_40k_cityscapes_20200605_003338-2966598c.pth --device cpu --out-file result.jpg
 ```
 
-你会在你的当前文件夹中看到一个新的图像`result.jpg`，其中的分割掩膜覆盖在所有对象上。
+你会在你的当前文件夹中看到一个新的图像 `result.jpg`，其中的分割掩膜覆盖在所有对象上。
 
 如果您是**作为 PyThon 包安装**，那么可以打开您的 Python 解释器，复制并粘贴如下代码：
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

There is a typing error in the mmsegmentation document that supports estimation.

## Modification

Fix the typing error.
from "pip install-U albumentations –no-binary qudida,albumentations " to "pip install -U albumentations --no-binary qudida,albumentations".


## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
