### PR TITLE
[Fix] Fix get_flops scrip

### DIFF
--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -86,7 +86,7 @@ def inference(args: argparse.Namespace, logger: MMLogger) -> dict:
                                   'supported yet.')
     outputs = get_model_complexity_info(
         model,
-        input_shape,
+        input_shape=None,
         inputs=data['inputs'],
         show_table=False,
         show_arch=False)


### PR DESCRIPTION
## Motivation

`inputs` and `input_shape` can't be both set to mmengine api `get_model_complexity_info`

https://github.com/open-mmlab/mmengine/pull/1056


## Modification

Set `input_shape` to None.


