### PR TITLE
Update confusion_matrix.py

### DIFF
--- a/tools/analysis_tools/confusion_matrix.py
+++ b/tools/analysis_tools/confusion_matrix.py
@@ -63,7 +63,7 @@ def calculate_confusion_matrix(dataset, results):
     for idx, per_img_res in enumerate(results):
         res_segm = per_img_res
         gt_segm = dataset[idx]['data_samples'] \
-            .gt_sem_seg.data.squeeze().numpy().astype(np.uint8)
+            .gt_sem_seg.data.squeeze().numpy().astype(np.uint32)
         gt_segm, res_segm = gt_segm.flatten(), res_segm.flatten()
         if reduce_zero_label:
             gt_segm = gt_segm - 1


### PR DESCRIPTION
## Motivation

The current implementation do not work correctly when num_classes is larger than 16. Because the gt seg map was forced to uint8 dtype.

## Modification

Let gt seg map being np.uint32, rather than uint8 for no reason. The function works fine after the modification.
