### PR TITLE
[Fix] Fix get_flops crash for SAN model

### DIFF
--- a/mmseg/models/segmentors/multimodal_encoder_decoder.py
+++ b/mmseg/models/segmentors/multimodal_encoder_decoder.py
@@ -226,8 +226,13 @@ class MultimodalEncoderDecoder(BaseSegmentor):
         Returns:
             Tensor: Forward output of model without any post-processes.
         """
-        x = self.extract_feat(inputs)
-        return self.decode_head.forward(x)
+        classifier_embeds = self.text_encoder()
+        clip_inputs = inputs
+        if self.asymetric_input:
+            clip_inputs = F.interpolate(
+                inputs, scale_factor=self.encoder_resolution, mode='bilinear')
+        x = self.image_encoder(clip_inputs)
+        return self.decode_head.forward([inputs, x, classifier_embeds], [])
 
     def slide_inference(self, inputs: Tensor,
                         batch_img_metas: List[dict]) -> Tensor:

--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -84,6 +84,10 @@ def inference(args: argparse.Namespace, logger: MMLogger) -> dict:
         # TODO: Support MaskFormer and Mask2Former
         raise NotImplementedError('MaskFormer and Mask2Former are not '
                                   'supported yet.')
+    if cfg.model.decode_head.type == 'SideAdapterCLIPHead':
+        # SAN requires text encoder outputs that _forward() doesn't provide
+        raise NotImplementedError(
+            'SAN is not supported yet. See #3866')
     outputs = get_model_complexity_info(
         model,
         input_shape=None,


### PR DESCRIPTION
Running `get_flops.py` on a SAN config crashes with:

`TypeError: SideAdapterCLIPHead.forward() missing 1 required positional argument: 'deep_supervision_idxs'`

The issue is that `MultimodalEncoderDecoder._forward()` passes only backbone features to `decode_head.forward(x)`, but `SideAdapterCLIPHead.forward()` expects a `(imgs, clip_features, class_embeds)` triplet and a `deep_supervision_idxs` arg.

Fixed `_forward()` to match the `encode_decode()` path — runs both text encoder and image encoder, passes the full triplet. Also added SAN to the unsupported guard in `get_flops.py` since the text encoder FLOPs aren't captured by the tracing.

Fixes #3866