### PR TITLE
Fix fsdp weight reading error

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -5,6 +5,7 @@ import os.path as osp
 
 from mmengine.config import Config, DictAction
 from mmengine.runner import Runner
+from mmseg.registry import RUNNERS
 
 
 # TODO: support fuse_conv_bn, visualization, and format_only
@@ -113,7 +114,13 @@ def main():
         cfg.test_evaluator['keep_results'] = True
 
     # build the runner from config
-    runner = Runner.from_cfg(cfg)
+    if 'runner_type' not in cfg:
+        # build the default runner
+        runner = Runner.from_cfg(cfg)
+    else:
+        # build customized runner from the registry
+        # if 'runner_type' is set in the cfg
+        runner = RUNNERS.build(cfg)
 
     # start testing
     runner.test()


### PR DESCRIPTION
Fix fsdp weight reading error

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

I used FSDP to train the model and saved the model weights in shards. However, during testing, there were errors in reading the weights, and it was found that the reason was that the test. py script omitted the judgment of the runner type..

## Modification

Referring to the train.by script, a judgment of the runner type has been added to the test.by script.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
NO.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
