### PR TITLE
support moore threads MUSA gpu

### DIFF
--- a/mmseg/apis/mmseg_inferencer.py
+++ b/mmseg/apis/mmseg_inferencer.py
@@ -9,17 +9,16 @@ import numpy as np
 import torch
 import torch.nn as nn
 from mmcv.transforms import Compose
+from mmengine.device.utils import is_musa_available
 from mmengine.infer.infer import BaseInferencer, ModelType
 from mmengine.model import revert_sync_batchnorm
 from mmengine.registry import init_default_scope
 from mmengine.runner.checkpoint import _load_checkpoint_to_model
-from mmengine.device.utils import is_musa_available
 from PIL import Image
 
 from mmseg.structures import SegDataSample
 from mmseg.utils import ConfigType, SampleList, get_classes, get_palette
 from mmseg.visualization import SegLocalVisualizer
-
 
 InputType = Union[str, np.ndarray]
 InputsType = Union[InputType, Sequence[InputType]]
@@ -83,7 +82,8 @@ class MMSegInferencer(BaseInferencer):
         super().__init__(
             model=model, weights=weights, device=device, scope=scope)
 
-        if device == 'cpu' or (not torch.cuda.is_available() and not is_musa_available()):
+        if device == 'cpu' or (not torch.cuda.is_available()
+                               and not is_musa_available()):
             self.model = revert_sync_batchnorm(self.model)
 
         assert isinstance(self.visualizer, SegLocalVisualizer)

--- a/mmseg/apis/mmseg_inferencer.py
+++ b/mmseg/apis/mmseg_inferencer.py
@@ -13,11 +13,13 @@ from mmengine.infer.infer import BaseInferencer, ModelType
 from mmengine.model import revert_sync_batchnorm
 from mmengine.registry import init_default_scope
 from mmengine.runner.checkpoint import _load_checkpoint_to_model
+from mmengine.device.utils import is_musa_available
 from PIL import Image
 
 from mmseg.structures import SegDataSample
 from mmseg.utils import ConfigType, SampleList, get_classes, get_palette
 from mmseg.visualization import SegLocalVisualizer
+
 
 InputType = Union[str, np.ndarray]
 InputsType = Union[InputType, Sequence[InputType]]
@@ -81,7 +83,7 @@ class MMSegInferencer(BaseInferencer):
         super().__init__(
             model=model, weights=weights, device=device, scope=scope)
 
-        if device == 'cpu' or not torch.cuda.is_available():
+        if device == 'cpu' or (not torch.cuda.is_available() and not is_musa_available()):
             self.model = revert_sync_batchnorm(self.model)
 
         assert isinstance(self.visualizer, SegLocalVisualizer)

--- a/mmseg/models/assigners/hungarian_assigner.py
+++ b/mmseg/models/assigners/hungarian_assigner.py
@@ -3,12 +3,13 @@ from typing import List, Union
 
 import torch
 from mmengine import ConfigDict
-from mmengine.structures import InstanceData
 from mmengine.device.utils import is_musa_available
+from mmengine.structures import InstanceData
 from scipy.optimize import linear_sum_assignment
+
 if is_musa_available():
     from torch_musa.core.amp import autocast
-else:   
+else:
     from torch.cuda.amp import autocast
 
 from mmseg.registry import TASK_UTILS

--- a/mmseg/models/assigners/hungarian_assigner.py
+++ b/mmseg/models/assigners/hungarian_assigner.py
@@ -4,8 +4,12 @@ from typing import List, Union
 import torch
 from mmengine import ConfigDict
 from mmengine.structures import InstanceData
+from mmengine.device.utils import is_musa_available
 from scipy.optimize import linear_sum_assignment
-from torch.cuda.amp import autocast
+if is_musa_available():
+    from torch_musa.core.amp import autocast
+else:   
+    from torch.cuda.amp import autocast
 
 from mmseg.registry import TASK_UTILS
 from .base_assigner import BaseAssigner

--- a/mmseg/models/losses/focal_loss.py
+++ b/mmseg/models/losses/focal_loss.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.ops import sigmoid_focal_loss as _sigmoid_focal_loss
+from mmengine.device.utils import is_musa_available
 
 from mmseg.registry import MODELS
 from .utils import weight_reduce_loss
@@ -269,7 +270,7 @@ class FocalLoss(nn.Module):
             reduction_override if reduction_override else self.reduction)
         if self.use_sigmoid:
             num_classes = pred.size(1)
