### PR TITLE
[Fix] Add bpe_simple_vocab_16e6.txt.gz to release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include requirements/*.txt
 include mmseg/.mim/model-index.yml
-include mmaction/.mim/dataset-index.yml
+include mmseg/utils/bpe_simple_vocab_16e6.txt.gz
 recursive-include mmseg/.mim/configs *.py *.yaml
 recursive-include mmseg/.mim/tools *.py *.sh


### PR DESCRIPTION
## Motivation

https://github.com/open-mmlab/mmsegmentation/issues/3383

## Modification

- Add bpe_simple_vocab_16e6.txt.gz to `MANIFEST.in`


