### PR TITLE
"input_shape" and "inputs" cannot be both set

### DIFF
--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -86,7 +86,7 @@ def inference(args: argparse.Namespace, logger: MMLogger) -> dict:
                                   'supported yet.')
     outputs = get_model_complexity_info(
         model,
-        input_shape,
+        input_shape=None,
         inputs=data['inputs'],
         show_table=False,
         show_arch=False)


### PR DESCRIPTION
when using mmengine>=v0.7.3, ["input_shape" and "inputs" cannot be both set](https://github.com/open-mmlab/mmengine/blob/main/mmengine/analysis/print_helper.py#L724) in function ``get_model_complexity_info``.