-            if torch.cuda.is_available() and pred.is_cuda:
+            if (torch.cuda.is_available() and pred.is_cuda) or (is_musa_available() and pred.device == 'musa'):
                 if target.dim() == 1:
                     one_hot_target = F.one_hot(
                         target, num_classes=num_classes + 1)

--- a/mmseg/models/losses/focal_loss.py
+++ b/mmseg/models/losses/focal_loss.py
@@ -270,7 +270,9 @@ class FocalLoss(nn.Module):
             reduction_override if reduction_override else self.reduction)
         if self.use_sigmoid:
             num_classes = pred.size(1)
-            if (torch.cuda.is_available() and pred.is_cuda) or (is_musa_available() and pred.device == 'musa'):
+            if (torch.cuda.is_available()
+                    and pred.is_cuda) or (is_musa_available()
+                                          and pred.device == 'musa'):
                 if target.dim() == 1:
                     one_hot_target = F.one_hot(
                         target, num_classes=num_classes + 1)

--- a/tests/test_models/test_backbones/test_clip_text_encoder.py
+++ b/tests/test_models/test_backbones/test_clip_text_encoder.py
@@ -1,12 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 from mmengine import Config
+from mmengine.device.utils import is_musa_available
 from mmengine.registry import init_default_scope
 
 from mmseg.models.text_encoder import CLIPTextEncoder
 from mmseg.utils import get_classes
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_clip_text_encoder():

--- a/tests/test_models/test_backbones/test_clip_text_encoder.py
+++ b/tests/test_models/test_backbones/test_clip_text_encoder.py
@@ -6,6 +6,8 @@ from mmengine.registry import init_default_scope
 from mmseg.models.text_encoder import CLIPTextEncoder
 from mmseg.utils import get_classes
 
+from mmengine.device.utils import is_musa_available
+
 
 def test_clip_text_encoder():
     init_default_scope('mmseg')
@@ -23,6 +25,8 @@ def test_clip_text_encoder():
     text_encoder = CLIPTextEncoder(**cfg)
     if torch.cuda.is_available():
         text_encoder = text_encoder.cuda()
+    elif is_musa_available():
+        text_encoder = text_encoder.musa()
 
     with torch.no_grad():
         class_embeds = text_encoder()

--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -12,6 +12,7 @@ from mmengine.model.utils import revert_sync_batchnorm
 from mmengine.registry import init_default_scope
 from mmengine.structures import PixelData
 from mmengine.utils import is_list_of, is_tuple_of
+from mmengine.device.utils import is_musa_available
 from torch import Tensor
 
 from mmseg.structures import SegDataSample
@@ -190,6 +191,8 @@ def _test_encoder_decoder_forward(cfg_file):
     # convert to cuda Tensor if applicable
     if torch.cuda.is_available():
         segmentor = segmentor.cuda()
+    elif is_musa_available():
+        segmentor = segmentor.musa()
     else:
         segmentor = revert_sync_batchnorm(segmentor)
 

--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -8,11 +8,11 @@ import numpy as np
 import pytest
 import torch
 import torch.nn as nn
+from mmengine.device.utils import is_musa_available
 from mmengine.model.utils import revert_sync_batchnorm
 from mmengine.registry import init_default_scope
 from mmengine.structures import PixelData
 from mmengine.utils import is_list_of, is_tuple_of
-from mmengine.device.utils import is_musa_available
 from torch import Tensor
 
 from mmseg.structures import SegDataSample

--- a/tests/test_models/test_heads/test_ann_head.py
+++ b/tests/test_models/test_heads/test_ann_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import ANNHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_ann_head():

--- a/tests/test_models/test_heads/test_ann_head.py
+++ b/tests/test_models/test_heads/test_ann_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import ANNHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_ann_head():
@@ -16,5 +18,7 @@ def test_ann_head():
         project_channels=8)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 21, 21)

--- a/tests/test_models/test_heads/test_apc_head.py
+++ b/tests/test_models/test_heads/test_apc_head.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import APCHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_apc_head():
@@ -34,6 +36,8 @@ def test_apc_head():
         fusion=True)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.fusion is True
     assert head.acm_modules[0].pool_scale == 1
     assert head.acm_modules[1].pool_scale == 2
@@ -51,6 +55,8 @@ def test_apc_head():
         fusion=False)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.fusion is False
     assert head.acm_modules[0].pool_scale == 1
     assert head.acm_modules[1].pool_scale == 2

