### PR TITLE
[Docs] Fix VOCaug broken download link in the guideline

### DIFF
--- a/docs/en/user_guides/2_dataset_prepare.md
+++ b/docs/en/user_guides/2_dataset_prepare.md
@@ -250,7 +250,7 @@ python tools/dataset_converters/cityscapes.py data/cityscapes --nproc 8
 ## Pascal VOC
 
 Pascal VOC 2012 could be downloaded from [here](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar).
-Beside, most recent works on Pascal VOC dataset usually exploit extra augmentation data, which could be found [here](http://www.eecs.berkeley.edu/Research/Projects/CS/vision/grouping/semantic_contours/benchmark.tgz).
+Beside, most recent works on Pascal VOC dataset usually exploit extra augmentation data, which could be found [here](https://opendatalab.com/OpenDataLab/SBD/tree/main/raw).
 
 If you would like to use augmented VOC dataset, please run following command to convert augmentation annotations into proper format.
 

--- a/docs/zh_cn/user_guides/2_dataset_prepare.md
+++ b/docs/zh_cn/user_guides/2_dataset_prepare.md
@@ -250,7 +250,7 @@ python tools/dataset_converters/cityscapes.py data/cityscapes --nproc 8
 ## Pascal VOC
 
 Pascal VOC 2012 可从[此处](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar)下载。
-此外，Pascal VOC 数据集的最新工作通常利用额外的增强数据，可以在[这里](http://www.eecs.berkeley.edu/Research/Projects/CS/vision/grouping/semantic_contours/benchmark.tgz)找到。
+此外，Pascal VOC 数据集的最新工作通常利用额外的增强数据，可以在[这里](https://opendatalab.com/OpenDataLab/SBD/tree/main/raw)找到。
 
 如果您想使用增强的 VOC 数据集，请运行以下命令将增强数据的标注转换为正确的格式。
 


### PR DESCRIPTION
## Motivation

VOCaug dataset download link is broken, so we need to provide another available link.

![image](https://github.com/open-mmlab/mmsegmentation/assets/55696968/503b342f-ba36-421b-8abc-e9484505e0b0)

## Modification

Provide the same file in OpenDataLab. See below:

![image](https://github.com/open-mmlab/mmsegmentation/assets/55696968/c2abce88-9162-4e54-b417-35bb9c7bf261) 

## BC-breaking (Optional)

It's just a small fix. Not a BC.

## Use cases (Optional)

It's just a small fix. No new feature introduced.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
