### PR TITLE
Make mmseg to be able to run on mmcv=2.2.0

### DIFF
--- a/mmseg/__init__.py
+++ b/mmseg/__init__.py
@@ -8,7 +8,7 @@ from packaging.version import parse
 from .version import __version__, version_info
 
 MMCV_MIN = '2.0.0rc4'
-MMCV_MAX = '2.3.0'
+MMCV_MAX = '2.2.0'
 MMENGINE_MIN = '0.5.0'
 MMENGINE_MAX = '1.0.0'
 
@@ -62,7 +62,7 @@ assert (mmcv_version >= mmcv_min_version), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
     f'Please install mmcv>={MMCV_MIN}.'
 
-assert (mmcv_version < mmcv_max_version), \
+assert (mmcv_version <= mmcv_max_version), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
     f'Please install mmcv<{MMCV_MAX}.'
 
@@ -70,7 +70,7 @@ mmengine_min_version = digit_version(MMENGINE_MIN)
 mmengine_max_version = digit_version(MMENGINE_MAX)
 mmengine_version = digit_version(mmengine.__version__)
 
-assert (mmengine_version >= mmengine_version), \
+assert (mmengine_version >= mmengine_min_version), \
     f'MMEngine=={mmengine.__version__} is used but incompatible. ' \
     f'Please install mmengine>={MMENGINE_MIN}.'
 

--- a/mmseg/__init__.py
+++ b/mmseg/__init__.py
@@ -8,7 +8,7 @@ from packaging.version import parse
 from .version import __version__, version_info
 
 MMCV_MIN = '2.0.0rc4'
-MMCV_MAX = '2.2.0'
+MMCV_MAX = '2.3.0'
 MMENGINE_MIN = '0.5.0'
 MMENGINE_MAX = '1.0.0'
 
@@ -62,9 +62,9 @@ assert (mmcv_version >= mmcv_min_version), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
     f'Please install mmcv>={MMCV_MIN}.'
 
-assert (mmcv_version <= mmcv_max_version), \
+assert (mmcv_version < mmcv_max_version), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
-    f'Please install mmcv<={MMCV_MAX}.'
+    f'Please install mmcv<{MMCV_MAX}.'
 
 mmengine_min_version = digit_version(MMENGINE_MIN)
 mmengine_max_version = digit_version(MMENGINE_MAX)
@@ -74,7 +74,7 @@ assert (mmengine_version >= mmengine_version), \
     f'MMEngine=={mmengine.__version__} is used but incompatible. ' \
     f'Please install mmengine>={MMENGINE_MIN}.'
 
-assert (mmengine_version <= mmengine_max_version), \
+assert (mmengine_version < mmengine_max_version), \
     f'MMEngine=={mmengine.__version__} is used but incompatible. ' \
-    f'Please install mmengine<={MMENGINE_MAX}.'
+    f'Please install mmengine<{MMENGINE_MAX}.'
 __all__ = ['__version__', 'version_info', 'digit_version']

--- a/mmseg/__init__.py
+++ b/mmseg/__init__.py
@@ -58,17 +58,23 @@ mmcv_max_version = digit_version(MMCV_MAX)
 mmcv_version = digit_version(mmcv.__version__)
 
 
-assert (mmcv_min_version <= mmcv_version < mmcv_max_version), \
+assert (mmcv_version >= mmcv_min_version), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
-    f'Please install mmcv>=2.0.0rc4.'
+    f'Please install mmcv>={MMCV_MIN}.'
+
+assert (mmcv_version <= mmcv_max_version), \
+    f'MMCV=={mmcv.__version__} is used but incompatible. ' \
+    f'Please install mmcv<={MMCV_MAX}.'
 
 mmengine_min_version = digit_version(MMENGINE_MIN)
 mmengine_max_version = digit_version(MMENGINE_MAX)
 mmengine_version = digit_version(mmengine.__version__)
 
-assert (mmengine_min_version <= mmengine_version < mmengine_max_version), \
+assert (mmengine_version >= mmengine_version), \
     f'MMEngine=={mmengine.__version__} is used but incompatible. ' \
-    f'Please install mmengine>={mmengine_min_version}, '\
-    f'<{mmengine_max_version}.'
+    f'Please install mmengine>={MMENGINE_MIN}.'
 
+assert (mmengine_version <= mmengine_max_version), \
+    f'MMEngine=={mmengine.__version__} is used but incompatible. ' \
+    f'Please install mmengine<={MMENGINE_MAX}.'
 __all__ = ['__version__', 'version_info', 'digit_version']


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The documentation says it is okay to run with `mmcv >= 2.2.0`, but `mmseg` incorrectly asserts it to be less than 2.2.0.

## Modification

1. Allow `mmcv` with version 2.2.0 to run with the latest `mmseg` package.
2. Separate the assertion for the package version checks into two statements to provide users with clear feedback on whether their version is less or more than the required range.

## BC-breaking (Optional)

No

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
5. The documentation has been modified accordingly, like docstring or example tutorials.