--- a/tests/test_models/test_heads/test_apc_head.py
+++ b/tests/test_models/test_heads/test_apc_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import APCHead
 from .utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_apc_head():

--- a/tests/test_models/test_heads/test_aspp_head.py
+++ b/tests/test_models/test_heads/test_aspp_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import ASPPHead, DepthwiseSeparableASPPHead
 from .utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_aspp_head():

--- a/tests/test_models/test_heads/test_aspp_head.py
+++ b/tests/test_models/test_heads/test_aspp_head.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import ASPPHead, DepthwiseSeparableASPPHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_aspp_head():
@@ -29,6 +31,8 @@ def test_aspp_head():
         in_channels=8, channels=4, num_classes=19, dilations=(1, 12, 24))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.aspp_modules[0].conv.dilation == (1, 1)
     assert head.aspp_modules[1].conv.dilation == (12, 12)
     assert head.aspp_modules[2].conv.dilation == (24, 24)
@@ -49,6 +53,8 @@ def test_dw_aspp_head():
         dilations=(1, 12, 24))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.c1_bottleneck is None
     assert head.aspp_modules[0].conv.dilation == (1, 1)
     assert head.aspp_modules[1].depthwise_conv.dilation == (12, 12)
@@ -67,6 +73,8 @@ def test_dw_aspp_head():
         dilations=(1, 12, 24))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.c1_bottleneck.in_channels == 4
     assert head.c1_bottleneck.out_channels == 2
     assert head.aspp_modules[0].conv.dilation == (1, 1)

--- a/tests/test_models/test_heads/test_decode_head.py
+++ b/tests/test_models/test_heads/test_decode_head.py
@@ -7,7 +7,9 @@ from mmengine.structures import PixelData
 
 from mmseg.models.decode_heads.decode_head import BaseDecodeHead
 from mmseg.structures import SegDataSample
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 @patch.multiple(BaseDecodeHead, __abstractmethods__=set())
@@ -70,6 +72,8 @@ def test_decode_head():
     head = BaseDecodeHead(32, 16, num_classes=19)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.in_channels == 32
     assert head.input_transform is None
     transformed_inputs = head._transform_inputs(inputs)
@@ -84,6 +88,8 @@ def test_decode_head():
                           input_transform='resize_concat')
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.in_channels == 48
     assert head.input_transform == 'resize_concat'
     transformed_inputs = head._transform_inputs(inputs)
@@ -108,6 +114,8 @@ def test_decode_head():
             type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     loss = head.loss_by_feat(
         seg_logits=inputs, batch_data_samples=data_samples)
     assert 'loss_ce' in loss
@@ -128,6 +136,8 @@ def test_decode_head():
         ])
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
 
     loss = head.loss_by_feat(
         seg_logits=inputs, batch_data_samples=data_samples)
@@ -155,6 +165,8 @@ def test_decode_head():
                      dict(type='CrossEntropyLoss', loss_name='loss_3')))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     loss = head.loss_by_feat(
         seg_logits=inputs, batch_data_samples=data_samples)
     assert 'loss_1' in loss
@@ -176,6 +188,8 @@ def test_decode_head():
                      dict(type='CrossEntropyLoss', loss_name='loss_ce')))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     loss_3 = head.loss_by_feat(
         seg_logits=inputs, batch_data_samples=data_samples)
 
@@ -186,6 +200,8 @@ def test_decode_head():
         loss_decode=(dict(type='CrossEntropyLoss', loss_name='loss_ce')))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     loss = head.loss_by_feat(
         seg_logits=inputs, batch_data_samples=data_samples)
     assert 'loss_ce' in loss

--- a/tests/test_models/test_heads/test_decode_head.py
+++ b/tests/test_models/test_heads/test_decode_head.py
@@ -3,13 +3,12 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 from mmengine.structures import PixelData
 
 from mmseg.models.decode_heads.decode_head import BaseDecodeHead
 from mmseg.structures import SegDataSample
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 @patch.multiple(BaseDecodeHead, __abstractmethods__=set())

--- a/tests/test_models/test_heads/test_dm_head.py
+++ b/tests/test_models/test_heads/test_dm_head.py
@@ -1,11 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import DMHead
 from .utils import _conv_has_norm, to_cuda, to_musa
 
-from mmengine.device.utils import is_musa_available
 
 def test_dm_head():
 

