### PR TITLE
[Fix] Fix unsafe dictionary access

### DIFF
--- a/mmseg/apis/inference.py
+++ b/mmseg/apis/inference.py
@@ -58,11 +58,10 @@ def init_model(config: Union[str, Path, Config],
     model = MODELS.build(config.model)
     if checkpoint is not None:
         checkpoint = load_checkpoint(model, checkpoint, map_location='cpu')
-        dataset_meta = checkpoint['meta'].get('dataset_meta', None)
         # save the dataset_meta in the model for convenience
         if 'dataset_meta' in checkpoint.get('meta', {}):
             # mmseg 1.x
-            model.dataset_meta = dataset_meta
+            model.dataset_meta = checkpoint['meta']['dataset_meta']
         elif 'CLASSES' in checkpoint.get('meta', {}):
             # < mmseg 1.x
             classes = checkpoint['meta']['CLASSES']


### PR DESCRIPTION
## Motivation

The method `init_model` in  [mmseg/apis/inference.py](https://github.com/open-mmlab/mmsegmentation/blob/b040e147adfa027bbc071b624bedf0ae84dfc922/mmseg/apis/inference.py#L61) has an unsafe dictionary access in line 61. The key `'meta'` is accessed directly, even though the following lines always use `checkpoint.get('meta')` to ensure it even exists and have functional handling for the case that it doesn't (in the `else` case). As a result, the program will throw a KeyError before ever reaching the already implemented handling of this very case. This bug is the reason for #3558.

## Modification

Simply moving the dictionary access AFTER the check that the key exists will suffice. This will allow `init_model` to reach the `else` case when `checkpoint['meta']` does not exist.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
