### PR TITLE
[Fix] Fix dimension error when using slide inference with Mask2Former head

### DIFF
--- a/mmseg/models/decode_heads/mask2former_head.py
+++ b/mmseg/models/decode_heads/mask2former_head.py
@@ -150,8 +150,11 @@ class Mask2FormerHead(MMDET_Mask2FormerHead):
         all_cls_scores, all_mask_preds = self(x, batch_data_samples)
         mask_cls_results = all_cls_scores[-1]
         mask_pred_results = all_mask_preds[-1]
-        if 'pad_shape' in batch_img_metas[0]:
-            size = batch_img_metas[0]['pad_shape']
+        if isinstance(batch_img_metas[0]['img_shape'], torch.Size):
+            # slide inference
+            size = batch_img_metas[0]['img_shape']
+        elif 'pad_shape' in batch_img_metas[0]:
+            size = batch_img_metas[0]['pad_shape'][:2]
         else:
             size = batch_img_metas[0]['img_shape']
         # upsample mask


### PR DESCRIPTION
## Motivation

The method `predict` in [mmseg/models/decode_heads/mask2former_head.py](https://github.com/open-mmlab/mmsegmentation/blob/b040e147adfa027bbc071b624bedf0ae84dfc922/mmseg/models/decode_heads/mask2former_head.py#L153) is incompatible with the `'slide'` inference mode.

To elaborate, on line 280 of `slide_inference` in [mmseg/models/segmentors/encoder_decoder.py](https://github.com/open-mmlab/mmsegmentation/blob/b040e147adfa027bbc071b624bedf0ae84dfc922/mmseg/models/segmentors/encoder_decoder.py#L280), the key `'img_shape'` of `batch_img_metas[0]` is overwritten by the shape of the cropped image / sliding window.

In line 353 of [mmseg/models/decode_heads/decode_head.py](https://github.com/open-mmlab/mmsegmentation/blob/b040e147adfa027bbc071b624bedf0ae84dfc922/mmseg/models/decode_heads/decode_head.py#L353), this is the first key that is used to get the target size for upsampling. As such, `crop_seg_logits` will have the same shape as `crop_img`.

In [mmseg/models/decode_heads/mask2former_head.py](https://github.com/open-mmlab/mmsegmentation/blob/b040e147adfa027bbc071b624bedf0ae84dfc922/mmseg/models/decode_heads/mask2former_head.py#L153), the first shape that is referenced as a target for upsampling is `'pad_shape'` instead. Since `slide_inference` does not overwrite this key, each cropped image is upsampled to the size of the full image, and then further padded with zeros by `slide_inference`, leading to a dimension mismatch when trying to add up the padded `crop_seg_logits`. This leads to the issue described in #3666.

## Modification

I have simply adjusted the size selection in [mmseg/models/decode_heads/mask2former_head.py](https://github.com/open-mmlab/mmsegmentation/blob/b040e147adfa027bbc071b624bedf0ae84dfc922/mmseg/models/decode_heads/mask2former_head.py#L153) to match that of [mmseg/models/decode_heads/decode_head.py](https://github.com/open-mmlab/mmsegmentation/blob/b040e147adfa027bbc071b624bedf0ae84dfc922/mmseg/models/decode_heads/decode_head.py#L353). As a result, a dimension mismatch no longer occurs when using slide inference with a Mask2Former head.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