--- a/tests/test_models/test_heads/test_dm_head.py
+++ b/tests/test_models/test_heads/test_dm_head.py
@@ -3,8 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import DMHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
 
+from mmengine.device.utils import is_musa_available
 
 def test_dm_head():
 
@@ -34,6 +35,8 @@ def test_dm_head():
         fusion=True)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.fusion is True
     assert head.dcm_modules[0].filter_size == 1
     assert head.dcm_modules[1].filter_size == 3
@@ -51,6 +54,8 @@ def test_dm_head():
         fusion=False)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.fusion is False
     assert head.dcm_modules[0].filter_size == 1
     assert head.dcm_modules[1].filter_size == 3

--- a/tests/test_models/test_heads/test_dnl_head.py
+++ b/tests/test_models/test_heads/test_dnl_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import DNLHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_dnl_head():

--- a/tests/test_models/test_heads/test_dnl_head.py
+++ b/tests/test_models/test_heads/test_dnl_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import DNLHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_dnl_head():
@@ -14,6 +16,8 @@ def test_dnl_head():
     inputs = [torch.randn(1, 8, 23, 23)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)
 
@@ -23,6 +27,8 @@ def test_dnl_head():
     inputs = [torch.randn(1, 8, 23, 23)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)
 
@@ -31,6 +37,8 @@ def test_dnl_head():
     inputs = [torch.randn(1, 8, 23, 23)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)
 
@@ -40,5 +48,7 @@ def test_dnl_head():
     inputs = [torch.randn(1, 8, 23, 23)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)

--- a/tests/test_models/test_heads/test_ema_head.py
+++ b/tests/test_models/test_heads/test_ema_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import EMAHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_emanet_head():
@@ -19,5 +21,7 @@ def test_emanet_head():
     inputs = [torch.randn(1, 4, 23, 23)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)

--- a/tests/test_models/test_heads/test_ema_head.py
+++ b/tests/test_models/test_heads/test_ema_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import EMAHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_emanet_head():

--- a/tests/test_models/test_heads/test_fcn_head.py
+++ b/tests/test_models/test_heads/test_fcn_head.py
@@ -5,7 +5,9 @@ from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
 from mmengine.utils.dl_utils.parrots_wrapper import SyncBatchNorm
 
 from mmseg.models.decode_heads import DepthwiseSeparableFCNHead, FCNHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_fcn_head():
@@ -36,6 +38,8 @@ def test_fcn_head():
         in_channels=8, channels=4, num_classes=19, concat_input=False)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available:
+        head, inputs = to_musa(head, inputs)
     assert len(head.convs) == 2
     assert not head.concat_input and not hasattr(head, 'conv_cat')
     outputs = head(inputs)
@@ -47,6 +51,8 @@ def test_fcn_head():
         in_channels=8, channels=4, num_classes=19, concat_input=True)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert len(head.convs) == 2
     assert head.concat_input
     assert head.conv_cat.in_channels == 12
@@ -58,6 +64,8 @@ def test_fcn_head():
     head = FCNHead(in_channels=8, channels=4, num_classes=19)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     for i in range(len(head.convs)):
         assert head.convs[i].kernel_size == (3, 3)
         assert head.convs[i].padding == 1
@@ -69,6 +77,8 @@ def test_fcn_head():
     head = FCNHead(in_channels=8, channels=4, num_classes=19, kernel_size=1)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     for i in range(len(head.convs)):
         assert head.convs[i].kernel_size == (1, 1)
         assert head.convs[i].padding == 0
@@ -80,6 +90,8 @@ def test_fcn_head():
     head = FCNHead(in_channels=8, channels=4, num_classes=19, num_convs=1)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert len(head.convs) == 1
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)
@@ -94,6 +106,8 @@ def test_fcn_head():
         concat_input=False)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert isinstance(head.convs, torch.nn.Identity)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)

--- a/tests/test_models/test_heads/test_fcn_head.py
+++ b/tests/test_models/test_heads/test_fcn_head.py
@@ -2,12 +2,11 @@
 import pytest
 import torch
 from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
+from mmengine.device.utils import is_musa_available
 from mmengine.utils.dl_utils.parrots_wrapper import SyncBatchNorm
 
 from mmseg.models.decode_heads import DepthwiseSeparableFCNHead, FCNHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_fcn_head():

