### PR TITLE
[Fix] DDRNet: fix tensor size mismatch on non-standard input resolutions

### DIFF
--- a/mmseg/models/backbones/ddrnet.py
+++ b/mmseg/models/backbones/ddrnet.py
@@ -180,10 +180,13 @@ class DDRNet(BaseModule):
 
     def forward(self, x):
         """Forward function."""
-        out_size = (x.shape[-2] // 8, x.shape[-1] // 8)
 
         # stage 0-2
         x = self.stem(x)
+
+        # Use actual spatial dims after stem to avoid off-by-one errors
+        # when input resolution is not perfectly divisible by 8.
+        out_size = x.shape[-2:]
 
         # stage3
         x_c = self.context_branch_layers[0](x)


### PR DESCRIPTION
When using DDRNet with input dimensions that don't divide evenly by 8 (e.g. after `keep_ratio=True` resizing), the forward pass crashes with:

`RuntimeError: The size of tensor a (182) must match the size of tensor b (181) at non-singleton dimension 3`

The issue is that `out_size` is precomputed as `(H // 8, W // 8)` from the raw input, but the stem's strided convolutions can produce spatial dims that are off by one due to integer division rounding. When `comp_c` gets resized to `out_size` and added to `x_s`, the shapes don't match.

Moved `out_size` to be computed from the actual tensor shape after the stem, so the resize target always matches `x_s`.

Fixes #3347