### PR TITLE
Fix RandomRotFlip interpolation for segmentation maps

### DIFF
--- a/mmseg/datasets/transforms/transforms.py
+++ b/mmseg/datasets/transforms/transforms.py
@@ -923,7 +923,8 @@ class RandomRotFlip(BaseTransform):
         angle = np.random.uniform(min(*self.degree), max(*self.degree))
         results['img'] = mmcv.imrotate(results['img'], angle=angle)
         for key in results.get('seg_fields', []):
-            results[key] = mmcv.imrotate(results[key], angle=angle)
+            results[key] = mmcv.imrotate(
+                results[key], angle=angle, interpolation='nearest')
         return results
 
     def transform(self, results: dict) -> dict:


### PR DESCRIPTION
## Motivation

`RandomRotFlip.random_rotate` currently rotates segmentation fields with
`mmcv.imrotate` without specifying the interpolation mode. Since
`mmcv.imrotate` defaults to bilinear interpolation, rotating semantic
segmentation masks may introduce unexpected label values around class
boundaries.

Fixes #3399.

## Modification

- Use `interpolation='nearest'` when rotating entries in `seg_fields` in
  `RandomRotFlip.random_rotate`.

## BC-breaking (Optional)

No backward-incompatible change is expected. The change only makes
`RandomRotFlip` preserve discrete segmentation labels during rotation.

## Use cases (Optional)

This affects training pipelines that use `RandomRotFlip` for semantic
segmentation masks. It prevents augmented masks from containing invalid class
ids produced by bilinear interpolation.

## Checklist

1. The change is small and limited to `RandomRotFlip.random_rotate`.
2. Local pre-commit was not completed because the local pre-commit environment
   failed on the deprecated `python_venv` hook.
3. Local unit tests were not run because the local environment is missing
   `mmcv`.
4. No documentation change is required because this is a bug fix.