--- a/tests/test_models/test_heads/test_gc_head.py
+++ b/tests/test_models/test_heads/test_gc_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import GCHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_gc_head():

--- a/tests/test_models/test_heads/test_gc_head.py
+++ b/tests/test_models/test_heads/test_gc_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import GCHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_gc_head():
@@ -12,5 +14,7 @@ def test_gc_head():
     inputs = [torch.randn(1, 4, 23, 23)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)

--- a/tests/test_models/test_heads/test_ham_head.py
+++ b/tests/test_models/test_heads/test_ham_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import LightHamHead
 from .utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 ham_norm_cfg = dict(type='GN', num_groups=32, requires_grad=True)
 

--- a/tests/test_models/test_heads/test_ham_head.py
+++ b/tests/test_models/test_heads/test_ham_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import LightHamHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 ham_norm_cfg = dict(type='GN', num_groups=32, requires_grad=True)
 
@@ -38,6 +40,8 @@ def test_ham_head():
     ]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.in_channels == [16, 32, 64]
     assert head.hamburger.ham_in.in_channels == 64
     outputs = head(inputs)

--- a/tests/test_models/test_heads/test_isa_head.py
+++ b/tests/test_models/test_heads/test_isa_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import ISAHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_isa_head():
@@ -16,5 +18,7 @@ def test_isa_head():
         down_factor=(8, 8))
     if torch.cuda.is_available():
         isa_head, inputs = to_cuda(isa_head, inputs)
+    elif is_musa_available():
+        isa_head, inputs = to_musa(isa_head, inputs)
     output = isa_head(inputs)
     assert output.shape == (1, isa_head.num_classes, 23, 23)

--- a/tests/test_models/test_heads/test_isa_head.py
+++ b/tests/test_models/test_heads/test_isa_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import ISAHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_isa_head():

--- a/tests/test_models/test_heads/test_mask2former_head.py
+++ b/tests/test_models/test_heads/test_mask2former_head.py
@@ -6,7 +6,9 @@ from mmengine.structures import PixelData
 from mmseg.models.decode_heads import Mask2FormerHead
 from mmseg.structures import SegDataSample
 from mmseg.utils import SampleList
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_mask2former_head():
@@ -141,6 +143,10 @@ def test_mask2former_head():
         head, inputs = to_cuda(head, inputs)
         for data_sample in data_samples:
             data_sample.gt_sem_seg.data = data_sample.gt_sem_seg.data.cuda()
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
+        for data_sample in data_samples:
+            data_sample.gt_sem_seg.data = data_sample.gt_sem_seg.data.musa()
 
     loss_dict = head.loss(inputs, data_samples, None)
     assert isinstance(loss_dict, dict)

--- a/tests/test_models/test_heads/test_mask2former_head.py
+++ b/tests/test_models/test_heads/test_mask2former_head.py
@@ -1,14 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 from mmengine import Config
+from mmengine.device.utils import is_musa_available
 from mmengine.structures import PixelData
 
 from mmseg.models.decode_heads import Mask2FormerHead
 from mmseg.structures import SegDataSample
 from mmseg.utils import SampleList
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_mask2former_head():

--- a/tests/test_models/test_heads/test_nl_head.py
+++ b/tests/test_models/test_heads/test_nl_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import NLHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_nl_head():

--- a/tests/test_models/test_heads/test_nl_head.py
+++ b/tests/test_models/test_heads/test_nl_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import NLHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_nl_head():
@@ -12,5 +14,7 @@ def test_nl_head():
     inputs = [torch.randn(1, 8, 23, 23)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 23, 23)

--- a/tests/test_models/test_heads/test_ocr_head.py
+++ b/tests/test_models/test_heads/test_ocr_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import FCNHead, OCRHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_ocr_head():

--- a/tests/test_models/test_heads/test_ocr_head.py
+++ b/tests/test_models/test_heads/test_ocr_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import FCNHead, OCRHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_ocr_head():
@@ -14,6 +16,9 @@ def test_ocr_head():
     if torch.cuda.is_available():
         head, inputs = to_cuda(ocr_head, inputs)
         head, inputs = to_cuda(fcn_head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(ocr_head, inputs)
+        head, inputs = to_musa(fcn_head, inputs)
     prev_output = fcn_head(inputs)
     output = ocr_head(inputs, prev_output)
     assert output.shape == (1, ocr_head.num_classes, 23, 23)

--- a/tests/test_models/test_heads/test_psa_head.py
+++ b/tests/test_models/test_heads/test_psa_head.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import PSAHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_psa_head():
@@ -37,6 +39,8 @@ def test_psa_head():
         in_channels=4, channels=2, num_classes=19, mask_size=(13, 13))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 13, 13)
 
