### PR TITLE
[Bugfix] test resize with pad_shape

### DIFF
--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -350,10 +350,14 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             Tensor: Outputs segmentation logits map.
         """
 
-        if 'pad_shape' in batch_img_metas[0]:
-            size = batch_img_metas[0]['pad_shape']
+        if isinstance(batch_img_metas[0]['img_shape'], torch.Size):
+            # slide inference
+            size = batch_img_metas[0]['img_shape']
+        elif 'pad_shape' in batch_img_metas[0]:
+            size = batch_img_metas[0]['pad_shape'][:2]
         else:
             size = batch_img_metas[0]['img_shape']
+
         seg_logits = resize(
             input=seg_logits,
             size=size,

--- a/mmseg/models/decode_heads/decode_head.py
+++ b/mmseg/models/decode_heads/decode_head.py
@@ -350,9 +350,13 @@ class BaseDecodeHead(BaseModule, metaclass=ABCMeta):
             Tensor: Outputs segmentation logits map.
         """
 
+        if 'pad_shape' in batch_img_metas[0]:
+            size = batch_img_metas[0]['pad_shape']
+        else:
+            size = batch_img_metas[0]['img_shape']
         seg_logits = resize(
             input=seg_logits,
-            size=batch_img_metas[0]['img_shape'],
+            size=size,
             mode='bilinear',
             align_corners=self.align_corners)
         return seg_logits

--- a/mmseg/models/decode_heads/san_head.py
+++ b/mmseg/models/decode_heads/san_head.py
@@ -586,8 +586,11 @@ class SideAdapterCLIPHead(BaseDecodeHead):
         """
         mask_pred = seg_logits[0]
         cls_score = seg_logits[1]
-        if 'pad_shape' in batch_img_metas[0]:
-            size = batch_img_metas[0]['pad_shape']
+        if isinstance(batch_img_metas[0]['img_shape'], torch.Size):
+            # slide inference
+            size = batch_img_metas[0]['img_shape']
+        elif 'pad_shape' in batch_img_metas[0]:
+            size = batch_img_metas[0]['pad_shape'][:2]
         else:
             size = batch_img_metas[0]['img_shape']
         # upsample mask

--- a/projects/hssn/decode_head/sep_aspp_contrast_head.py
+++ b/projects/hssn/decode_head/sep_aspp_contrast_head.py
@@ -127,8 +127,11 @@ class DepthwiseSeparableASPPContrastHead(DepthwiseSeparableASPPHead):
         # elif seg_logit.size(1) == 144 # For Mapillary dataset, 124+16+4
         # unofficial repository not release mapillary until 2023/2/6
 
-        if 'pad_shape' in batch_img_metas[0]:
-            size = batch_img_metas[0]['pad_shape']
+        if isinstance(batch_img_metas[0]['img_shape'], torch.Size):
+            # slide inference
+            size = batch_img_metas[0]['img_shape']
+        elif 'pad_shape' in batch_img_metas[0]:
+            size = batch_img_metas[0]['pad_shape'][:2]
         else:
             size = batch_img_metas[0]['img_shape']
         seg_logit = seg_logit[:, :-hiera_num_classes]

--- a/projects/hssn/decode_head/sep_aspp_contrast_head.py
+++ b/projects/hssn/decode_head/sep_aspp_contrast_head.py
@@ -127,10 +127,14 @@ class DepthwiseSeparableASPPContrastHead(DepthwiseSeparableASPPHead):
         # elif seg_logit.size(1) == 144 # For Mapillary dataset, 124+16+4
         # unofficial repository not release mapillary until 2023/2/6
 
+        if 'pad_shape' in batch_img_metas[0]:
+            size = batch_img_metas[0]['pad_shape']
+        else:
+            size = batch_img_metas[0]['img_shape']
         seg_logit = seg_logit[:, :-hiera_num_classes]
         seg_logit = resize(
             input=seg_logit,
-            size=batch_img_metas[0]['img_shape'],
+            size=size,
             mode='bilinear',
             align_corners=self.align_corners)
 


### PR DESCRIPTION
## Motivation

When using `test_cfg` for `data_preprocessor`, `predict_by_feat` resizes to the original size, not the padded size.

```
data_preprocessor = dict(
    type="SegDataPreProcessor",
    #type="SegDataPreProcessorWithPad",
    mean=[123.675, 116.28, 103.53],
    std=[58.395, 57.12, 57.375],
    bgr_to_rgb=True,
    pad_val=0,
    seg_pad_val=255,
    test_cfg=dict(size=(128, 128)))
```

Refar to:
https://github.com/open-mmlab/mmsegmentation/blob/main/mmseg/models/decode_heads/san_head.py#L589-L592

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
