### PR TITLE
Fix Albu Transform in transforms.py

### DIFF
--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -2454,7 +2454,7 @@ class Albu(BaseTransform):
         # back to the original format
         albumentations_results = self.mapper(albumentations_results, self.keymap_back)
 
-        # 更新原始 results 中对应的键
+        # Update corresponding keys in the original `results`
         results.update(albumentations_results)
 
         # update final shape

--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -2424,31 +2424,38 @@ class Albu(BaseTransform):
         # dict to albumentations format
         results = self.mapper(results, self.keymap_to_albu)
 
+        albumentations_results = {
+            k: results.pop(k) for k in ['image', 'mask'] if k in results
+        }
+
         # Convert to RGB since Albumentations works with RGB images
         if self.bgr_to_rgb:
-            results['image'] = cv2.cvtColor(results['image'],
+            albumentations_results['image'] = cv2.cvtColor(albumentations_results['image'],
                                             cv2.COLOR_BGR2RGB)
             if self.additional_targets:
                 for key, value in self.additional_targets.items():
                     if value == 'image':
-                        results[key] = cv2.cvtColor(results[key],
+                        albumentations_results[key] = cv2.cvtColor(albumentations_results[key],
                                                     cv2.COLOR_BGR2RGB)
 
         # Apply Transform
-        results = self.aug(**results)
+        albumentations_results = self.aug(**albumentations_results)
 
         # Convert back to BGR
         if self.bgr_to_rgb:
-            results['image'] = cv2.cvtColor(results['image'],
+            albumentations_results['image'] = cv2.cvtColor(albumentations_results['image'],
                                             cv2.COLOR_RGB2BGR)
             if self.additional_targets:
                 for key, value in self.additional_targets.items():
                     if value == 'image':
-                        results[key] = cv2.cvtColor(results['image2'],
+                        albumentations_results[key] = cv2.cvtColor(albumentations_results['image2'],
                                                     cv2.COLOR_RGB2BGR)
 
         # back to the original format
-        results = self.mapper(results, self.keymap_back)
+        albumentations_results = self.mapper(albumentations_results, self.keymap_back)
+
+        # 更新原始 results 中对应的键
+        results.update(albumentations_results)
 
         # update final shape
         if self.update_pad_shape:


### PR DESCRIPTION
Directly using the `Albu` class in `transforms.py` for data augmentation will result in an error. After debugging point by point, I found that it was because redundant key-value pairs were passed into `self.aug`, so I made this modification.

## Motivation

- Added a new variable albumentations_results in the transform function to remove redundant keys from results, preventing errors in self.aug.

## Modification

- Introduced the albumentations_results variable in the transform function to store and process the image and mask keys.
- Removed redundant keys from results to ensure self.aug works correctly.

## Notes for Reviewers

- Please review the implementation of albumentations_results to confirm it effectively removes redundant keys and works as expected.