@@ -50,6 +54,8 @@ def test_psa_head():
         shrink_factor=1)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 13, 13)
 
@@ -63,6 +69,8 @@ def test_psa_head():
         psa_softmax=True)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 13, 13)
 
@@ -76,6 +84,8 @@ def test_psa_head():
         psa_type='collect')
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 13, 13)
 
@@ -90,6 +100,8 @@ def test_psa_head():
         psa_type='collect')
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 13, 13)
 
@@ -105,6 +117,8 @@ def test_psa_head():
         compact=True)
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 13, 13)
 
@@ -118,5 +132,7 @@ def test_psa_head():
         psa_type='distribute')
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 13, 13)

--- a/tests/test_models/test_heads/test_psa_head.py
+++ b/tests/test_models/test_heads/test_psa_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import PSAHead
 from .utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_psa_head():

--- a/tests/test_models/test_heads/test_psp_head.py
+++ b/tests/test_models/test_heads/test_psp_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import PSPHead
 from .utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_psp_head():

--- a/tests/test_models/test_heads/test_psp_head.py
+++ b/tests/test_models/test_heads/test_psp_head.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import PSPHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_psp_head():
@@ -29,6 +31,8 @@ def test_psp_head():
         in_channels=4, channels=2, num_classes=19, pool_scales=(1, 2, 3))
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     assert head.psp_modules[0][0].output_size == 1
     assert head.psp_modules[1][0].output_size == 2
     assert head.psp_modules[2][0].output_size == 3

--- a/tests/test_models/test_heads/test_san_head.py
+++ b/tests/test_models/test_heads/test_san_head.py
@@ -1,13 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 from mmengine import Config
+from mmengine.device.utils import is_musa_available
 from mmengine.structures import PixelData
 
 from mmseg.models.decode_heads import SideAdapterCLIPHead
 from mmseg.structures import SegDataSample
 from .utils import list_to_cuda, list_to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_san_head():

--- a/tests/test_models/test_heads/test_san_head.py
+++ b/tests/test_models/test_heads/test_san_head.py
@@ -5,7 +5,9 @@ from mmengine.structures import PixelData
 
 from mmseg.models.decode_heads import SideAdapterCLIPHead
 from mmseg.structures import SegDataSample
-from .utils import list_to_cuda
+from .utils import list_to_cuda, list_to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_san_head():
@@ -113,6 +115,11 @@ def test_san_head():
         data = list_to_cuda([inputs, clip_feature, class_embed])
         for data_sample in data_samples:
             data_sample.gt_sem_seg.data = data_sample.gt_sem_seg.data.cuda()
+    elif is_musa_available():
+        head = head.musa()
+        data = list_to_musa([inputs, clip_feature, class_embed])
+        for data_sample in data_samples:
+            data_sample.gt_sem_seg.data = data_sample.gt_sem_seg.data.musa()
     else:
         data = [inputs, clip_feature, class_embed]
 

--- a/tests/test_models/test_heads/test_segmenter_mask_head.py
+++ b/tests/test_models/test_heads/test_segmenter_mask_head.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import SegmenterMaskTransformerHead
 from .utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_segmenter_mask_transformer_head():

--- a/tests/test_models/test_heads/test_segmenter_mask_head.py
+++ b/tests/test_models/test_heads/test_segmenter_mask_head.py
@@ -2,7 +2,9 @@
 import torch
 
 from mmseg.models.decode_heads import SegmenterMaskTransformerHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_segmenter_mask_transformer_head():
@@ -20,5 +22,7 @@ def test_segmenter_mask_transformer_head():
     inputs = [torch.randn(1, 2, 32, 32)]
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 32, 32)

--- a/tests/test_models/test_heads/test_setr_mla_head.py
+++ b/tests/test_models/test_heads/test_setr_mla_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import SETRMLAHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_setr_mla_head(capsys):

--- a/tests/test_models/test_heads/test_setr_mla_head.py
+++ b/tests/test_models/test_heads/test_setr_mla_head.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import SETRMLAHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_setr_mla_head(capsys):
@@ -47,6 +49,8 @@ def test_setr_mla_head(capsys):
     ]
     if torch.cuda.is_available():
         head, x = to_cuda(head, x)
