### PR TITLE
[Fix] changed Resize to RandomResize

### DIFF
--- a/docs/en/migration/interface.md
+++ b/docs/en/migration/interface.md
@@ -263,7 +263,7 @@ test_pipeline = [
 ```python
 test_pipeline = [
     dict(type='LoadImageFromFile'),
-    dict(type='Resize', scale=(2560, 640), keep_ratio=True),
+    dict(type='RandomResize', scale=(2560, 640), keep_ratio=True),
     dict(type='LoadAnnotations', reduce_zero_label=True),
     dict(type='PackSegInputs')
 ]


### PR DESCRIPTION
[Fix] changed example in documentation as The original Resize in MMSeg 1.x has been changed to RandomResize

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR aims to resolve a contradiction between the documentation and the provided example. The documentation states that RandomResize should be used, but the example incorrectly uses Resize. This inconsistency can cause confusion for users following the guide.

## Modification

changed in test pipeline Resize to RandomResize to follow mmseg 1.x changes

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMDet3D.
4. The documentation has been modified accordingly, like docstring or example tutorials.
