### PR TITLE
Allow custom visualizer

### DIFF
--- a/mmseg/engine/hooks/visualization_hook.py
+++ b/mmseg/engine/hooks/visualization_hook.py
@@ -7,10 +7,10 @@ import mmcv
 import mmengine.fileio as fileio
 from mmengine.hooks import Hook
 from mmengine.runner import Runner
+from mmengine.visualization import Visualizer
 
 from mmseg.registry import HOOKS
 from mmseg.structures import SegDataSample
-from mmseg.visualization import SegLocalVisualizer
 
 
 @HOOKS.register_module()
@@ -42,8 +42,7 @@ class SegVisualizationHook(Hook):
                  show: bool = False,
                  wait_time: float = 0.,
                  backend_args: Optional[dict] = None):
-        self._visualizer: SegLocalVisualizer = \
-            SegLocalVisualizer.get_current_instance()
+        self._visualizer: Visualizer = Visualizer.get_current_instance()
         self.interval = interval
         self.show = show
         if self.show:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Current Visualization Hook can only get instances of `SegLocalVisualizer`. This makes impossible to use any other custom implementation.

## Modification

This PR just allows to instantiate a different visualizer (following mmdetection implementation):
https://github.com/open-mmlab/mmdetection/blob/main/mmdet/engine/hooks/visualization_hook.py#L58