+    elif is_musa_available():
+        head, x = to_musa(head, x)
     out = head(x)
     assert out.shape == (1, head.num_classes, h * 4, w * 4)
 
@@ -59,5 +63,7 @@ def test_setr_mla_head(capsys):
     ]
     if torch.cuda.is_available():
         head, x = to_cuda(head, x)
+    elif is_musa_available:
+        head, x = to_musa(head, x)
     out = head(x)
     assert out.shape == (1, head.num_classes, h * 4, w * 8)

--- a/tests/test_models/test_heads/test_setr_up_head.py
+++ b/tests/test_models/test_heads/test_setr_up_head.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import SETRUPHead
-from .utils import to_cuda
+from .utils import to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_setr_up_head(capsys):
@@ -45,6 +47,8 @@ def test_setr_up_head(capsys):
     x = [torch.randn(1, 4, h, w)]
     if torch.cuda.is_available():
         head, x = to_cuda(head, x)
+    elif is_musa_available():
+        head, x = to_musa(head, x)
     out = head(x)
     assert out.shape == (1, head.num_classes, h * 4, w * 4)
 
@@ -52,5 +56,7 @@ def test_setr_up_head(capsys):
     x = [torch.randn(1, 4, h, w * 2)]
     if torch.cuda.is_available():
         head, x = to_cuda(head, x)
+    elif is_musa_available():
+        head, x = to_musa(head, x)
     out = head(x)
     assert out.shape == (1, head.num_classes, h * 4, w * 8)

--- a/tests/test_models/test_heads/test_setr_up_head.py
+++ b/tests/test_models/test_heads/test_setr_up_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import SETRUPHead
 from .utils import to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_setr_up_head(capsys):

--- a/tests/test_models/test_heads/test_uper_head.py
+++ b/tests/test_models/test_heads/test_uper_head.py
@@ -3,7 +3,9 @@ import pytest
 import torch
 
 from mmseg.models.decode_heads import UPerHead
-from .utils import _conv_has_norm, to_cuda
+from .utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_uper_head():
@@ -31,5 +33,7 @@ def test_uper_head():
         in_channels=[4, 2], channels=2, num_classes=19, in_index=[-2, -1])
     if torch.cuda.is_available():
         head, inputs = to_cuda(head, inputs)
+    elif is_musa_available():
+        head, inputs = to_musa(head, inputs)
     outputs = head(inputs)
     assert outputs.shape == (1, head.num_classes, 45, 45)

--- a/tests/test_models/test_heads/test_uper_head.py
+++ b/tests/test_models/test_heads/test_uper_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.decode_heads import UPerHead
 from .utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_uper_head():

--- a/tests/test_models/test_heads/utils.py
+++ b/tests/test_models/test_heads/utils.py
@@ -29,7 +29,8 @@ def list_to_cuda(data):
         return data
     else:
         return data.cuda()
-    
+
+
 def to_musa(module, data):
     module = module.to('musa')
     if isinstance(data, list):

--- a/tests/test_models/test_heads/utils.py
+++ b/tests/test_models/test_heads/utils.py
@@ -29,3 +29,19 @@ def list_to_cuda(data):
         return data
     else:
         return data.cuda()
+    
+def to_musa(module, data):
+    module = module.to('musa')
+    if isinstance(data, list):
+        for i in range(len(data)):
+            data[i] = data[i].to('musa')
+    return module, data
+
+
+def list_to_musa(data):
+    if isinstance(data, list):
+        for i in range(len(data)):
+            data[i] = list_to_musa(data[i])
+        return data
+    else:
+        return data.to('musa')

--- a/tests/test_models/test_necks/test_ic_neck.py
+++ b/tests/test_models/test_necks/test_ic_neck.py
@@ -4,7 +4,9 @@ import torch
 
 from mmseg.models.necks import ICNeck
 from mmseg.models.necks.ic_neck import CascadeFeatureFusion
-from ..test_heads.utils import _conv_has_norm, to_cuda
+from ..test_heads.utils import _conv_has_norm, to_cuda, to_musa
+
+from mmengine.device.utils import is_musa_available
 
 
 def test_ic_neck():
@@ -28,6 +30,8 @@ def test_ic_neck():
         align_corners=False)
     if torch.cuda.is_available():
         neck, inputs = to_cuda(neck, inputs)
+    elif is_musa_available():
+        neck, inputs = to_musa(neck, inputs)
 
     outputs = neck(inputs)
     assert outputs[0].shape == (1, 4, 16, 32)

--- a/tests/test_models/test_necks/test_ic_neck.py
+++ b/tests/test_models/test_necks/test_ic_neck.py
@@ -1,12 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
+from mmengine.device.utils import is_musa_available
 
 from mmseg.models.necks import ICNeck
 from mmseg.models.necks.ic_neck import CascadeFeatureFusion
 from ..test_heads.utils import _conv_has_norm, to_cuda, to_musa
-
-from mmengine.device.utils import is_musa_available
 
 
 def test_ic_neck():

--- a/tests/test_models/test_segmentors/utils.py
+++ b/tests/test_models/test_segmentors/utils.py
@@ -2,6 +2,7 @@
 import torch
 from mmengine.optim import OptimWrapper
 from mmengine.structures import PixelData
+from mmengine.device.utils import is_musa_available
 from torch import nn
 from torch.optim import SGD
 
@@ -114,6 +115,8 @@ def _segmentor_forward_train_test(segmentor):
     # convert to cuda Tensor if applicable
     if torch.cuda.is_available():
         segmentor = segmentor.cuda()
+    elif is_musa_available():
+        segmentor = segmentor.musa()
 
     # check data preprocessor
     if not hasattr(segmentor,
@@ -164,6 +167,8 @@ def _segmentor_predict(segmentor):
     # convert to cuda Tensor if applicable
     if torch.cuda.is_available():
         segmentor = segmentor.cuda()
+    elif is_musa_available():
+        segmentor = segmentor.musa()
 
     # check data preprocessor
     if not hasattr(segmentor,

--- a/tests/test_models/test_segmentors/utils.py
+++ b/tests/test_models/test_segmentors/utils.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.device.utils import is_musa_available
 from mmengine.optim import OptimWrapper
 from mmengine.structures import PixelData
-from mmengine.device.utils import is_musa_available
 from torch import nn
 from torch.optim import SGD
 

--- a/tests/test_visualization/test_local_visualizer.py
+++ b/tests/test_visualization/test_local_visualizer.py
@@ -8,8 +8,8 @@ import cv2
 import mmcv
 import numpy as np
 import torch
-from mmengine.structures import PixelData
 from mmengine.device.utils import is_musa_available
+from mmengine.structures import PixelData
 
 from mmseg.structures import SegDataSample
 from mmseg.visualization import SegLocalVisualizer

--- a/tests/test_visualization/test_local_visualizer.py
+++ b/tests/test_visualization/test_local_visualizer.py
@@ -9,6 +9,7 @@ import mmcv
 import numpy as np
 import torch
 from mmengine.structures import PixelData
+from mmengine.device.utils import is_musa_available
 
 from mmseg.structures import SegDataSample
 from mmseg.visualization import SegLocalVisualizer
@@ -73,6 +74,8 @@ class TestSegLocalVisualizer(TestCase):
 
         if torch.cuda.is_available():
             test_add_datasample_forward(gt_sem_seg.cuda())
+        elif is_musa_available():
+            test_add_datasample_forward(gt_sem_seg.musa())
         test_add_datasample_forward(gt_sem_seg)
 
     def test_cityscapes_add_datasample(self):
@@ -149,6 +152,8 @@ class TestSegLocalVisualizer(TestCase):
 
         if torch.cuda.is_available():
             test_cityscapes_add_datasample_forward(gt_sem_seg.cuda())
+        elif is_musa_available():
+            test_cityscapes_add_datasample_forward(gt_sem_seg.musa())
         test_cityscapes_add_datasample_forward(gt_sem_seg)
 
     def _assert_image_and_shape(self, out_file, out_shape):
@@ -210,4 +215,6 @@ class TestSegLocalVisualizer(TestCase):
 
         if torch.cuda.is_available():
             test_add_datasample_forward_depth(gt_depth_map.cuda())
+        elif is_musa_available():
+            test_add_datasample_forward_depth(gt_depth_map.musa())
         test_add_datasample_forward_depth(gt_depth_map)


### PR DESCRIPTION
## Motivation

support moore threads MUSA gpu

## Modification

Due to compatibility with cuda, cuda operators can be directly ported

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.

## Other openmmlab supports musa PR
https://github.com/open-mmlab/mmengine/pull/1453
